### PR TITLE
fix: pass username parameter to /check-open-ai-key endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LoreSmith MCP Router
+# LoreSmith
 
 Dungeouns & Dragons(DND) RAG
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     />
     <meta name="theme-color" content="#000000" />
 
-    <title>LoreSmith MCP Router</title>
+    <title>LoreSmith</title>
 
     <script>
       document.documentElement.classList.toggle(

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -457,7 +457,7 @@ export default function Chat() {
             </div>
 
             <div className="flex-1">
-              <h2 className="font-semibold text-base">LoreSmith MCP Router</h2>
+              <h2 className="font-semibold text-base">LoreSmith</h2>
             </div>
 
             <div className="flex items-center gap-2 mr-2">

--- a/src/components/pdf-upload/PdfUploadAgent.tsx
+++ b/src/components/pdf-upload/PdfUploadAgent.tsx
@@ -92,9 +92,22 @@ export const PdfUploadAgent = ({
 
         // Also check if we need to require OpenAI key when not authenticated
         try {
-          const response = await fetch(
-            API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.OPENAI.CHECK_KEY)
-          );
+          // Extract username from JWT if available
+          let username = null;
+          if (jwt) {
+            try {
+              const payload = JSON.parse(atob(jwt.split(".")[1]));
+              username = payload?.username;
+            } catch {
+              // JWT parsing failed, continue without username
+            }
+          }
+
+          const url = username
+            ? `${API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.OPENAI.CHECK_KEY)}?username=${encodeURIComponent(username)}`
+            : API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.OPENAI.CHECK_KEY);
+
+          const response = await fetch(url);
           const result = (await response.json()) as { success: boolean };
           console.log("Initial OpenAI key check:", result);
 
@@ -156,9 +169,23 @@ export const PdfUploadAgent = ({
     if (showAuthInput && !isAuthenticated) {
       const checkOpenAIRequirement = async () => {
         try {
-          const response = await fetch(
-            API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.OPENAI.CHECK_KEY)
-          );
+          // Extract username from JWT if available
+          let username = null;
+          const jwt = getStoredJwt();
+          if (jwt) {
+            try {
+              const payload = JSON.parse(atob(jwt.split(".")[1]));
+              username = payload?.username;
+            } catch {
+              // JWT parsing failed, continue without username
+            }
+          }
+
+          const url = username
+            ? `${API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.OPENAI.CHECK_KEY)}?username=${encodeURIComponent(username)}`
+            : API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.OPENAI.CHECK_KEY);
+
+          const response = await fetch(url);
           const result = (await response.json()) as { success: boolean };
           console.log("Auth form OpenAI key check:", result);
 
@@ -312,9 +339,23 @@ export const PdfUploadAgent = ({
 
       // Check if a default OpenAI key is available
       try {
-        const response = await fetch(
-          API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.OPENAI.CHECK_KEY)
-        );
+        // Extract username from JWT if available
+        let username = null;
+        const jwt = getStoredJwt();
+        if (jwt) {
+          try {
+            const payload = JSON.parse(atob(jwt.split(".")[1]));
+            username = payload?.username;
+          } catch {
+            // JWT parsing failed, continue without username
+          }
+        }
+
+        const url = username
+          ? `${API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.OPENAI.CHECK_KEY)}?username=${encodeURIComponent(username)}`
+          : API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.OPENAI.CHECK_KEY);
+
+        const response = await fetch(url);
         const result = (await response.json()) as { success: boolean };
 
         console.log("OpenAI key check result:", result);


### PR DESCRIPTION
- Extract username from JWT token when available
- Pass username as query parameter to /check-open-ai-key endpoint
- Handle missing or invalid JWT gracefully
- Fix 400 "Username is required" error in production

The frontend was calling the endpoint without the required username parameter, causing authentication issues in production.