### PR TITLE
feat: implement global model manager with auto-initialization

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -90,7 +90,8 @@ export async function determineAgent(
   const intent = await AgentRouter.routeMessage(
     userMessage,
     recentContext,
-    ragService
+    ragService,
+    null // We don't have the model here, so it will create a new one
   );
 
   console.log(

--- a/src/services/agent-registry.ts
+++ b/src/services/agent-registry.ts
@@ -137,7 +137,7 @@ export class AgentRegistryService {
     agentType: string,
     ctx: DurableObjectState,
     env: any,
-    model: any
+    model?: any
   ): any {
     return AgentRouter.createAgentInstance(agentType, ctx, env, model);
   }

--- a/src/services/model-manager.ts
+++ b/src/services/model-manager.ts
@@ -1,0 +1,96 @@
+import { openai } from "@ai-sdk/openai";
+import { MODEL_CONFIG } from "../constants";
+
+export class ModelManager {
+  private static instance: ModelManager;
+  private model: any = null;
+  private apiKey: string | null = null;
+
+  private constructor() {}
+
+  static getInstance(): ModelManager {
+    if (!ModelManager.instance) {
+      ModelManager.instance = new ModelManager();
+    }
+    return ModelManager.instance;
+  }
+
+  /**
+   * Initialize the model with a user's API key
+   */
+  initializeModel(apiKey: string): void {
+    if (this.apiKey === apiKey && this.model) {
+      // Already initialized with the same key
+      return;
+    }
+
+    // Set the API key in the environment for the model creation
+    const originalApiKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = apiKey;
+
+    try {
+      // Create the model instance
+      this.model = openai(MODEL_CONFIG.OPENAI.PRIMARY as any);
+      this.apiKey = apiKey;
+
+      console.log("[ModelManager] Model initialized with user API key");
+    } catch (error) {
+      // Restore the original API key if there was an error
+      if (originalApiKey === undefined) {
+        delete (process.env as any).OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = originalApiKey;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Get the current model instance
+   */
+  getModel(): any {
+    if (!this.model) {
+      // Auto-initialize with a default API key if not already initialized
+      const defaultApiKey = process.env.OPENAI_API_KEY;
+      if (!defaultApiKey) {
+        throw new Error(
+          "Model not initialized and no default OPENAI_API_KEY found in environment. Please call initializeModel() with a valid API key first."
+        );
+      }
+      console.log(
+        "[ModelManager] Auto-initializing model with default API key"
+      );
+      this.initializeModel(defaultApiKey);
+    }
+    return this.model;
+  }
+
+  /**
+   * Check if the model is initialized
+   */
+  isInitialized(): boolean {
+    return this.model !== null;
+  }
+
+  /**
+   * Check if we can auto-initialize with a default API key
+   */
+  canAutoInitialize(): boolean {
+    return !this.isInitialized() && !!process.env.OPENAI_API_KEY;
+  }
+
+  /**
+   * Get the current API key
+   */
+  getApiKey(): string | null {
+    return this.apiKey;
+  }
+
+  /**
+   * Clear the model instance (useful for testing or when switching users)
+   */
+  clearModel(): void {
+    this.model = null;
+    this.apiKey = null;
+  }
+}


### PR DESCRIPTION
- Add ModelManager singleton for centralized model management
- Auto-initialize model with environment OPENAI_API_KEY when not set
- Update AgentRouter to use global model manager as fallback
- Modify server to initialize global model with user's API key
- Make model parameter optional in agent creation methods
- Add canAutoInitialize() helper method for checking initialization capability

This ensures all agents use the same authenticated model instance and gracefully falls back to environment API key when user-specific key is not available.