### PR TITLE
fix: resolve streaming errors by creating models with user API keys d…

### DIFF
--- a/src/services/model-manager.ts
+++ b/src/services/model-manager.ts
@@ -24,6 +24,11 @@ export class ModelManager {
       return;
     }
 
+    console.log(
+      "[ModelManager] Initializing model with API key:",
+      apiKey.substring(0, 20) + "..."
+    );
+
     // Set the API key in the environment for the model creation
     const originalApiKey = process.env.OPENAI_API_KEY;
     process.env.OPENAI_API_KEY = apiKey;
@@ -33,8 +38,13 @@ export class ModelManager {
       this.model = openai(MODEL_CONFIG.OPENAI.PRIMARY as any);
       this.apiKey = apiKey;
 
-      console.log("[ModelManager] Model initialized with user API key");
+      console.log(
+        "[ModelManager] Model initialized successfully with user API key"
+      );
+      console.log("[ModelManager] Model type:", typeof this.model);
+      console.log("[ModelManager] Model object:", this.model);
     } catch (error) {
+      console.error("[ModelManager] Error initializing model:", error);
       // Restore the original API key if there was an error
       if (originalApiKey === undefined) {
         delete (process.env as any).OPENAI_API_KEY;


### PR DESCRIPTION
…irectly

- Extract API key from JWT in BaseAgent and create model directly
- Add proper environment variable management for API key usage
- Enhance logging to track model creation and API key usage
- Add error handling and fallback for model creation failures
- Ensure models are created with user's actual API key instead of global manager

This resolves the "Error while streaming in OnboardingAgent" error by ensuring agents use models created with the correct user API key from the JWT.