### PR TITLE
feat: add debug toggle control for tool invocation cards

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -546,7 +546,16 @@ export default function Chat() {
                 <div key={m.id}>
                   {showDebug && (
                     <pre className="text-xs text-muted-foreground overflow-scroll">
-                      {JSON.stringify(m, null, 2)}
+                      {JSON.stringify(
+                        {
+                          ...m,
+                          parts: m.parts?.filter(
+                            (part) => part.type !== "tool-invocation"
+                          ),
+                        },
+                        null,
+                        2
+                      )}
                     </pre>
                   )}
                   <div
@@ -620,8 +629,8 @@ export default function Chat() {
                                     | keyof typeof pdfTools
                                 );
 
-                              // Skip rendering the card in debug mode
-                              if (showDebug) return null;
+                              // Skip rendering the card when debug is off
+                              if (!showDebug) return null;
 
                               return (
                                 <ToolInvocationCard
@@ -631,6 +640,7 @@ export default function Chat() {
                                   toolCallId={toolCallId}
                                   needsConfirmation={needsConfirmation}
                                   addToolResult={addToolResult}
+                                  showDebug={showDebug}
                                 />
                               );
                             }

--- a/src/components/tool-invocation-card/ToolInvocationCard.tsx
+++ b/src/components/tool-invocation-card/ToolInvocationCard.tsx
@@ -27,6 +27,7 @@ interface ToolInvocationCardProps {
   toolCallId: string;
   needsConfirmation: boolean;
   addToolResult: (args: { toolCallId: string; result: string }) => void;
+  showDebug?: boolean;
 }
 
 export function ToolInvocationCard({
@@ -34,6 +35,7 @@ export function ToolInvocationCard({
   toolCallId,
   needsConfirmation,
   addToolResult,
+  showDebug = false,
 }: ToolInvocationCardProps) {
   const [isExpanded, setIsExpanded] = useState(true);
 
@@ -220,37 +222,40 @@ export function ToolInvocationCard({
               </div>
             )}
 
-          {!needsConfirmation && toolInvocation.state === "result" && (
-            <div className="mt-3 border-t border-[#F48120]/10 pt-3">
-              <h5 className="text-xs font-medium mb-1 text-muted-foreground">
-                Result:
-              </h5>
-              <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
-                {(() => {
-                  const result = toolInvocation.result;
-                  if (typeof result === "object" && result.content) {
-                    return result.content
-                      .map((item: { type: string; text: string }) => {
-                        if (
-                          item.type === "text" &&
-                          item.text.startsWith("\n~ Page URL:")
-                        ) {
-                          const lines = item.text.split("\n").filter(Boolean);
-                          return lines
-                            .map(
-                              (line: string) => `- ${line.replace("\n~ ", "")}`
-                            )
-                            .join("\n");
-                        }
-                        return item.text;
-                      })
-                      .join("\n");
-                  }
-                  return JSON.stringify(result, null, 2);
-                })()}
-              </pre>
-            </div>
-          )}
+          {!needsConfirmation &&
+            toolInvocation.state === "result" &&
+            showDebug && (
+              <div className="mt-3 border-t border-[#F48120]/10 pt-3">
+                <h5 className="text-xs font-medium mb-1 text-muted-foreground">
+                  Result:
+                </h5>
+                <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
+                  {(() => {
+                    const result = toolInvocation.result;
+                    if (typeof result === "object" && result.content) {
+                      return result.content
+                        .map((item: { type: string; text: string }) => {
+                          if (
+                            item.type === "text" &&
+                            item.text.startsWith("\n~ Page URL:")
+                          ) {
+                            const lines = item.text.split("\n").filter(Boolean);
+                            return lines
+                              .map(
+                                (line: string) =>
+                                  `- ${line.replace("\n~ ", "")}`
+                              )
+                              .join("\n");
+                          }
+                          return item.text;
+                        })
+                        .join("\n");
+                    }
+                    return JSON.stringify(result, null, 2);
+                  })()}
+                </pre>
+              </div>
+            )}
         </div>
       </div>
     </Card>


### PR DESCRIPTION
- Add showDebug prop to ToolInvocationCard component
- Hide tool result section when debug mode is disabled
- Completely hide tool invocation cards when debug toggle is off
- Maintain clean UI by default while preserving debug functionality
- Auto-fix code formatting issues with prettier

The debug toggle now controls visibility of tool invocation details:
- Debug OFF: Clean interface with no tool cards shown
- Debug ON: Full tool invocation details with result sections