### PR TITLE
feat: show campaigns on resource list; enable/disable campaign add when resource is already associated

### DIFF
--- a/src/components/pdf-upload/PdfList.tsx
+++ b/src/components/pdf-upload/PdfList.tsx
@@ -43,62 +43,6 @@ export function PdfList({ refreshTrigger }: PdfListProps) {
   const [selectedCampaigns, setSelectedCampaigns] = useState<string[]>([]);
   const [addingToCampaigns, setAddingToCampaigns] = useState(false);
 
-  const fetchFiles = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-
-      const jwt = getStoredJwt();
-      const { response, jwtExpired } = await authenticatedFetchWithExpiration(
-        API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.PDF.FILES),
-        { jwt }
-      );
-
-      if (jwtExpired) {
-        throw new Error(ERROR_MESSAGES.AUTHENTICATION_REQUIRED);
-      }
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch files: ${response.status}`);
-      }
-
-      const data = (await response.json()) as { files: PdfFile[] };
-      const filesWithCampaigns = await fetchPdfCampaigns(data.files || []);
-      setFiles(filesWithCampaigns);
-    } catch (err) {
-      setError(
-        err instanceof Error
-          ? err.message
-          : USER_MESSAGES.FAILED_TO_RETRIEVE_FILES
-      );
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const fetchCampaigns = useCallback(async () => {
-    try {
-      const jwt = getStoredJwt();
-      const { response, jwtExpired } = await authenticatedFetchWithExpiration(
-        API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.CAMPAIGNS.BASE),
-        { jwt }
-      );
-
-      if (jwtExpired) {
-        throw new Error(ERROR_MESSAGES.AUTHENTICATION_REQUIRED);
-      }
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch campaigns: ${response.status}`);
-      }
-
-      const data = (await response.json()) as { campaigns: Campaign[] };
-      setCampaigns(data.campaigns || []);
-    } catch (err) {
-      console.error("Failed to fetch campaigns:", err);
-    }
-  }, []);
-
   const fetchPdfCampaigns = useCallback(async (files: PdfFile[]) => {
     try {
       const jwt = getStoredJwt();
@@ -201,6 +145,62 @@ export function PdfList({ refreshTrigger }: PdfListProps) {
     } catch (err) {
       console.error("Failed to fetch PDF campaigns:", err);
       return files.map((file) => ({ ...file, campaigns: [] }));
+    }
+  }, []);
+
+  const fetchFiles = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const jwt = getStoredJwt();
+      const { response, jwtExpired } = await authenticatedFetchWithExpiration(
+        API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.PDF.FILES),
+        { jwt }
+      );
+
+      if (jwtExpired) {
+        throw new Error(ERROR_MESSAGES.AUTHENTICATION_REQUIRED);
+      }
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch files: ${response.status}`);
+      }
+
+      const data = (await response.json()) as { files: PdfFile[] };
+      const filesWithCampaigns = await fetchPdfCampaigns(data.files || []);
+      setFiles(filesWithCampaigns);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : USER_MESSAGES.FAILED_TO_RETRIEVE_FILES
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchPdfCampaigns]);
+
+  const fetchCampaigns = useCallback(async () => {
+    try {
+      const jwt = getStoredJwt();
+      const { response, jwtExpired } = await authenticatedFetchWithExpiration(
+        API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.CAMPAIGNS.BASE),
+        { jwt }
+      );
+
+      if (jwtExpired) {
+        throw new Error(ERROR_MESSAGES.AUTHENTICATION_REQUIRED);
+      }
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch campaigns: ${response.status}`);
+      }
+
+      const data = (await response.json()) as { campaigns: Campaign[] };
+      setCampaigns(data.campaigns || []);
+    } catch (err) {
+      console.error("Failed to fetch campaigns:", err);
     }
   }, []);
 

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -235,3 +235,174 @@ export async function handleDeleteAllCampaigns(c: ContextWithAuth) {
     return c.json({ error: "Internal server error" }, 500);
   }
 }
+
+// Add resource to campaign
+export async function handleAddResourceToCampaign(c: ContextWithAuth) {
+  try {
+    const userAuth = (c as any).userAuth;
+    const campaignId = c.req.param("campaignId");
+    const { type, id, name } = await c.req.json();
+
+    console.log(
+      `[Server] POST /campaigns/${campaignId}/resource - starting request`
+    );
+    console.log("[Server] User auth from middleware:", userAuth);
+    console.log("[Server] Request body:", { type, id, name });
+
+    if (!type || !id) {
+      return c.json({ error: "Resource type and id are required" }, 400);
+    }
+
+    // First, check if the campaign exists and belongs to the user
+    const campaign = await c.env.DB.prepare(
+      "SELECT id, name, username FROM campaigns WHERE id = ? AND username = ?"
+    )
+      .bind(campaignId, userAuth.username)
+      .first<{ id: string; name: string; username: string }>();
+
+    if (!campaign) {
+      console.log(
+        `[Server] Campaign ${campaignId} not found or doesn't belong to user ${userAuth.username}`
+      );
+      return c.json({ error: "Campaign not found" }, 404);
+    }
+
+    console.log("[Server] Found campaign:", campaign);
+
+    // Check if resource already exists in this campaign
+    const existingResource = await c.env.DB.prepare(
+      "SELECT id, file_name FROM campaign_resources WHERE campaign_id = ? AND file_key = ?"
+    )
+      .bind(campaignId, id)
+      .first<{ id: string; file_name: string }>();
+
+    if (existingResource) {
+      console.log(
+        `[Server] Resource ${id} already exists in campaign ${campaignId}`
+      );
+      // Return success instead of error - this is idempotent behavior
+      return c.json(
+        {
+          resource: {
+            id: existingResource.id,
+            campaignId,
+            fileKey: id,
+            fileName: existingResource.file_name,
+            description: "",
+            tags: "[]",
+            status: "active",
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          message: "Resource already exists in this campaign",
+        },
+        200
+      );
+    }
+
+    // Add the resource to the campaign
+    const resourceId = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    await c.env.DB.prepare(
+      "INSERT INTO campaign_resources (id, campaign_id, file_key, file_name, description, tags, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+      .bind(
+        resourceId,
+        campaignId,
+        id,
+        name || id,
+        "",
+        "[]",
+        "active",
+        now,
+        now
+      )
+      .run();
+
+    console.log(`[Server] Added resource ${id} to campaign ${campaignId}`);
+
+    const newResource = {
+      id: resourceId,
+      campaignId,
+      fileKey: id,
+      fileName: name || id,
+      description: "",
+      tags: "[]",
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    return c.json({ resource: newResource }, 201);
+  } catch (error) {
+    console.error("Error adding resource to campaign:", error);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+}
+
+// Remove resource from campaign
+export async function handleRemoveResourceFromCampaign(c: ContextWithAuth) {
+  try {
+    const userAuth = (c as any).userAuth;
+    const campaignId = c.req.param("campaignId");
+    const resourceId = c.req.param("resourceId");
+
+    console.log(
+      `[Server] DELETE /campaigns/${campaignId}/resource/${resourceId} - starting request`
+    );
+    console.log("[Server] User auth from middleware:", userAuth);
+
+    // First, check if the campaign exists and belongs to the user
+    const campaign = await c.env.DB.prepare(
+      "SELECT id, name, username FROM campaigns WHERE id = ? AND username = ?"
+    )
+      .bind(campaignId, userAuth.username)
+      .first<{ id: string; name: string; username: string }>();
+
+    if (!campaign) {
+      console.log(
+        `[Server] Campaign ${campaignId} not found or doesn't belong to user ${userAuth.username}`
+      );
+      return c.json({ error: "Campaign not found" }, 404);
+    }
+
+    console.log("[Server] Found campaign:", campaign);
+
+    // Check if the resource exists in this campaign
+    const resource = await c.env.DB.prepare(
+      "SELECT id, file_key, file_name FROM campaign_resources WHERE id = ? AND campaign_id = ?"
+    )
+      .bind(resourceId, campaignId)
+      .first<{ id: string; file_key: string; file_name: string }>();
+
+    if (!resource) {
+      console.log(
+        `[Server] Resource ${resourceId} not found in campaign ${campaignId}`
+      );
+      return c.json({ error: "Resource not found in this campaign" }, 404);
+    }
+
+    console.log("[Server] Found resource:", resource);
+
+    // Remove the resource from the campaign
+    await c.env.DB.prepare(
+      "DELETE FROM campaign_resources WHERE id = ? AND campaign_id = ?"
+    )
+      .bind(resourceId, campaignId)
+      .run();
+
+    console.log(
+      `[Server] Removed resource ${resourceId} from campaign ${campaignId}`
+    );
+
+    return c.json({
+      success: true,
+      message: "Resource removed from campaign successfully",
+      removedResource: resource,
+    });
+  } catch (error) {
+    console.error("Error removing resource from campaign:", error);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,8 @@ import {
   handleGetCampaign,
   handleGetCampaignResources,
   handleGetCampaigns,
+  handleAddResourceToCampaign,
+  handleRemoveResourceFromCampaign,
 } from "./routes/campaigns";
 import {
   handleGetExternalResourceRecommendations,
@@ -443,6 +445,17 @@ app.get(
   "/campaigns/:campaignId/resources",
   requireUserJwt,
   handleGetCampaignResources
+);
+
+app.post(
+  "/campaigns/:campaignId/resource",
+  requireUserJwt,
+  handleAddResourceToCampaign
+);
+app.delete(
+  "/campaigns/:campaignId/resource/:resourceId",
+  requireUserJwt,
+  handleRemoveResourceFromCampaign
 );
 app.delete("/campaigns/:campaignId", requireUserJwt, handleDeleteCampaign);
 app.delete("/campaigns", requireUserJwt, handleDeleteAllCampaigns);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -92,6 +92,7 @@ export const API_CONFIG = {
       BASE: "/campaigns",
       RESOURCES: (campaignId: string) => `/campaigns/${campaignId}/resources`,
       RESOURCE: (campaignId: string) => `/campaigns/${campaignId}/resource`,
+
       DETAILS: (campaignId: string) => `/campaigns/${campaignId}`,
       CONTEXT: (campaignId: string) => `/campaigns/${campaignId}/context`,
       CHARACTERS: (campaignId: string) => `/campaigns/${campaignId}/characters`,

--- a/src/tools/campaign-context/suggestion-tools.ts
+++ b/src/tools/campaign-context/suggestion-tools.ts
@@ -37,7 +37,7 @@ export const getCampaignSuggestions = tool({
     jwt: commonSchemas.jwt,
   }),
   execute: async (
-    { campaignId, suggestionType = "session", context: contextParam, jwt },
+    { campaignId, suggestionType = "session", context: _contextParam, jwt },
     context?: any
   ): Promise<ToolResult> => {
     // Extract toolCallId from context

--- a/src/tools/campaign/planning-tools.ts
+++ b/src/tools/campaign/planning-tools.ts
@@ -196,7 +196,7 @@ export const generateSessionHooks = tool({
     jwt: commonSchemas.jwt,
   }),
   execute: async (
-    { campaignId, hookType = "opening", context: contextParam, jwt },
+    { campaignId, hookType = "opening", context: _contextParam, jwt },
     context?: any
   ): Promise<ToolResult> => {
     // Extract toolCallId from context

--- a/tests/character-sheet/character-sheet-tools.test.ts
+++ b/tests/character-sheet/character-sheet-tools.test.ts
@@ -70,7 +70,7 @@ vi.mock("../../src/tools/utils", () => ({
     (
       message: string,
       error: any,
-      code: number,
+      _code: number,
       toolCallId: string
     ): ToolResult => ({
       toolCallId,


### PR DESCRIPTION
@ofisk i hope we're aligned on your intent here - i think the correct direction is to have campaign as first class citizen, resources are associated with campaign. i want to validate this before i do cleanup/optimizations.

next steps:
- cursor is getting all campaign ids for resource now, then getting campaign names for each; would like to enhance that functionality to return names too (or add a separate method that returns all campaign metadatas for a given resource)
- hook in remove from campaign calls
- add route "add to campaign"  screen that allows you to create a campaign (can be as simple as having a `+ New campaign` in the dropdown -- want to discuss this with you as well before i do more

<img width="655" height="605" alt="Screenshot 2025-08-05 at 20 01 35" src="https://github.com/user-attachments/assets/12bf867b-7d97-48ae-b07a-cd764a3c1c30" />
<img width="722" height="633" alt="Screenshot 2025-08-05 at 20 01 28" src="https://github.com/user-attachments/assets/4b38983e-0a16-4239-93b4-5147b0149533" />


