### PR TITLE
refactor: implement service factory pattern with unified Env usage

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -140,8 +140,7 @@ export default function Chat() {
         if (payload.username) {
           setUsername(payload.username);
           // Check if JWT is expired
-          const authService = new AuthService({} as any);
-          if (authService.isJwtExpired(jwt)) {
+          if (AuthService.isJwtExpired(jwt)) {
             // JWT expired, show auth modal
             console.log("[App] JWT expired, showing auth modal");
             setShowAuthModal(true);

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -6,7 +6,7 @@ export interface Env extends AuthEnv {
   FILE_BUCKET: R2Bucket;
   DB: D1Database;
   VECTORIZE: VectorizeIndex;
-  AUTORAG: any; // AutoRAG binding
+  AI: Ai;
   Chat: DurableObjectNamespace;
   UserFileTracker: DurableObjectNamespace;
   UploadSession: DurableObjectNamespace;

--- a/src/routes/assessment.ts
+++ b/src/routes/assessment.ts
@@ -1,6 +1,6 @@
 import type { Context } from "hono";
 import type { Env } from "../middleware/auth";
-import { AssessmentService } from "../services/assessment-service";
+import { getAssessmentService } from "../services/service-factory";
 import type { AuthPayload } from "../services/auth-service";
 
 // Extend the context to include userAuth
@@ -12,7 +12,7 @@ type ContextWithAuth = Context<{ Bindings: Env }> & {
 export async function handleGetUserState(c: ContextWithAuth) {
   try {
     const userAuth = (c as any).userAuth;
-    const assessmentService = new AssessmentService(c.env.DB);
+    const assessmentService = getAssessmentService(c.env);
     const userState = await assessmentService.analyzeUserState(
       userAuth.username
     );
@@ -33,7 +33,7 @@ export async function handleGetAssessmentRecommendations(c: ContextWithAuth) {
       return c.json({ error: "Current module is required" }, 400);
     }
 
-    const assessmentService = new AssessmentService(c.env.DB);
+    const assessmentService = getAssessmentService(c.env);
     const recommendations = await assessmentService.getCampaignHealth(
       currentModule,
       userState,
@@ -51,7 +51,7 @@ export async function handleGetAssessmentRecommendations(c: ContextWithAuth) {
 export async function handleGetUserActivity(c: ContextWithAuth) {
   try {
     const userAuth = (c as any).userAuth;
-    const assessmentService = new AssessmentService(c.env.DB);
+    const assessmentService = getAssessmentService(c.env);
     const activity = await assessmentService.getUserActivity(userAuth.username);
 
     return c.json({ activity });
@@ -70,7 +70,7 @@ export async function handleModuleIntegration(c: ContextWithAuth) {
       return c.json({ error: "Module name is required" }, 400);
     }
 
-    const assessmentService = new AssessmentService(c.env.DB);
+    const assessmentService = getAssessmentService(c.env);
     const result = await assessmentService.storeModuleAnalysis(
       moduleName,
       integrationData

--- a/src/routes/library.ts
+++ b/src/routes/library.ts
@@ -4,8 +4,7 @@
 import { Hono } from "hono";
 import type { Env } from "../middleware/auth";
 import type { AuthPayload } from "../services/auth-service";
-import { RAGService } from "../services/rag-service";
-import { StorageService } from "../services/storage-service";
+import { getRagService, getStorageService } from "../services/service-factory";
 import type { SearchQuery } from "../types/upload";
 import { requireUserJwt } from "../middleware/auth";
 
@@ -22,7 +21,7 @@ library.get("/files", async (c) => {
     const limit = parseInt(c.req.query("limit") || "20");
     const offset = parseInt(c.req.query("offset") || "0");
 
-    const ragService = new RAGService(c.env);
+    const ragService = getRagService(c.env);
     const files = await ragService.searchFiles({
       query: "",
       userId,
@@ -68,7 +67,7 @@ library.get("/search", async (c) => {
       includeSemantic,
     };
 
-    const ragService = new RAGService(c.env);
+    const ragService = getRagService(c.env);
     const results = await ragService.searchFiles(searchQuery);
 
     console.log(`[Library] Search results:`, {
@@ -98,7 +97,7 @@ library.get("/files/:fileId", async (c) => {
     const fileId = c.req.param("fileId");
     const userId = c.get("userAuth")?.username || "anonymous";
 
-    const ragService = new RAGService(c.env);
+    const ragService = getRagService(c.env);
     const metadata = await ragService.getFileMetadata(fileId, userId);
 
     if (!metadata) {
@@ -121,7 +120,7 @@ library.put("/files/:fileId", async (c) => {
     const userId = c.get("userAuth")?.username || "anonymous";
     const updates = await c.req.json();
 
-    const ragService = new RAGService(c.env);
+    const ragService = getRagService(c.env);
     const success = await ragService.updateFileMetadata(
       fileId,
       userId,
@@ -151,7 +150,7 @@ library.delete("/files/:fileId", async (c) => {
     const userId = c.get("userAuth")?.username || "anonymous";
 
     // Get file metadata first
-    const ragService = new RAGService(c.env);
+    const ragService = getRagService(c.env);
     const metadata = await ragService.getFileMetadata(fileId, userId);
 
     if (!metadata) {
@@ -189,7 +188,7 @@ library.get("/files/:fileId/download", async (c) => {
     const fileId = c.req.param("fileId");
     const userId = c.get("userAuth")?.username || "anonymous";
 
-    const ragService = new RAGService(c.env);
+    const ragService = getRagService(c.env);
     const metadata = await ragService.getFileMetadata(fileId, userId);
 
     if (!metadata) {
@@ -213,7 +212,7 @@ library.post("/files/:fileId/regenerate", async (c) => {
     const fileId = c.req.param("fileId");
     const userId = c.get("userAuth")?.username || "anonymous";
 
-    const ragService = new RAGService(c.env);
+    const ragService = getRagService(c.env);
     const metadata = await ragService.getFileMetadata(fileId, userId);
 
     if (!metadata) {
@@ -259,7 +258,7 @@ library.get("/storage-usage", async (c) => {
       return c.json({ error: "Authentication required" }, 401);
     }
 
-    const storageService = new StorageService(c.env);
+    const storageService = getStorageService(c.env);
     const usage = await storageService.getUserStorageUsage(
       userAuth.username,
       userAuth.isAdmin || false

--- a/src/routes/upload.ts
+++ b/src/routes/upload.ts
@@ -5,8 +5,7 @@ import { Hono } from "hono";
 import type { Env } from "../middleware/auth";
 import { requireUserJwt } from "../middleware/auth";
 import type { AuthPayload } from "../services/auth-service";
-
-import { UploadService } from "../services/upload-service";
+import { getUploadService } from "../services/service-factory";
 
 const upload = new Hono<{
   Bindings: Env;
@@ -27,7 +26,7 @@ upload.post("/start", async (c) => {
       return c.json({ error: "Filename and fileSize are required" }, 400);
     }
 
-    const uploadService = new UploadService(c.env);
+    const uploadService = getUploadService(c.env);
     const result = await uploadService.startUpload(
       userId,
       filename,
@@ -73,7 +72,7 @@ upload.post("/part", async (c) => {
       );
     }
 
-    const uploadService = new UploadService(c.env);
+    const uploadService = getUploadService(c.env);
     const arrayBuffer = await file.arrayBuffer();
     const result = await uploadService.uploadPart(
       sessionId,
@@ -112,7 +111,7 @@ upload.post("/complete", async (c) => {
       return c.json({ error: "sessionId is required" }, 400);
     }
 
-    const uploadService = new UploadService(c.env);
+    const uploadService = getUploadService(c.env);
     const { fileKey, metadata } = await uploadService.completeUpload(sessionId);
 
     // AutoRAG will automatically index content from the R2 bucket
@@ -206,7 +205,7 @@ upload.post("/complete", async (c) => {
 upload.get("/progress/:sessionId", async (c) => {
   try {
     const sessionId = c.req.param("sessionId");
-    const uploadService = new UploadService(c.env);
+    const uploadService = getUploadService(c.env);
     const progress = await uploadService.getProgress(sessionId);
 
     return c.json({
@@ -223,7 +222,7 @@ upload.get("/progress/:sessionId", async (c) => {
 upload.delete("/session/:sessionId", async (c) => {
   try {
     const sessionId = c.req.param("sessionId");
-    const uploadService = new UploadService(c.env);
+    const uploadService = getUploadService(c.env);
     await uploadService.cleanupSession(sessionId);
 
     return c.json({ success: true });

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,6 +57,8 @@ import type { AgentType } from "./services/agent-router";
 import type { AuthEnv } from "./services/auth-service";
 import { AuthService } from "./services/auth-service";
 import { ModelManager } from "./services/model-manager";
+import { getAutoRAGService } from "./services/service-factory";
+import { completeProgress } from "./services/progress";
 
 interface Env extends AuthEnv {
   ADMIN_SECRET?: string;
@@ -518,16 +520,8 @@ async function queueHandler(batch: MessageBatch<any>, env: Env): Promise<void> {
         `[PDF Queue] Processing message for file: ${message.body.fileKey}`
       );
 
-      // Import progress tracking
-      const { completeProgress } = await import("./services/progress");
-
       // Create RAG service instance with progress tracking
-      const { AutoRAGService } = await import("./services/autorag-service");
-      const ragService = new AutoRAGService(
-        env.DB,
-        env.AI,
-        message.body.openaiApiKey
-      );
+      const ragService = getAutoRAGService(env);
 
       // Update status to processing
       await env.DB.prepare(
@@ -575,9 +569,6 @@ async function queueHandler(batch: MessageBatch<any>, env: Env): Promise<void> {
         `[PDF Queue] Error processing ${message.body.fileKey}:`,
         error
       );
-
-      // Import progress tracking for error handling
-      const { completeProgress } = await import("./services/progress");
 
       // Determine specific error message
       let errorMessage = "PDF processing failed";

--- a/src/services/assessment-service.ts
+++ b/src/services/assessment-service.ts
@@ -1,4 +1,5 @@
 import type { D1Database } from "@cloudflare/workers-types";
+import type { Env } from "../middleware/auth";
 import type { ModuleAnalysis } from "../tools/campaign-context/assessment-core";
 import type { Campaign, CampaignResource } from "../types/campaign";
 
@@ -46,7 +47,11 @@ export interface ToolRecommendation {
 }
 
 export class AssessmentService {
-  constructor(private db: D1Database) {}
+  private db: D1Database;
+
+  constructor(env: Env) {
+    this.db = env.DB;
+  }
 
   /**
    * Analyze user's current state for contextual guidance

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,6 +1,8 @@
 import type { JWTPayload } from "jose";
 import { jwtVerify, SignJWT } from "jose";
+import type { Env } from "../middleware/auth";
 import { ERROR_MESSAGES, JWT_STORAGE_KEY } from "../constants";
+import { getAuthService } from "./service-factory";
 
 export interface AuthPayload extends JWTPayload {
   type: "user-auth";
@@ -43,7 +45,7 @@ export interface AuthContext {
  * - Error handling
  */
 export class AuthService {
-  constructor(private env: AuthEnv) {}
+  constructor(private env: Env) {}
 
   /**
    * Get JWT secret from environment
@@ -218,7 +220,7 @@ export class AuthService {
     authHeader: string | null | undefined,
     env: any
   ): Promise<AuthPayload | null> {
-    const authService = new AuthService(env);
+    const authService = getAuthService(env);
     return authService.extractAuthFromHeader(authHeader);
   }
 

--- a/src/services/rag-service.ts
+++ b/src/services/rag-service.ts
@@ -3,6 +3,7 @@
 // Updated to work with AutoRAG for enhanced content processing
 
 import type { Env } from "../middleware/auth";
+import { getAutoRAGService } from "./service-factory";
 import type { FileMetadata, SearchQuery, SearchResult } from "../types/upload";
 
 export class RAGService {
@@ -39,14 +40,8 @@ export class RAGService {
       // Use AutoRAG for enhanced metadata generation if available
       let result: { description: string; tags: string[] };
       try {
-        if (this.env.AUTORAG) {
-          const { AutoRAGService } = await import(
-            "../services/autorag-service"
-          );
-          const autoRagService = new AutoRAGService(
-            this.env.DB,
-            this.env.AUTORAG
-          );
+        if (this.env.AI) {
+          const autoRagService = getAutoRAGService(this.env);
 
           // Use AutoRAG for intelligent metadata generation
           const semanticResult = await autoRagService.generateSemanticMetadata(
@@ -141,7 +136,7 @@ export class RAGService {
   private async extractPdfText(buffer: ArrayBuffer): Promise<string> {
     try {
       // Use AutoRAG's text extraction if available
-      if (this.env.AUTORAG) {
+      if (this.env.AI) {
         // AutoRAG handles PDF content directly - no extraction needed
         return `PDF content processed by AutoRAG (${buffer.byteLength} bytes)`;
       }

--- a/src/services/service-factory.ts
+++ b/src/services/service-factory.ts
@@ -1,0 +1,133 @@
+// Service Factory - Provides cached service instances to reduce memory usage and initialization overhead
+// Uses per-request caching to reuse services within the same request context
+
+import type { Env } from "../middleware/auth";
+import { AssessmentService } from "./assessment-service";
+import { AutoRAGService } from "./autorag-service";
+import { AuthService } from "./auth-service";
+import { RAGService } from "./rag-service";
+import { UploadService } from "./upload-service";
+import { StorageService } from "./storage-service";
+import { CampaignService } from "./campaign-service";
+import { ModelManager } from "./model-manager";
+import { AgentRegistryService } from "./agent-registry";
+import { AgentRouter } from "./agent-router";
+
+// Service factory class with per-request caching
+export class ServiceFactory {
+  private static services = new Map<string, any>();
+
+  // Clear services (called between requests to prevent memory leaks)
+  static clearCache(): void {
+    ServiceFactory.services.clear();
+  }
+
+  // Get or create AssessmentService
+  static getAssessmentService(env: Env): AssessmentService {
+    const key = "assessment";
+    if (!ServiceFactory.services.has(key)) {
+      ServiceFactory.services.set(key, new AssessmentService(env));
+    }
+    return ServiceFactory.services.get(key);
+  }
+
+  // Get or create AutoRAGService
+  static getAutoRAGService(env: Env): AutoRAGService {
+    const key = "autorag";
+    if (!ServiceFactory.services.has(key)) {
+      ServiceFactory.services.set(key, new AutoRAGService(env));
+    }
+    return ServiceFactory.services.get(key);
+  }
+
+  // Get or create AuthService
+  static getAuthService(env: Env): AuthService {
+    const key = "auth";
+    if (!ServiceFactory.services.has(key)) {
+      ServiceFactory.services.set(key, new AuthService(env));
+    }
+    return ServiceFactory.services.get(key);
+  }
+
+  // Get or create RAGService
+  static getRagService(env: Env): RAGService {
+    const key = "rag";
+    if (!ServiceFactory.services.has(key)) {
+      ServiceFactory.services.set(key, new RAGService(env));
+    }
+    return ServiceFactory.services.get(key);
+  }
+
+  // Get or create UploadService
+  static getUploadService(env: Env): UploadService {
+    const key = "upload";
+    if (!ServiceFactory.services.has(key)) {
+      ServiceFactory.services.set(key, new UploadService(env));
+    }
+    return ServiceFactory.services.get(key);
+  }
+
+  // Get or create StorageService
+  static getStorageService(env: Env): StorageService {
+    const key = "storage";
+    if (!ServiceFactory.services.has(key)) {
+      ServiceFactory.services.set(key, new StorageService(env));
+    }
+    return ServiceFactory.services.get(key);
+  }
+
+  // Get or create CampaignService
+  static getCampaignService(env: Env): CampaignService {
+    const key = "campaign";
+    if (!ServiceFactory.services.has(key)) {
+      ServiceFactory.services.set(key, new CampaignService(env.DB));
+    }
+    return ServiceFactory.services.get(key);
+  }
+
+  // Get or create ModelManager (singleton pattern)
+  static getModelManager(): ModelManager {
+    const key = "model-manager";
+    if (!ServiceFactory.services.has(key)) {
+      ServiceFactory.services.set(key, ModelManager.getInstance());
+    }
+    return ServiceFactory.services.get(key);
+  }
+
+  // Get or create AgentRegistryService (static class, no instance needed)
+  static getAgentRegistryService(): typeof AgentRegistryService {
+    return AgentRegistryService;
+  }
+
+  // Get or create AgentRouter (static class, no instance needed)
+  static getAgentRouter(): typeof AgentRouter {
+    return AgentRouter;
+  }
+}
+
+// Helper functions for backward compatibility
+export const getAssessmentService = (env: Env) =>
+  ServiceFactory.getAssessmentService(env);
+
+export const getAutoRAGService = (env: Env) =>
+  ServiceFactory.getAutoRAGService(env);
+
+export const getAuthService = (env: Env) => ServiceFactory.getAuthService(env);
+
+export const getRagService = (env: Env) => ServiceFactory.getRagService(env);
+
+export const getUploadService = (env: Env) =>
+  ServiceFactory.getUploadService(env);
+
+export const getStorageService = (env: Env) =>
+  ServiceFactory.getStorageService(env);
+
+export const getCampaignService = (env: Env) =>
+  ServiceFactory.getCampaignService(env);
+
+export const getModelManager = () => ServiceFactory.getModelManager();
+
+export const getAgentRegistryService = () =>
+  ServiceFactory.getAgentRegistryService();
+
+export const getAgentRouter = () => ServiceFactory.getAgentRouter();

--- a/src/tools/campaign-context/assessment-tools.ts
+++ b/src/tools/campaign-context/assessment-tools.ts
@@ -1,4 +1,5 @@
-import { AssessmentService } from "../../services/assessment-service";
+import { getAssessmentService } from "../../services/service-factory";
+import type { Env } from "../../middleware/auth";
 import type { Campaign, CampaignResource } from "../../types/campaign";
 import {
   analyzeCampaignHealth,
@@ -15,10 +16,10 @@ export async function assessCampaignHealthTool(
   campaignId: string,
   campaign: Campaign,
   _resources: CampaignResource[],
-  db: any
+  env: Env
 ): Promise<CampaignAssessment> {
   try {
-    const assessmentService = new AssessmentService(db);
+    const assessmentService = getAssessmentService(env);
 
     // Get real campaign data from database
     const resourcesData =
@@ -72,10 +73,10 @@ export async function extractModuleFromPDFTool(
 export async function integrateModuleIntoTool(
   campaignId: string,
   moduleAnalysis: ModuleAnalysis,
-  db: any
+  env: Env
 ): Promise<{ success: boolean; message: string }> {
   try {
-    const assessmentService = new AssessmentService(db);
+    const assessmentService = getAssessmentService(env);
     const success = await assessmentService.storeModuleAnalysis(
       campaignId,
       moduleAnalysis
@@ -103,10 +104,10 @@ export async function getCampaignHealthScoreTool(
   campaignId: string,
   campaign: Campaign,
   resources: CampaignResource[],
-  db: any
+  env: Env
 ): Promise<{ overallScore: number; summary: string; priorityAreas: string[] }> {
   try {
-    const assessmentService = new AssessmentService(db);
+    const assessmentService = getAssessmentService(env);
     const assessment = await assessmentService.getCampaignHealth(
       campaignId,
       campaign,
@@ -134,10 +135,10 @@ export async function getCampaignRecommendationsTool(
   campaignId: string,
   campaign: Campaign,
   resources: CampaignResource[],
-  db: any
+  env: Env
 ): Promise<{ recommendations: Recommendation[]; focusArea: string }> {
   try {
-    const assessmentService = new AssessmentService(db);
+    const assessmentService = getAssessmentService(env);
     const assessment = await assessmentService.getCampaignHealth(
       campaignId,
       campaign,
@@ -208,7 +209,7 @@ export async function analyzeCampaignDimensionTool(
   dimension: "narrative" | "characters" | "plotHooks" | "sessionReadiness",
   campaign: Campaign,
   resources: CampaignResource[],
-  db: any
+  env: Env
 ): Promise<{
   dimension: string;
   score: number;
@@ -216,7 +217,7 @@ export async function analyzeCampaignDimensionTool(
   suggestions: string[];
 }> {
   try {
-    const assessmentService = new AssessmentService(db);
+    const assessmentService = getAssessmentService(env);
     const assessment = await assessmentService.getCampaignHealth(
       campaignId,
       campaign,

--- a/src/tools/onboarding/guidance-tools.ts
+++ b/src/tools/onboarding/guidance-tools.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ToolResult } from "../../constants";
-import { AssessmentService } from "../../services/assessment-service";
+import { getAssessmentService } from "../../services/service-factory";
 import { commonSchemas, createToolError, createToolSuccess } from "../utils";
 import type { ActionSuggestion } from "./state-analysis-tools";
 
@@ -118,7 +118,7 @@ export const suggestNextActionsTool = tool({
         );
       }
 
-      const assessmentService = new AssessmentService(env.DB);
+      const assessmentService = getAssessmentService(env);
       const userState = await assessmentService.analyzeUserState(username);
 
       const actions: ActionSuggestion[] = [];
@@ -199,7 +199,7 @@ export const provideCampaignGuidanceTool = tool({
         );
       }
 
-      const assessmentService = new AssessmentService(env.DB);
+      const assessmentService = getAssessmentService(env);
       const campaignHealth = await assessmentService.getCampaignHealth(
         campaignId,
         {} as any,

--- a/src/tools/onboarding/state-analysis-tools.ts
+++ b/src/tools/onboarding/state-analysis-tools.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { AssessmentService } from "../../services/assessment-service";
+import { getAssessmentService } from "../../services/service-factory";
 import type { Campaign, CampaignResource } from "../../types/campaign";
 import { commonSchemas, createToolError, createToolSuccess } from "../utils";
 
@@ -83,7 +83,7 @@ export const analyzeUserStateTool = tool({
         );
       }
 
-      const assessmentService = new AssessmentService(env.DB);
+      const assessmentService = getAssessmentService(env);
       const userState = await assessmentService.analyzeUserState(username);
 
       return createToolSuccess(
@@ -124,7 +124,7 @@ export const getCampaignHealthTool = tool({
         );
       }
 
-      const assessmentService = new AssessmentService(env.DB);
+      const assessmentService = getAssessmentService(env);
       // Note: This would need campaign and resources data, simplified for now
       const campaignHealth = await assessmentService.getCampaignHealth(
         campaignId,
@@ -170,7 +170,7 @@ export const getUserActivityTool = tool({
         );
       }
 
-      const assessmentService = new AssessmentService(env.DB);
+      const assessmentService = getAssessmentService(env);
       const userActivity = await assessmentService.getUserActivity(username);
 
       return createToolSuccess(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,8 +11,18 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  define: {
+    global: "globalThis",
+  },
   build: {
     rollupOptions: {
+      external: [
+        "cloudflare:email",
+        "cloudflare:workers",
+        "async_hooks",
+        "node:os",
+        "path",
+      ],
       output: {
         manualChunks: (id) => {
           // Simplified chunking to avoid React/AI vendor conflicts


### PR DESCRIPTION
- Add ServiceFactory with per-request caching for all services
- Standardize all service constructors to take full Env object
- Update service instantiation across routes, tools, and server
- Fix type conflicts between global and middleware Env types
- Improve type safety with consistent Env type usage
- Add proper property extraction in service constructors