### PR TITLE
fix: correct AutoRAG filter structure to use array format

### DIFF
--- a/src/dao/campaign-dao.ts
+++ b/src/dao/campaign-dao.ts
@@ -31,11 +31,13 @@ export interface CampaignCharacter {
 export interface CampaignResource {
   id: string;
   campaign_id: string;
-  resource_type: string;
-  resource_id: string;
-  resource_name?: string;
+  file_key: string;
+  file_name: string;
+  description?: string;
+  tags?: string;
+  status: string;
   created_at: string;
-  updated_at: string;
+  updated_at?: string;
 }
 
 export interface CampaignWithDetails extends Campaign {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -392,7 +392,7 @@ export async function handleAddResourceToCampaign(c: ContextWithAuth) {
           const structuredExtractionPrompt =
             RPG_EXTRACTION_PROMPTS.formatStructuredContentPrompt(
               campaignId,
-              resource.resource_name || resource.id
+              resource.file_name || resource.id
             );
 
           console.log(
@@ -405,10 +405,16 @@ export async function handleAddResourceToCampaign(c: ContextWithAuth) {
             {
               max_results: 20,
               rewrite_query: false,
-              source_filter: resource.id,
-              scope: "file_only",
-              exclude_sources: ["*"],
-              include_sources: [resource.id],
+              filters: {
+                type: "and",
+                filters: [
+                  {
+                    type: "eq",
+                    key: "filename",
+                    value: resource.file_name,
+                  },
+                ],
+              },
             }
           );
 
@@ -505,14 +511,14 @@ export async function handleAddResourceToCampaign(c: ContextWithAuth) {
                   message: `Resource added to campaign successfully. Generated ${result.created} snippets for review.`,
                   resource: {
                     id: resource.id,
-                    name: resource.resource_name || resource.id,
-                    type: resource.resource_type || "unknown",
+                    name: resource.file_name || resource.id,
+                    type: "file",
                   },
                   snippets: {
                     count: result.created,
                     campaignId,
                     resourceId: resource.id,
-                    message: `Generated ${result.created} snippets from "${resource.resource_name || resource.id}".`,
+                    message: `Generated ${result.created} snippets from "${resource.file_name || resource.id}".`,
                   },
                   // Hint for the client chat to render UI immediately
                   ui: {
@@ -534,8 +540,8 @@ export async function handleAddResourceToCampaign(c: ContextWithAuth) {
                     "Resource added to campaign successfully. No snippets were generated from this resource.",
                   resource: {
                     id: resource.id,
-                    name: resource.resource_name || resource.id,
-                    type: resource.resource_type || "unknown",
+                    name: resource.file_name || resource.id,
+                    type: "file",
                   },
                 });
               }
@@ -550,8 +556,8 @@ export async function handleAddResourceToCampaign(c: ContextWithAuth) {
                   "Resource added to campaign successfully. Could not generate snippets from this resource.",
                 resource: {
                   id: resource.id,
-                  name: resource.resource_name || resource.id,
-                  type: resource.resource_type || "unknown",
+                  name: resource.file_name || resource.id,
+                  type: "file",
                 },
               });
             }
@@ -568,8 +574,8 @@ export async function handleAddResourceToCampaign(c: ContextWithAuth) {
                 "Resource added to campaign successfully. Error occurred while generating snippets.",
               resource: {
                 id: resource.id,
-                name: resource.resource_name || resource.id,
-                type: resource.resource_type || "unknown",
+                name: resource.file_name || resource.id,
+                type: "file",
               },
               error: "Snippet generation failed",
             });

--- a/src/services/campaign-autorag-service.ts
+++ b/src/services/campaign-autorag-service.ts
@@ -161,7 +161,19 @@ export class CampaignAutoRAG extends AutoRAGClientBase {
     );
 
     const rejectedFolder = `${this.campaignRagBasePath}/rejected/`;
-    const searchOptions = { ...options, folder: rejectedFolder };
+    const searchOptions = {
+      ...options,
+      filters: {
+        type: "and" as const,
+        filters: [
+          {
+            type: "eq" as const,
+            key: "folder",
+            value: rejectedFolder,
+          },
+        ],
+      },
+    };
 
     return await this.autoRagClient.search(query, searchOptions);
   }

--- a/src/tools/campaign-context/assessment-tools.ts
+++ b/src/tools/campaign-context/assessment-tools.ts
@@ -31,6 +31,14 @@ export async function assessCampaignHealthTool(
         type: "file" as const,
         id: resource.id,
         name: resource.file_name,
+        campaign_id: resource.campaign_id,
+        file_key: resource.file_key,
+        file_name: resource.file_name,
+        description: resource.description,
+        tags: resource.tags,
+        status: resource.status,
+        created_at: resource.created_at,
+        updated_at: resource.updated_at,
       })
     );
 

--- a/src/types/campaign.ts
+++ b/src/types/campaign.ts
@@ -6,6 +6,14 @@ export interface CampaignResource {
   type: ResourceType;
   id: string;
   name: string;
+  campaign_id: string;
+  file_key: string;
+  file_name: string;
+  description?: string;
+  tags?: string;
+  status: string;
+  created_at: string;
+  updated_at?: string;
 }
 
 // Base campaign interface used by Durable Objects

--- a/tests/services/campaign-auto-rag.test.ts
+++ b/tests/services/campaign-auto-rag.test.ts
@@ -99,7 +99,16 @@ describe("CampaignAutoRAG", () => {
 
       expect(mockSearch).toHaveBeenCalledWith("test query", {
         limit: 5,
-        folder: "campaigns/test-campaign-123/rejected/",
+        filters: {
+          type: "and",
+          filters: [
+            {
+              type: "eq",
+              key: "folder",
+              value: "campaigns/test-campaign-123/rejected/",
+            },
+          ],
+        },
       });
     });
   });


### PR DESCRIPTION
- Update filter structure from single ComparisonFilter to CompoundFilter with filters array
- Fix campaigns route to use proper filter format for filename filtering
- Update autorag-client service to use consistent filter structure
- Update campaign-autorag service to use proper filter format
- Use official Cloudflare SDK types (ComparisonFilter, CompoundFilter) instead of custom types
- Fix test expectations to match new filter structure
- Ensure all AutoRAG filtering follows Cloudflare documentation standards