### PR TITLE
fix(ux): prevent duplicate campaign creations and add async progress …

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -11,6 +11,8 @@ import loresmith from "@/assets/loresmith.png";
 import { Button } from "@/components/button/Button";
 import { Card } from "@/components/card/Card";
 import { HelpButton } from "@/components/help/HelpButton";
+import { NotificationBell } from "./components/notifications/NotificationBell";
+import { useNotifications } from "./components/notifications/NotificationProvider";
 import { MemoizedMarkdown } from "@/components/memoized-markdown";
 import { ResourceSidePanel } from "@/components/resource-side-panel";
 import { Textarea } from "@/components/textarea/Textarea";
@@ -65,6 +67,24 @@ function getSessionId(): string {
   const newSessionId = generateSessionId();
   localStorage.setItem("chat-session-id", newSessionId);
   return newSessionId;
+}
+
+function TopBarNotifications() {
+  const { activeNotifications, dismissNotification, clearActiveNotifications } =
+    useNotifications();
+
+  return (
+    <div className="ml-1">
+      <NotificationBell
+        notifications={activeNotifications}
+        onDismiss={(notificationId) => {
+          const ts = parseInt(notificationId.split("-")[0], 10);
+          dismissNotification(ts);
+        }}
+        onDismissAll={clearActiveNotifications}
+      />
+    </div>
+  );
 }
 
 export default function Chat() {
@@ -685,6 +705,9 @@ export default function Chat() {
               >
                 <Trash size={20} />
               </Button>
+
+              {/* Notifications button styled like other top bar buttons */}
+              <TopBarNotifications />
             </div>
 
             {/* Main Content Area */}

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Button } from "../button/Button";
 import { NOTIFICATION_TYPES } from "../../constants/notification-types";
 import type { NotificationPayload } from "../../durable-objects/notification-hub";
 
@@ -79,14 +80,16 @@ export function NotificationBell({
 
   return (
     <div className="relative" ref={dropdownRef}>
-      <button
-        type="button"
-        onClick={() => setIsOpen(!isOpen)}
-        className="relative p-2 text-gray-600 hover:text-gray-800 transition-colors"
+      <Button
+        variant="secondary"
+        size="md"
+        shape="circular"
+        className="relative h-9 w-9"
         aria-label="Notifications"
+        onClick={() => setIsOpen(!isOpen)}
       >
         <svg
-          className="w-6 h-6"
+          className="w-5 h-5"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -99,13 +102,12 @@ export function NotificationBell({
             d="M15 17h5l-5 5v-5zM4.5 19.5a2.5 2.5 0 01-2.5-2.5V7a2.5 2.5 0 012.5-2.5h15a2.5 2.5 0 012.5 2.5v10a2.5 2.5 0 01-2.5 2.5h-15z"
           />
         </svg>
-
         {notifications.length > 0 && (
-          <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center font-medium">
+          <span className="absolute -top-1 -right-1 bg-red-500 text-white text-[10px] rounded-full w-4 h-4 flex items-center justify-center font-medium leading-none">
             {notifications.length > 99 ? "99+" : notifications.length}
           </span>
         )}
-      </button>
+      </Button>
 
       {isOpen && (
         <div className="absolute right-0 mt-2 w-80 bg-white border border-gray-200 rounded-lg shadow-lg z-50 max-h-96 overflow-hidden">

--- a/src/components/notifications/NotificationProvider.tsx
+++ b/src/components/notifications/NotificationProvider.tsx
@@ -1,13 +1,16 @@
 import React, { createContext, useContext, useState } from "react";
 import type { NotificationPayload } from "../../durable-objects/notification-hub";
 import { useNotificationStream } from "../../hooks/useNotificationStream";
-import { NotificationBell } from "./NotificationBell";
 
 interface NotificationContextType {
   notifications: NotificationPayload[];
   isConnected: boolean;
   error: string | null;
   clearNotifications: () => void;
+  // Active, user-visible notifications (toast list)
+  activeNotifications: NotificationPayload[];
+  dismissNotification: (timestamp: number) => void;
+  clearActiveNotifications: () => void;
 }
 
 const NotificationContext = createContext<NotificationContextType | null>(null);
@@ -58,28 +61,23 @@ export function NotificationProvider({
     );
   };
 
+  const clearActiveNotifications = () => setActiveNotifications([]);
+
   const contextValue: NotificationContextType = {
     notifications,
     isConnected,
     error,
     clearNotifications,
+    activeNotifications,
+    dismissNotification,
+    clearActiveNotifications,
   };
 
   return (
     <NotificationContext.Provider value={contextValue}>
       {children}
 
-      {/* Render notification bell */}
-      <div className="fixed top-4 right-4 z-50">
-        <NotificationBell
-          notifications={activeNotifications}
-          onDismiss={(notificationId) => {
-            const timestamp = parseInt(notificationId.split("-")[0], 10);
-            dismissNotification(timestamp);
-          }}
-          onDismissAll={() => setActiveNotifications([])}
-        />
-      </div>
+      {/* Bell is rendered by the top bar consumer to avoid overlap */}
 
       {/* Connection status indicator */}
       {!isConnected && (

--- a/src/components/resource-side-panel/ResourceSidePanel.tsx
+++ b/src/components/resource-side-panel/ResourceSidePanel.tsx
@@ -96,8 +96,9 @@ export function ResourceSidePanel({
   };
 
   const handleCreateCampaignForFileWrapper = async () => {
-    await handleCreateCampaignForFile(uploadedFileInfo);
+    // Close immediately for instant feedback, then process in background
     setIsCreateCampaignModalOpen(false);
+    await handleCreateCampaignForFile(uploadedFileInfo);
     clearUploadedFileInfo();
   };
 
@@ -105,8 +106,9 @@ export function ResourceSidePanel({
     name: string,
     description: string
   ) => {
-    await handleCreateCampaign(name, description);
+    // Close immediately for instant feedback, then process in background
     setIsCreateCampaignModalOpen(false);
+    await handleCreateCampaign(name, description);
   };
 
   const handleCampaignClick = (campaign: Campaign) => {

--- a/src/components/select/MultiSelect.tsx
+++ b/src/components/select/MultiSelect.tsx
@@ -13,6 +13,8 @@ export type MultiSelectProps = {
   selectedValues: string[];
   onSelectionChange: (values: string[]) => void;
   size?: "sm" | "md" | "base";
+  /** If true, the dropdown closes after each selection change */
+  closeOnSelect?: boolean;
 };
 
 export const MultiSelect = ({
@@ -22,6 +24,7 @@ export const MultiSelect = ({
   selectedValues,
   onSelectionChange,
   size = "base",
+  closeOnSelect = false,
 }: MultiSelectProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -45,6 +48,9 @@ export const MultiSelect = ({
       ? selectedValues.filter((v) => v !== value)
       : [...selectedValues, value];
     onSelectionChange(newSelection);
+    if (closeOnSelect) {
+      setIsOpen(false);
+    }
   };
 
   const selectedLabels = options

--- a/src/constants/notification-types.ts
+++ b/src/constants/notification-types.ts
@@ -10,10 +10,15 @@ export const NOTIFICATION_TYPES = {
 
   // File-related notifications
   FILE_UPLOADED: "file_uploaded",
+  FILE_UPLOAD_FAILED: "file_upload_failed",
+  INDEXING_STARTED: "indexing_started",
+  INDEXING_COMPLETED: "indexing_completed",
+  INDEXING_FAILED: "indexing_failed",
   CAMPAIGN_FILE_ADDED: "campaign_file_added",
 
   // Campaign-related notifications
   CAMPAIGN_CREATED: "campaign_created",
+  CAMPAIGN_DELETED: "campaign_deleted",
 
   // System notifications
   SUCCESS: "success",

--- a/src/hooks/useNotificationStream.ts
+++ b/src/hooks/useNotificationStream.ts
@@ -197,27 +197,6 @@ export function useNotificationStream(
           error: null,
         }));
         reconnectAttempts.current = 0;
-        // Send a synthetic notification to verify the UI path
-        try {
-          const connectedNotice: NotificationPayload = {
-            type: NOTIFICATION_TYPES.CONNECTED,
-            title: "Notifications Connected",
-            message: "You're subscribed to real-time updates.",
-            timestamp: Date.now(),
-          };
-          // Update local list for badge/count consumers
-          setState((prev) => ({
-            ...prev,
-            notifications: [connectedNotice, ...prev.notifications].slice(
-              0,
-              50
-            ),
-          }));
-          // Notify provider so the NotificationBell renders it immediately
-          optsRef.current.onNotification?.(connectedNotice);
-        } catch (_e) {
-          // ignore
-        }
         optsRef.current.onConnect?.();
         isConnectingRef.current = false;
       };
@@ -250,11 +229,19 @@ export function useNotificationStream(
             return;
           }
 
+          if (
+            notification.type === NOTIFICATION_TYPES.CONNECTED ||
+            notification.type === "connected"
+          ) {
+            setState((prev) => ({ ...prev, isConnected: true, error: null }));
+            return;
+          }
+
           setState((prev) => ({
             ...prev,
-            isConnected: true, // Fallback: treat first message as connected
+            isConnected: true,
             error: null,
-            notifications: [notification, ...prev.notifications].slice(0, 50), // Keep last 50 notifications
+            notifications: [notification, ...prev.notifications].slice(0, 50),
           }));
           console.log("[useNotificationStream] ▶ message:", notification.type);
           optsRef.current.onNotification?.(notification);

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -57,10 +57,16 @@ export async function notifyShardGeneration(
   fileName: string,
   shardCount: number
 ): Promise<void> {
+  const isNone = !shardCount || shardCount === 0;
+  const title = isNone ? "No Shards Found" : "New Shards Ready!";
+  const message = isNone
+    ? `🔎 No shards were discovered from "${fileName}". You can try another source or refine your materials.`
+    : `🎉 ${shardCount} new shards generated from "${fileName}"! Check your "${campaignName}" campaign to review them.`;
+
   await notifyUser(env, userId, {
     type: NOTIFICATION_TYPES.SHARDS_GENERATED,
-    title: "New Shards Ready!",
-    message: `🎉 ${shardCount} new shards generated from "${fileName}"! Check your "${campaignName}" campaign to review them.`,
+    title,
+    message,
     data: {
       campaignName,
       fileName,
@@ -94,6 +100,69 @@ export async function notifyFileUploadComplete(
     },
   });
   console.log("[notifyFileUploadComplete] Notification sent successfully");
+}
+
+/**
+ * Publish a file upload failure notification
+ */
+export async function notifyFileUploadFailed(
+  env: Env,
+  userId: string,
+  fileName: string,
+  reason?: string
+): Promise<void> {
+  await notifyUser(env, userId, {
+    type: NOTIFICATION_TYPES.FILE_UPLOAD_FAILED,
+    title: "Upload Faltered",
+    message: `⚠️ The scroll "${fileName}" could not be stowed. ${reason ? `Reason: ${reason}` : "Please try again."}`,
+    data: {
+      fileName,
+      reason,
+    },
+  });
+}
+
+/**
+ * Publish indexing lifecycle notifications
+ */
+export async function notifyIndexingStarted(
+  env: Env,
+  userId: string,
+  fileName: string
+): Promise<void> {
+  await notifyUser(env, userId, {
+    type: NOTIFICATION_TYPES.INDEXING_STARTED,
+    title: "Indexing Begun",
+    message: `📜 We’re scribing "${fileName}" into your library.`,
+    data: { fileName },
+  });
+}
+
+export async function notifyIndexingCompleted(
+  env: Env,
+  userId: string,
+  fileName: string
+): Promise<void> {
+  await notifyUser(env, userId, {
+    type: NOTIFICATION_TYPES.INDEXING_COMPLETED,
+    title: "Indexing Complete",
+    message: `✨ "${fileName}" is now searchable in your tome.`,
+    data: { fileName },
+  });
+}
+
+export async function notifyIndexingFailed(
+  env: Env,
+  userId: string,
+  fileName: string,
+  reason?: string
+): Promise<void> {
+  await notifyUser(env, userId, {
+    type: NOTIFICATION_TYPES.INDEXING_FAILED,
+    title: "Indexing Failed",
+    message: `🛑 Our quill slipped while indexing "${fileName}". ${reason ? `Reason: ${reason}` : "Please try again later."}`,
+    data: { fileName, reason },
+  });
 }
 
 /**

--- a/tests/notifications/notification-hub.test.ts
+++ b/tests/notifications/notification-hub.test.ts
@@ -6,8 +6,8 @@ vi.mock("cloudflare:workers", () => ({
   DurableObject: class {},
 }));
 
-// Mock Durable Object environment
-const mockEnv = {
+// Mock Durable Object environment (unused, keep underscore to satisfy linter)
+const _mockEnv = {
   NOTIFICATIONS: {
     idFromName: (name: string) => ({ toString: () => name }),
     get: (_id: any) =>


### PR DESCRIPTION
…feedback

- Close Create Campaign modal immediately on submit to avoid double clicks

- Disable Create button and show 'Creating…' with progress cursor

- Add transparent progress fill to library items during upload/indexing

- Drive progress from EventBus events; clear on completion/failure