### PR TITLE
Shard UI: render R2-staged shards; decouple via ui_hint

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "vite dev",
     "dev": "wrangler dev --config wrangler.local.jsonc --port 8787 --local",
     "build": "vite build",
-    "deploy": "vite build && wrangler deploy",
+    "deploy": "vite build && wrangler deploy --config wrangler.jsonc",
     "migrate": "./scripts/migrate.sh",
     "test": "vitest",
     "types": "wrangler types",

--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -1,0 +1,163 @@
+import type { Message } from "@ai-sdk/react";
+import { Card } from "@/components/card/Card";
+import { MemoizedMarkdown } from "@/components/memoized-markdown";
+import { ToolInvocationCard } from "@/components/tool-invocation-card/ToolInvocationCard";
+import { ShardManagementUI } from "./ShardManagementUI";
+
+interface ChatMessageListProps {
+  messages: Message[];
+  showDebug: boolean;
+  shouldRenderShardUI: (campaignId?: string) => boolean;
+  addToolResult: any;
+  formatTime: (date: Date) => string;
+}
+
+export function ChatMessageList({
+  messages,
+  showDebug,
+  shouldRenderShardUI,
+  addToolResult,
+  formatTime,
+}: ChatMessageListProps) {
+  return (
+    <>
+      {messages
+        .filter((m: Message) => {
+          if (m.role === "user" && m.content === "Get started") return false;
+          return true;
+        })
+        .map((m: Message, _index) => {
+          const isUser = m.role === "user";
+
+          return (
+            <div key={m.id}>
+              {showDebug && (
+                <pre className="text-xs text-muted-foreground overflow-scroll">
+                  {JSON.stringify(
+                    {
+                      ...m,
+                      parts: m.parts?.filter(
+                        (part) => part.type !== "tool-invocation"
+                      ),
+                    },
+                    null,
+                    2
+                  )}
+                </pre>
+              )}
+              <div
+                className={`flex ${isUser ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  className={`${isUser ? "flex flex-row-reverse gap-2 max-w-[85%]" : "w-full"}`}
+                >
+                  <div className={isUser ? "flex-1" : "w-full"}>
+                    <div>
+                      {(() => {
+                        const topLevelData: any = (m as any)?.data;
+                        if (
+                          topLevelData?.type === "ui_hint" &&
+                          topLevelData?.hint?.type === "shards_ready"
+                        ) {
+                          const cid = topLevelData?.hint?.data?.campaignId as
+                            | string
+                            | undefined;
+                          if (!shouldRenderShardUI(cid)) return null;
+                          const Comp = ShardManagementUI;
+                          const groups = topLevelData.hint.data.groups || [];
+                          const total = Array.isArray(groups)
+                            ? groups.reduce(
+                                (t: number, g: any) =>
+                                  t + (g?.shards?.length || 0),
+                                0
+                              )
+                            : 0;
+                          return (
+                            <div
+                              key={`${m.id}-render-top-uihint`}
+                              className="w-full"
+                            >
+                              <Comp
+                                campaignId={cid!}
+                                resourceId={topLevelData.hint.data.resourceId}
+                                shards={groups}
+                                total={total}
+                                action="show_staged"
+                              />
+                            </div>
+                          );
+                        }
+                        return null;
+                      })()}
+                      {m.parts?.map((part, i) => {
+                        const hasTopLevelRender = false;
+                        if (part.type === "text" && hasTopLevelRender) {
+                          return null;
+                        }
+                        if (part.type === "text") {
+                          return (
+                            <div key={`${m.id}-text-${i}`}>
+                              <Card
+                                className={`p-3 rounded-md bg-neutral-100 dark:bg-neutral-900 ${
+                                  isUser
+                                    ? "rounded-br-none"
+                                    : "rounded-bl-none border-assistant-border"
+                                } ${
+                                  part.text.startsWith("scheduled message")
+                                    ? "border-accent/50"
+                                    : ""
+                                } relative`}
+                              >
+                                {part.text.startsWith("scheduled message") && (
+                                  <span className="absolute -top-3 -left-2 text-base">
+                                    🕒
+                                  </span>
+                                )}
+                                <MemoizedMarkdown
+                                  content={part.text.replace(
+                                    /^scheduled message: /,
+                                    ""
+                                  )}
+                                />
+                              </Card>
+                              <p
+                                className={`text-xs text-muted-foreground mt-1 ${
+                                  isUser ? "text-right" : "text-left"
+                                }`}
+                              >
+                                {formatTime(
+                                  new Date(m.createdAt as unknown as string)
+                                )}
+                              </p>
+                            </div>
+                          );
+                        }
+
+                        if (part.type === "tool-invocation") {
+                          const toolInvocation = part.toolInvocation;
+                          const toolCallId = toolInvocation.toolCallId;
+                          const needsConfirmation = false; // external card will manage specifics
+                          if (!showDebug) return null;
+                          return (
+                            <ToolInvocationCard
+                              key={`${m.id}-tool-${toolCallId}-${i}`}
+                              toolInvocation={toolInvocation}
+                              toolCallId={toolCallId}
+                              needsConfirmation={needsConfirmation as any}
+                              addToolResult={addToolResult}
+                              showDebug={showDebug}
+                            />
+                          );
+                        }
+                        return null;
+                      })}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+    </>
+  );
+}

--- a/src/components/chat/shard/ShardHeader.tsx
+++ b/src/components/chat/shard/ShardHeader.tsx
@@ -3,8 +3,8 @@ import type React from "react";
 interface ShardHeaderProps {
   action: string;
   total: number;
-  campaignId: string;
-  resourceId?: string;
+  campaignName: string | null;
+  resourceName?: string | null;
   shardType?: string;
   selectedCount: number;
   totalShards: number;
@@ -14,8 +14,8 @@ interface ShardHeaderProps {
 export const ShardHeader: React.FC<ShardHeaderProps> = ({
   action,
   total,
-  campaignId,
-  resourceId,
+  campaignName,
+  resourceName,
   shardType,
   selectedCount,
   totalShards,
@@ -29,8 +29,8 @@ export const ShardHeader: React.FC<ShardHeaderProps> = ({
           {action.replace("show_", "").replace("_", " ").toUpperCase()}
         </h3>
         <p className="text-sm text-gray-600">
-          Found {total} shards for campaign {campaignId}
-          {resourceId && ` • Resource: ${resourceId}`}
+          Found {total} shards for campaign {campaignName || "unknown campaign"}
+          {` • Resource: ${resourceName || "unknown resource"}`}
           {shardType && ` • Type: ${shardType}`}
         </p>
       </div>

--- a/src/components/chat/shard/ShardItem.tsx
+++ b/src/components/chat/shard/ShardItem.tsx
@@ -6,7 +6,7 @@ interface ShardItemProps {
     text: string;
     metadata: {
       entityType: string;
-      confidence: number;
+      confidence?: number;
       query?: string;
     };
   };
@@ -42,9 +42,12 @@ export const ShardItem: React.FC<ShardItemProps> = ({
             <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
               {shard.metadata.entityType}
             </span>
-            <span className="text-sm text-gray-500">
-              Confidence: {Math.round(shard.metadata.confidence * 100)}%
-            </span>
+            {typeof shard.metadata.confidence === "number" &&
+              !Number.isNaN(shard.metadata.confidence) && (
+                <span className="text-sm text-gray-500">
+                  Confidence: {Math.round(shard.metadata.confidence * 100)}%
+                </span>
+              )}
           </div>
 
           <p className="text-gray-700 whitespace-pre-wrap text-sm">

--- a/src/components/upload/FileStatusIndicator.tsx
+++ b/src/components/upload/FileStatusIndicator.tsx
@@ -60,9 +60,6 @@ export function FileStatusIndicator({
         };
 
         if (result.success && result.updatedCount > 0) {
-          console.log(
-            `[FileStatusIndicator] Updated ${result.updatedCount} file statuses`
-          );
           // Trigger a custom event to refresh the ResourceList data instead of page reload
           window.dispatchEvent(
             new CustomEvent("file-status-updated", {
@@ -70,7 +67,6 @@ export function FileStatusIndicator({
             })
           );
         } else {
-          console.log("[FileStatusIndicator] No file statuses were updated");
         }
       }
     } catch (error) {

--- a/src/hooks/useShardRenderGate.ts
+++ b/src/hooks/useShardRenderGate.ts
@@ -1,0 +1,48 @@
+import { useEffect, useMemo, useState } from "react";
+import { API_CONFIG } from "../shared";
+import { authenticatedFetchWithExpiration } from "../services/auth-service";
+
+export function useShardRenderGate(
+  getJwt: () => string | null,
+  campaignIds: string[]
+) {
+  const [presence, setPresence] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const jwt = getJwt();
+    if (!jwt) return;
+    const unique = Array.from(new Set(campaignIds)).filter(Boolean) as string[];
+    unique.forEach((cid) => {
+      if (presence[cid] !== undefined) return;
+      (async () => {
+        try {
+          const { response, jwtExpired } =
+            await authenticatedFetchWithExpiration(
+              API_CONFIG.buildUrl(
+                API_CONFIG.ENDPOINTS.CAMPAIGNS.CAMPAIGN_AUTORAG.STAGED_SHARDS(
+                  cid
+                )
+              ),
+              { jwt }
+            );
+          if (!jwtExpired && response.ok) {
+            const json = (await response.json()) as { shards?: any[] };
+            const has = Array.isArray(json?.shards) && json.shards.length > 0;
+            setPresence((prev) => ({ ...prev, [cid]: has }));
+          } else {
+            setPresence((prev) => ({ ...prev, [cid]: false }));
+          }
+        } catch {
+          setPresence((prev) => ({ ...prev, [cid]: false }));
+        }
+      })();
+    });
+  }, [getJwt, campaignIds, presence]);
+
+  const shouldRender = useMemo(
+    () => (cid?: string) => (cid ? presence[cid] === true : false),
+    [presence]
+  );
+
+  return { shouldRender, presence };
+}

--- a/src/hooks/useUiHints.ts
+++ b/src/hooks/useUiHints.ts
@@ -1,0 +1,36 @@
+import { useEffect, useCallback } from "react";
+
+interface UiHint {
+  type: string;
+  data?: any;
+}
+
+interface UseUiHintsOptions {
+  onUiHint?: (hint: UiHint) => void;
+}
+
+export function useUiHints(options: UseUiHintsOptions = {}) {
+  const { onUiHint } = options;
+
+  const handleUiHint = useCallback(
+    (e: CustomEvent) => {
+      const { type, data } = (e as any).detail || {};
+      if (!type) return;
+      onUiHint?.({ type, data });
+    },
+    [onUiHint]
+  );
+
+  useEffect(() => {
+    window.addEventListener(
+      "ui-hint",
+      handleUiHint as unknown as EventListener
+    );
+    return () => {
+      window.removeEventListener(
+        "ui-hint",
+        handleUiHint as unknown as EventListener
+      );
+    };
+  }, [handleUiHint]);
+}

--- a/src/lib/autorag.ts
+++ b/src/lib/autorag.ts
@@ -130,6 +130,7 @@ export class AutoRAGClient {
       };
       rewrite_query?: boolean;
       filters?: ComparisonFilter | CompoundFilter;
+      system_prompt?: string;
     } = {}
   ): Promise<AutoRAGAISearchResult> {
     const {
@@ -137,6 +138,7 @@ export class AutoRAGClient {
       ranking_options = {},
       rewrite_query = false,
       filters,
+      system_prompt,
     } = options;
 
     console.log(
@@ -161,6 +163,10 @@ export class AutoRAGClient {
     // Add metadata filtering if specified
     if (filters) {
       searchPayload.filters = filters;
+    }
+
+    if (system_prompt) {
+      (searchPayload as any).system_prompt = system_prompt;
     }
 
     const response = await fetch(this.aiSearchUrl, {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -55,7 +55,8 @@ export async function notifyShardGeneration(
   userId: string,
   campaignName: string,
   fileName: string,
-  shardCount: number
+  shardCount: number,
+  context?: { campaignId: string; resourceId: string; groups?: any[] }
 ): Promise<void> {
   const isNone = !shardCount || shardCount === 0;
   const title = isNone ? "No Shards Found" : "New Shards Ready!";
@@ -71,6 +72,19 @@ export async function notifyShardGeneration(
       campaignName,
       fileName,
       shardCount,
+      // Provide optional decoupled UI hint (no component names)
+      ...(context
+        ? {
+            ui_hint: {
+              type: "shards_ready",
+              data: {
+                campaignId: context.campaignId,
+                resourceId: context.resourceId,
+                groups: context.groups,
+              },
+            },
+          }
+        : {}),
     },
   });
 }

--- a/src/queue_consumer.ts
+++ b/src/queue_consumer.ts
@@ -237,26 +237,30 @@ export class FileProcessingQueue {
 }
 
 // Export the queue handler function for Wrangler
-export default {
-  async queue(batch: MessageBatch<ProcessingMessage>, env: Env): Promise<void> {
-    const processor = new FileProcessingQueue(env);
+export async function queue(
+  batch: MessageBatch<ProcessingMessage>,
+  env: Env
+): Promise<void> {
+  const processor = new FileProcessingQueue(env);
 
-    console.log(`[Queue] Processing ${batch.messages.length} messages`);
+  console.log(`[Queue] Processing ${batch.messages.length} messages`);
 
-    for (const message of batch.messages) {
-      try {
-        await processor.handleMessage(message.body);
-        message.ack();
-      } catch (error) {
-        console.error(`[Queue] Failed to process message:`, error);
-        message.retry();
-      }
+  for (const message of batch.messages) {
+    try {
+      await processor.handleMessage(message.body);
+      message.ack();
+    } catch (error) {
+      console.error(`[Queue] Failed to process message:`, error);
+      message.retry();
     }
-  },
+  }
+}
 
-  async scheduled(_event: ScheduledEvent, env: Env): Promise<void> {
-    // Clean up old staging files every hour
-    const processor = new FileProcessingQueue(env);
-    await processor.cleanupStaging();
-  },
-};
+export async function scheduled(
+  _event: ScheduledEvent,
+  env: Env
+): Promise<void> {
+  // Clean up old staging files every hour
+  const processor = new FileProcessingQueue(env);
+  await processor.cleanupStaging();
+}

--- a/src/services/autorag-client.ts
+++ b/src/services/autorag-client.ts
@@ -111,6 +111,7 @@ export abstract class AutoRAGClientBase {
       };
       rewrite_query?: boolean;
       filters?: ComparisonFilter | CompoundFilter;
+      system_prompt?: string;
     } = {}
   ): Promise<AutoRAGAISearchResult> {
     await this.ensureInitialized();
@@ -118,7 +119,7 @@ export abstract class AutoRAGClientBase {
     const enforcedFilter = this.enforcedFilter();
 
     // Merge filters - if both exist, combine with logical AND
-    const mergedOptions = { ...options };
+    const mergedOptions = { ...options } as any;
     if (enforcedFilter && options.filters) {
       // Combine enforced filter with caller filters using AND
       mergedOptions.filters = {

--- a/src/utils/helpContent.ts
+++ b/src/utils/helpContent.ts
@@ -1,0 +1,61 @@
+export function getHelpContent(action: string): string {
+  switch (action) {
+    case "upload_resource":
+      return (
+        "## 📁 Uploading Resources\n\n" +
+        "To upload resources to your inspiration library:\n\n" +
+        "1. **Look for the 'Add to library' button** in the interface\n" +
+        "2. **Click the button** to open the upload modal\n" +
+        "3. **Drag and drop files** directly onto the upload area for quick upload\n" +
+        "4. **Select files** from your computer if you prefer\n\n" +
+        "**Supported file types:** PDF files, images, and other documents\n\n" +
+        "Once uploaded, your resources will be available in your inspiration library for campaign planning!"
+      );
+    case "create_campaign":
+      return (
+        "## 🎲 Creating a Campaign\n\n" +
+        "To create a new campaign:\n\n" +
+        "1. **Look for the 'Create Campaign' button** in the interface\n" +
+        "2. **Click the button** to open the campaign creation form\n" +
+        "3. **Enter campaign details** including:\n" +
+        "- Campaign name\n" +
+        "- Description\n" +
+        "- Setting details\n" +
+        "4. **Save your campaign** to start organizing your resources\n\n" +
+        "**Benefits:** Campaigns help you organize your resources, plan sessions, and track your story development!"
+      );
+    case "start_chat":
+      return (
+        "## 💬 Starting a Chat\n\n" +
+        "You can start chatting with me right here! Just type your questions about:\n\n" +
+        "**Campaign Ideas:**\n" +
+        "- World building concepts\n" +
+        "- Plot development\n" +
+        "- Character creation\n\n" +
+        "**GM Topics:**\n" +
+        "- Session planning\n" +
+        "- Encounter design\n" +
+        "- Story pacing\n\n" +
+        "**Tips:**\n" +
+        "- Be specific with your questions\n" +
+        "- Share your campaign context\n" +
+        "- Ask for examples or suggestions\n\n" +
+        "I'm here to help you develop your campaign ideas and provide guidance!"
+      );
+    default:
+      return (
+        "## 🎯 Getting Started\n\n" +
+        "I can help you with various tasks:\n\n" +
+        "**📁 Upload Resources:**\n" +
+        "- Look for the 'Add to library' button\n" +
+        "- Upload PDFs, images, and documents\n\n" +
+        "**🎲 Create Campaigns:**\n" +
+        "- Use the 'Create Campaign' button\n" +
+        "- Organize your story elements\n\n" +
+        "**💬 Start Chatting:**\n" +
+        "- Just type your questions here\n" +
+        "- Ask about campaign ideas, world building, or GM topics\n\n" +
+        "**💡 Pro Tip:** Be specific with your questions to get the most helpful responses!"
+      );
+  }
+}


### PR DESCRIPTION
- Add ui_hint (shards_ready) emission and client listener
- Render ShardManagementUI from R2 staged response; guard empty/missing shards
- Show friendly names; hide confidence when missing/NaN
- Replace dynamic import with static; fix lints and stable keys
- Remove no-op effect in ResourceList