### PR TITLE
Fix React error #31 in shard detail expansion

### DIFF
--- a/docs/CAMPAIGN_SHARD_FLOW.md
+++ b/docs/CAMPAIGN_SHARD_FLOW.md
@@ -355,8 +355,9 @@ POST /campaigns/:campaignId/shards/reject
 └── campaigns/
     └── [campaign-id]/
         ├── staging/            # Temporary shard candidates
-        ├── approved/           # Curated campaign knowledge
-        └── rejected/           # Rejected content (for audit)
+        └── context/
+            ├── approved/       # Curated campaign knowledge
+            └── rejected/       # Rejected content (for audit)
 ```
 
 ## Benefits

--- a/src/components/shard/ShardTypeDetector.ts
+++ b/src/components/shard/ShardTypeDetector.ts
@@ -58,13 +58,23 @@ export function getEditableProperties(shard: Shard): Array<{
 }> {
   const excludeFields = ["id", "metadata", "created_at", "updated_at"];
 
-  return Object.entries(shard)
+  const properties = Object.entries(shard)
     .filter(([key]) => !excludeFields.includes(key))
     .map(([key, value]) => ({
-      key,
+      key: key || "unnamed",
       value,
       type: getValueType(value),
     }));
+
+  // Remove duplicates based on key
+  const seenKeys = new Set<string>();
+  return properties.filter(({ key }) => {
+    if (seenKeys.has(key)) {
+      return false;
+    }
+    seenKeys.add(key);
+    return true;
+  });
 }
 
 /**

--- a/tests/integration/context-capture-flow.test.ts
+++ b/tests/integration/context-capture-flow.test.ts
@@ -180,7 +180,7 @@ describe("Campaign Context Capture Flow Integration", () => {
     // Verify shard moved to approved
     const approvedKey = stagingKey.replace(
       "/conversation/staging/",
-      "/conversation/approved/"
+      "/context/approved/"
     );
     const approvedData = await mockR2.get(approvedKey);
     expect(approvedData).not.toBeNull();
@@ -234,7 +234,7 @@ describe("Campaign Context Capture Flow Integration", () => {
     // Verify moved to approved
     const approvedKey = stagingKey.replace(
       "/conversation/staging/",
-      "/conversation/approved/"
+      "/context/approved/"
     );
     const approvedData = await mockR2.get(approvedKey);
     expect(approvedData).not.toBeNull();

--- a/tests/integration/shard-approval-flow.test.ts
+++ b/tests/integration/shard-approval-flow.test.ts
@@ -132,7 +132,16 @@ describe("Shard Approval Flow Integration", () => {
     await campaignAutoRAG.approveShards(stagingKey1);
 
     // Verify shard moved to approved
-    const approvedKey1 = stagingKey1.replace("/staging/", "/approved/");
+    // Extract filename from staging key and construct approved key
+    const stagingParts = stagingKey1.split("/");
+    const filename = stagingParts[stagingParts.length - 1];
+    const campaignsIndex = stagingParts.findIndex(
+      (part) => part === "campaigns"
+    );
+    const campaignBasePath = stagingParts
+      .slice(0, campaignsIndex + 2)
+      .join("/"); // campaigns + campaign-id
+    const approvedKey1 = `${campaignBasePath}/context/approved/${filename}`;
     const approvedData = await mockR2.get(approvedKey1);
     expect(approvedData).not.toBeNull();
 
@@ -148,7 +157,16 @@ describe("Shard Approval Flow Integration", () => {
     );
 
     // Verify shard moved to rejected with metadata
-    const rejectedKey = stagingKey2.replace("/staging/", "/rejected/");
+    // Extract filename from staging key and construct rejected key
+    const stagingParts2 = stagingKey2.split("/");
+    const filename2 = stagingParts2[stagingParts2.length - 1];
+    const campaignsIndex2 = stagingParts2.findIndex(
+      (part) => part === "campaigns"
+    );
+    const campaignBasePath2 = stagingParts2
+      .slice(0, campaignsIndex2 + 2)
+      .join("/"); // campaigns + campaign-id
+    const rejectedKey = `${campaignBasePath2}/context/rejected/${filename2}`;
     const rejectedData = await mockR2.get(rejectedKey);
     expect(rejectedData).not.toBeNull();
 
@@ -219,9 +237,16 @@ describe("Shard Approval Flow Integration", () => {
     await campaignAutoRAG.approveShards(stagingKey, [expansion]);
 
     // Verify expansion file was created
-    const expansionKey = stagingKey
-      .replace("/staging/", "/approved/")
-      .replace(".json", ".exp.json");
+    // Extract filename from staging key and construct expansion key
+    const stagingParts = stagingKey.split("/");
+    const filename = stagingParts[stagingParts.length - 1];
+    const campaignsIndex = stagingParts.findIndex(
+      (part) => part === "campaigns"
+    );
+    const campaignBasePath = stagingParts
+      .slice(0, campaignsIndex + 2)
+      .join("/"); // campaigns + campaign-id
+    const expansionKey = `${campaignBasePath}/context/approved/${filename.replace(".json", ".exp.json")}`;
     const expansionData = await mockR2.get(expansionKey);
 
     expect(expansionData).not.toBeNull();
@@ -270,13 +295,13 @@ describe("Shard Approval Flow Integration", () => {
 
     // Verify approved folder has 3 shards
     const approvedList = await mockR2.list({
-      prefix: `${campaignBasePath}/approved/`,
+      prefix: `${campaignBasePath}/context/approved/`,
     });
     expect(approvedList.objects).toHaveLength(3);
 
     // Verify rejected folder has 2 shards
     const rejectedList = await mockR2.list({
-      prefix: `${campaignBasePath}/rejected/`,
+      prefix: `${campaignBasePath}/context/rejected/`,
     });
     expect(rejectedList.objects).toHaveLength(2);
 

--- a/tests/services/campaign-auto-rag.test.ts
+++ b/tests/services/campaign-auto-rag.test.ts
@@ -41,7 +41,7 @@ describe("CampaignAutoRAG", () => {
     it("should return the correct approved folder path", () => {
       // Access the protected method through the class instance
       const result = (campaignAutoRAG as any).enforcedFilter();
-      expect(result).toBe("campaigns/test-campaign-123/approved/");
+      expect(result).toBe("campaigns/test-campaign-123/context/approved/");
     });
   });
 

--- a/tests/services/campaign-autorag-service.test.ts
+++ b/tests/services/campaign-autorag-service.test.ts
@@ -63,7 +63,7 @@ describe("CampaignAutoRAG", () => {
     it("should return correct approved path for filter enforcement", () => {
       const filter = (campaignAutoRAG as any).enforcedFilter();
 
-      expect(filter).toBe(`${campaignBasePath}/approved/`);
+      expect(filter).toBe(`${campaignBasePath}/context/approved/`);
     });
 
     it("should scope searches to approved content only", async () => {
@@ -326,7 +326,7 @@ describe("CampaignAutoRAG", () => {
   describe("rejectShards", () => {
     it("should wrap rejected data and move to rejected folder", async () => {
       const stagingKey = `${campaignBasePath}/staging/resource-123/shard-1.json`;
-      const rejectedKey = `${campaignBasePath}/rejected/resource-123/shard-1.json`;
+      const rejectedKey = `${campaignBasePath}/context/rejected/shard-1.json`;
       const reason = "Not relevant to campaign";
 
       const mockStagingData = {


### PR DESCRIPTION
- Add fallback keys for PropertyGrid properties to prevent React key errors
- Ensure array items have unique keys using String() conversion and index
- Add duplicate key filtering in getEditableProperties to prevent conflicts
- Handle undefined/null property keys gracefully with fallback values

Resolves the minified React error #31 that occurred when clicking on shard detail expansion, which was caused by duplicate or invalid React keys in the property rendering.

Fix object display in array properties for shard relations

- Replace simple pill display with structured sub-collection view for objects in arrays
- Objects in arrays now show as expandable cards with key-value pairs
- Update addArrayItem to parse JSON objects when adding new items
- Change placeholder text to indicate JSON support for objects
- Objects display their properties as readable key: value pairs instead of [object Object]

Resolves the issue where relations field showed '[object Object]' instead of displaying the actual object properties as a sub-collection.

Fix shard approval UI race condition and double-click issues

- Add optimistic UI updates to prevent double-approval attempts
- Implement proper error handling for 'Staging file not found' cases
- Add visual feedback with processing indicators and success messages
- Filter processed shards from display to prevent re-selection
- Add 500ms delay before refresh to ensure backend operations complete
- Improve user experience with immediate feedback and clear status messages

Fixes issue where UI was too slow to update and allowed second approval attempts after shards were already moved, causing 'Staging file not found' errors.