### PR TITLE
Implement impact-based rebuild heuristics with entity importance system

### DIFF
--- a/src/components/shard/FlexibleShardCard.tsx
+++ b/src/components/shard/FlexibleShardCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
   ChevronDown,
   ChevronRight,
@@ -6,6 +6,7 @@ import {
   FileText,
   Check,
   X,
+  Star,
 } from "lucide-react";
 import type { FlexibleShard } from "./ShardTypeDetector";
 import {
@@ -14,6 +15,14 @@ import {
   getEditableProperties,
 } from "./ShardTypeDetector";
 import { PropertyGrid } from "./PropertyField";
+import {
+  authenticatedFetchWithExpiration,
+  getStoredJwt,
+} from "@/services/core/auth-service";
+import { API_CONFIG } from "@/shared-config";
+import { ImportanceCalculationError } from "@/lib/errors";
+
+type ImportanceLevel = "high" | "medium" | "low" | null;
 
 interface FlexibleShardCardProps {
   shard: FlexibleShard;
@@ -23,6 +32,7 @@ interface FlexibleShardCardProps {
   onDelete?: (shardId: string) => void;
   onDeleteProperty?: (shardId: string, key: string) => void;
   className?: string;
+  campaignId?: string;
 }
 
 export function FlexibleShardCard({
@@ -33,8 +43,120 @@ export function FlexibleShardCard({
   onDelete,
   onDeleteProperty,
   className = "",
+  campaignId,
 }: FlexibleShardCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [importanceLoading, setImportanceLoading] = useState(false);
+
+  // Get importance from metadata
+  const importanceScore = (shard.metadata as any)?.importanceScore as
+    | number
+    | undefined;
+  const importanceOverride = (shard.metadata as any)?.importanceOverride as
+    | ImportanceLevel
+    | undefined;
+
+  // Determine current importance level from score or override
+  const getImportanceLevel = useMemo((): ImportanceLevel => {
+    if (importanceOverride !== undefined) {
+      return importanceOverride;
+    }
+    if (importanceScore !== undefined) {
+      if (importanceScore >= 80) return "high";
+      if (importanceScore >= 60) return "medium";
+      return "low";
+    }
+    return null;
+  }, [importanceScore, importanceOverride]);
+
+  const [currentImportance, setCurrentImportance] =
+    useState<ImportanceLevel>(getImportanceLevel);
+
+  // Update local state when shard metadata changes
+  useEffect(() => {
+    setCurrentImportance(getImportanceLevel);
+  }, [getImportanceLevel]);
+
+  const handleImportanceChange = async (newLevel: ImportanceLevel) => {
+    if (!campaignId) {
+      console.warn(
+        "[FlexibleShardCard] Cannot update importance: campaignId not provided"
+      );
+      return;
+    }
+
+    setImportanceLoading(true);
+    try {
+      const jwt = getStoredJwt();
+      if (!jwt) {
+        throw new Error("No authentication token available");
+      }
+
+      const { response, jwtExpired } = await authenticatedFetchWithExpiration(
+        API_CONFIG.buildUrl(
+          API_CONFIG.ENDPOINTS.CAMPAIGNS.ENTITIES.IMPORTANCE(
+            campaignId,
+            shard.id
+          )
+        ),
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${jwt}`,
+          },
+          body: JSON.stringify({ importanceLevel: newLevel }),
+        }
+      );
+
+      if (jwtExpired) {
+        throw new Error("Session expired. Please refresh the page.");
+      }
+
+      if (!response.ok) {
+        const errorData = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new ImportanceCalculationError(
+          errorData.error || `Failed to update importance`,
+          response.status
+        );
+      }
+
+      const result = (await response.json()) as {
+        entity?: {
+          metadata?: Record<string, unknown>;
+        };
+      };
+      if (result.entity) {
+        // Update local state
+        setCurrentImportance(newLevel);
+        // Notify parent component if onEdit is provided
+        if (onEdit) {
+          const currentMetadata =
+            typeof shard.metadata === "object" && shard.metadata !== null
+              ? shard.metadata
+              : {};
+          onEdit(shard.id, {
+            metadata: {
+              ...currentMetadata,
+              importanceOverride: newLevel,
+              importanceScore: (result.entity.metadata as any)?.importanceScore,
+            },
+          } as Partial<FlexibleShard>);
+        }
+      }
+    } catch (error) {
+      console.error("[FlexibleShardCard] Failed to update importance:", error);
+      alert(
+        error instanceof Error ? error.message : "Failed to update importance"
+      );
+      // Revert to previous value on error
+      setCurrentImportance(getImportanceLevel);
+    } finally {
+      setImportanceLoading(false);
+    }
+  };
 
   const editableProperties = useMemo(
     () =>
@@ -298,6 +420,44 @@ export function FlexibleShardCard({
                   </span>
                 </div>
               </div>
+            </div>
+          )}
+
+          {/* Importance */}
+          {campaignId && (
+            <div>
+              <label
+                htmlFor={`shard-importance-${shard.id}`}
+                className="text-sm font-medium text-gray-300 flex items-center gap-2 mb-2"
+              >
+                <Star size={14} />
+                Importance
+                {importanceScore !== undefined && (
+                  <span className="text-xs text-gray-400">
+                    (Score: {Math.round(importanceScore)})
+                  </span>
+                )}
+              </label>
+              <select
+                id={`shard-importance-${shard.id}`}
+                value={currentImportance || ""}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  handleImportanceChange(
+                    value === "" ? null : (value as ImportanceLevel)
+                  );
+                }}
+                disabled={importanceLoading}
+                className="w-full px-3 py-2 border border-gray-600 rounded text-sm bg-gray-700 text-white focus:border-purple-500 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <option value="">Auto (calculated)</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+              {importanceLoading && (
+                <p className="text-xs text-gray-400 mt-1">Updating...</p>
+              )}
             </div>
           )}
 

--- a/src/components/shard/ShardGrid.tsx
+++ b/src/components/shard/ShardGrid.tsx
@@ -362,6 +362,7 @@ export function ShardGrid({
                         onSelect={handleSelectShard}
                         onEdit={onShardEdit}
                         onDelete={onShardDelete}
+                        campaignId={campaignId}
                       />
                     ) : (
                       <FlexibleShardCard
@@ -370,6 +371,7 @@ export function ShardGrid({
                         onSelect={handleSelectShard}
                         onEdit={onShardEdit}
                         onDelete={onShardDelete}
+                        campaignId={campaignId}
                       />
                     )}
                   </div>

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -304,6 +304,19 @@ export class EntityExtractionError extends Error {
   }
 }
 
+export class ImportanceCalculationError extends Error {
+  constructor(
+    message?: string,
+    public readonly statusCode?: number
+  ) {
+    super(
+      message ||
+        "Failed to calculate or update entity importance. Please try again."
+    );
+    this.name = "ImportanceCalculationError";
+  }
+}
+
 export class EmbeddingGenerationError extends Error {
   constructor(message?: string) {
     super(message || "Failed to generate embeddings.");

--- a/src/lib/importance-config.ts
+++ b/src/lib/importance-config.ts
@@ -1,0 +1,55 @@
+export const HIGH_RANGE = { min: 80, max: 100 };
+export const MEDIUM_RANGE = { min: 60, max: 79 };
+export const LOW_RANGE = { min: 0, max: 59 };
+
+export type ImportanceLevel = "high" | "medium" | "low";
+
+export function mapScoreToLevel(score: number): ImportanceLevel {
+  if (score >= HIGH_RANGE.min) {
+    return "high";
+  }
+  if (score >= MEDIUM_RANGE.min) {
+    return "medium";
+  }
+  return "low";
+}
+
+export function isScoreInCategory(
+  score: number,
+  category: ImportanceLevel
+): boolean {
+  switch (category) {
+    case "high":
+      return score >= HIGH_RANGE.min && score <= HIGH_RANGE.max;
+    case "medium":
+      return score >= MEDIUM_RANGE.min && score <= MEDIUM_RANGE.max;
+    case "low":
+      return score >= LOW_RANGE.min && score <= LOW_RANGE.max;
+    default:
+      return false;
+  }
+}
+
+export function mapOverrideToScore(
+  override: ImportanceLevel | null,
+  currentScore: number
+): number {
+  if (override === null) {
+    return currentScore;
+  }
+
+  if (isScoreInCategory(currentScore, override)) {
+    return currentScore;
+  }
+
+  switch (override) {
+    case "high":
+      return 90;
+    case "medium":
+      return 60;
+    case "low":
+      return 10;
+    default:
+      return currentScore;
+  }
+}

--- a/src/lib/rebuild-config.ts
+++ b/src/lib/rebuild-config.ts
@@ -1,0 +1,9 @@
+export const FULL_REBUILD_THRESHOLD =
+  typeof process !== "undefined" && process.env.FULL_REBUILD_THRESHOLD
+    ? Number.parseInt(process.env.FULL_REBUILD_THRESHOLD, 10)
+    : 100;
+
+export const PARTIAL_REBUILD_THRESHOLD =
+  typeof process !== "undefined" && process.env.PARTIAL_REBUILD_THRESHOLD
+    ? Number.parseInt(process.env.PARTIAL_REBUILD_THRESHOLD, 10)
+    : 20;

--- a/src/routes/register-routes.ts
+++ b/src/routes/register-routes.ts
@@ -60,6 +60,7 @@ import {
   handleResolveDeduplicationEntry,
   handleCreateEntityRelationship,
   handleDeleteEntityRelationship,
+  handleUpdateEntityImportance,
 } from "@/routes/entities";
 import {
   handleDetectCommunities,
@@ -343,6 +344,14 @@ export function registerRoutes(app: Hono<{ Bindings: Env }>) {
     API_CONFIG.ENDPOINTS.CAMPAIGNS.ENTITIES.RELATIONSHIP_TYPES(":campaignId"),
     requireUserJwt,
     handleListRelationshipTypes
+  );
+  app.patch(
+    API_CONFIG.ENDPOINTS.CAMPAIGNS.ENTITIES.IMPORTANCE(
+      ":campaignId",
+      ":entityId"
+    ),
+    requireUserJwt,
+    handleUpdateEntityImportance
   );
   app.post(
     API_CONFIG.ENDPOINTS.CAMPAIGNS.ENTITIES.RELATIONSHIPS(

--- a/src/services/graph/entity-importance-service.ts
+++ b/src/services/graph/entity-importance-service.ts
@@ -1,0 +1,566 @@
+import type { EntityDAO } from "@/dao/entity-dao";
+import type { CommunityDAO } from "@/dao/community-dao";
+import {
+  mapOverrideToScore,
+  type ImportanceLevel,
+} from "@/lib/importance-config";
+
+interface GraphNode {
+  id: string;
+  neighbors: Set<string>;
+  inDegree: number;
+  outDegree: number;
+}
+
+interface Graph {
+  nodes: Map<string, GraphNode>;
+  edges: Array<{ from: string; to: string; weight: number }>;
+}
+
+export class EntityImportanceService {
+  constructor(
+    private readonly entityDAO: EntityDAO,
+    private readonly communityDAO?: CommunityDAO
+  ) {}
+
+  async calculatePageRank(
+    campaignId: string,
+    includeStaging = true
+  ): Promise<Map<string, number>> {
+    const graph = await this.buildGraph(campaignId, includeStaging);
+    const scores = new Map<string, number>();
+
+    if (graph.nodes.size === 0) {
+      console.log(
+        `[EntityImportance] PageRank: Empty graph for campaign ${campaignId}, skipping`
+      );
+      return scores;
+    }
+
+    console.log(
+      `[EntityImportance] PageRank: Calculating for ${graph.nodes.size} nodes, ${graph.edges.length} edges`
+    );
+
+    const dampingFactor = 0.85;
+    const maxIterations = 100;
+    const tolerance = 0.0001;
+
+    const nodeIds = Array.from(graph.nodes.keys());
+    const numNodes = nodeIds.length;
+
+    // Initialize all nodes with equal probability (1/n)
+    for (const id of nodeIds) {
+      scores.set(id, 1.0 / numNodes);
+    }
+
+    // Iterative PageRank algorithm: repeatedly update scores until convergence
+    // Each iteration redistributes importance based on incoming links
+    for (let iteration = 0; iteration < maxIterations; iteration++) {
+      const newScores = new Map<string, number>();
+      let maxDiff = 0;
+
+      // Calculate new PageRank score for each node
+      // A node's importance comes from nodes that link to it
+      for (const nodeId of nodeIds) {
+        const node = graph.nodes.get(nodeId);
+        if (!node) continue;
+
+        // Sum contributions from all neighbors (nodes that link to this node)
+        // Each neighbor contributes its score divided by its out-degree
+        // This distributes the neighbor's importance proportionally to its outgoing links
+        let sum = 0;
+        for (const neighborId of node.neighbors) {
+          const neighbor = graph.nodes.get(neighborId);
+          if (!neighbor || neighbor.outDegree === 0) continue;
+
+          const oldScore = scores.get(neighborId) ?? 0;
+          sum += oldScore / neighbor.outDegree;
+        }
+
+        // PageRank formula: (1-d)/n + d * sum of neighbor contributions
+        // The (1-d)/n term ensures all nodes have a minimum importance
+        // The damping factor (d) controls how much weight to give to link structure vs. uniform distribution
+        const newScore = (1 - dampingFactor) / numNodes + dampingFactor * sum;
+        newScores.set(nodeId, newScore);
+
+        // Track the maximum change to detect convergence
+        const oldScore = scores.get(nodeId) ?? 0;
+        maxDiff = Math.max(maxDiff, Math.abs(newScore - oldScore));
+      }
+
+      // Update scores for next iteration
+      scores.clear();
+      for (const [id, score] of newScores) {
+        scores.set(id, score);
+      }
+
+      // Stop early if scores have converged (changes are below tolerance)
+      if (maxDiff < tolerance) {
+        console.log(
+          `[EntityImportance] PageRank: Converged after ${iteration + 1} iterations (maxDiff: ${maxDiff.toFixed(6)})`
+        );
+        break;
+      }
+    }
+
+    const normalized = this.normalizeScores(scores);
+    console.log(
+      `[EntityImportance] PageRank: Completed ${maxIterations} iterations, normalized ${normalized.size} scores`
+    );
+    return normalized;
+  }
+
+  /**
+   * Calculate betweenness centrality for all entities.
+   * Betweenness centrality measures how often a node lies on the shortest path
+   * between other nodes. Nodes with high betweenness act as bridges/connectors
+   * in the graph and are important for information flow.
+   */
+  async calculateBetweennessCentrality(
+    campaignId: string,
+    includeStaging = true
+  ): Promise<Map<string, number>> {
+    const graph = await this.buildGraph(campaignId, includeStaging);
+    const scores = new Map<string, number>();
+
+    if (graph.nodes.size === 0) {
+      console.log(
+        `[EntityImportance] Betweenness: Empty graph for campaign ${campaignId}, skipping`
+      );
+      return scores;
+    }
+
+    const nodeIds = Array.from(graph.nodes.keys());
+    console.log(
+      `[EntityImportance] Betweenness: Calculating for ${nodeIds.length} nodes`
+    );
+
+    // Initialize all nodes with zero betweenness score
+    for (const id of nodeIds) {
+      scores.set(id, 0);
+    }
+
+    // For each node as a source, calculate shortest paths to all other nodes
+    // This implements Brandes' algorithm for efficient betweenness calculation
+    for (const sourceId of nodeIds) {
+      // Track shortest distances from source to each node
+      const distances = new Map<string, number>();
+      // Count number of shortest paths from source to each node
+      const paths = new Map<string, number>();
+      // Store predecessors (nodes that lead to each node on shortest paths)
+      const predecessors = new Map<string, string[]>();
+
+      // Breadth-first search starting from source
+      const queue: string[] = [sourceId];
+      distances.set(sourceId, 0);
+      paths.set(sourceId, 1);
+
+      // BFS: Explore graph level by level to find all shortest paths
+      while (queue.length > 0) {
+        const currentId = queue.shift()!;
+        const currentDist = distances.get(currentId) ?? Infinity;
+
+        const node = graph.nodes.get(currentId);
+        if (!node) continue;
+
+        // Examine all neighbors of current node
+        for (const neighborId of node.neighbors) {
+          const neighborDist = distances.get(neighborId);
+          const newDist = currentDist + 1;
+
+          // First time reaching this neighbor: found a shortest path
+          if (neighborDist === undefined) {
+            distances.set(neighborId, newDist);
+            // Number of paths to neighbor = number of paths to current node
+            paths.set(neighborId, paths.get(currentId) ?? 0);
+            // Current node is a predecessor of neighbor
+            predecessors.set(neighborId, [currentId]);
+            queue.push(neighborId);
+          } else if (newDist === neighborDist) {
+            // Found another shortest path of same length
+            // Add current node's path count to neighbor's path count
+            const currentPaths = paths.get(currentId) ?? 0;
+            paths.set(neighborId, (paths.get(neighborId) ?? 0) + currentPaths);
+            // Add current node as another predecessor
+            const preds = predecessors.get(neighborId) ?? [];
+            preds.push(currentId);
+            predecessors.set(neighborId, preds);
+          }
+        }
+      }
+
+      // Calculate dependency scores: how much each node contributes to
+      // betweenness when source is the starting point
+      const dependencies = new Map<string, number>();
+      // Process nodes in reverse order of distance (furthest first)
+      // This allows us to accumulate dependencies correctly
+      const sortedNodes = Array.from(distances.keys()).sort(
+        (a, b) => (distances.get(b) ?? 0) - (distances.get(a) ?? 0)
+      );
+
+      // Backward pass: accumulate dependencies from furthest nodes to source
+      for (const nodeId of sortedNodes) {
+        if (nodeId === sourceId) continue;
+
+        // Get all predecessors (nodes that lead to this node on shortest paths)
+        const preds = predecessors.get(nodeId) ?? [];
+        const nodePaths = paths.get(nodeId) ?? 1;
+
+        // Distribute this node's dependency to its predecessors
+        // Proportionally based on how many shortest paths go through each predecessor
+        for (const predId of preds) {
+          const predPaths = paths.get(predId) ?? 1;
+          // Dependency formula: (paths through predecessor / paths to node) * (1 + node's dependency)
+          // This distributes the node's importance back to nodes that lead to it
+          const dependency =
+            (predPaths / nodePaths) * (1 + (dependencies.get(nodeId) ?? 0));
+          dependencies.set(
+            predId,
+            (dependencies.get(predId) ?? 0) + dependency
+          );
+        }
+
+        // Add this node's dependency to its betweenness score
+        // (excluding the source node itself)
+        if (nodeId !== sourceId) {
+          scores.set(
+            nodeId,
+            (scores.get(nodeId) ?? 0) + (dependencies.get(nodeId) ?? 0)
+          );
+        }
+      }
+    }
+
+    const normalized = this.normalizeScores(scores);
+    console.log(
+      `[EntityImportance] Betweenness: Completed for ${normalized.size} nodes`
+    );
+    return normalized;
+  }
+
+  async calculateHierarchyLevel(
+    campaignId: string,
+    entityId: string
+  ): Promise<number> {
+    if (!this.communityDAO) {
+      return 50;
+    }
+
+    const communities = await this.communityDAO.findCommunitiesContainingEntity(
+      campaignId,
+      entityId
+    );
+
+    if (communities.length === 0) {
+      return 50;
+    }
+
+    const maxLevel = Math.max(...communities.map((c) => c.level));
+    const minLevel = Math.min(...communities.map((c) => c.level));
+    const levelRange = maxLevel - minLevel;
+
+    if (levelRange === 0) {
+      return 50;
+    }
+
+    const avgLevel =
+      communities.reduce((sum, c) => sum + c.level, 0) / communities.length;
+    const normalizedLevel = ((avgLevel - minLevel) / levelRange) * 100;
+
+    return Math.max(0, Math.min(100, normalizedLevel));
+  }
+
+  async calculateCombinedImportance(
+    campaignId: string,
+    entityId: string,
+    includeStaging = true
+  ): Promise<number> {
+    const [pagerank, betweenness, hierarchy] = await Promise.all([
+      this.calculatePageRank(campaignId, includeStaging),
+      this.calculateBetweennessCentrality(campaignId, includeStaging),
+      this.calculateHierarchyLevel(campaignId, entityId),
+    ]);
+
+    const pagerankScore = pagerank.get(entityId) ?? 0;
+    const betweennessScore = betweenness.get(entityId) ?? 0;
+    const hierarchyScore = hierarchy;
+
+    const combined =
+      pagerankScore * 0.4 + betweennessScore * 0.4 + hierarchyScore * 0.2;
+
+    return Math.max(0, Math.min(100, combined));
+  }
+
+  async getEntityImportance(
+    campaignId: string,
+    entityId: string,
+    includeStaging = true
+  ): Promise<number> {
+    const entity = await this.entityDAO.getEntityById(entityId);
+    if (!entity || entity.campaignId !== campaignId) {
+      return 50;
+    }
+
+    const metadata = (entity.metadata as Record<string, unknown>) || {};
+    const override = metadata.importanceOverride as
+      | ImportanceLevel
+      | null
+      | undefined;
+
+    if (override) {
+      const currentScore =
+        (metadata.importanceScore as number) ??
+        (await this.calculateCombinedImportance(
+          campaignId,
+          entityId,
+          includeStaging
+        ));
+      return mapOverrideToScore(override, currentScore);
+    }
+
+    if (typeof metadata.importanceScore === "number") {
+      return metadata.importanceScore;
+    }
+
+    const calculated = await this.calculateCombinedImportance(
+      campaignId,
+      entityId,
+      includeStaging
+    );
+
+    await this.entityDAO.updateEntity(entityId, {
+      metadata: {
+        ...metadata,
+        importanceScore: calculated,
+      },
+    });
+
+    return calculated;
+  }
+
+  async recalculateImportanceForEntity(
+    campaignId: string,
+    entityId: string
+  ): Promise<number> {
+    const calculated = await this.calculateCombinedImportance(
+      campaignId,
+      entityId,
+      true
+    );
+
+    const entity = await this.entityDAO.getEntityById(entityId);
+    if (!entity) {
+      return calculated;
+    }
+
+    const metadata = (entity.metadata as Record<string, unknown>) || {};
+    const override = metadata.importanceOverride as
+      | ImportanceLevel
+      | null
+      | undefined;
+
+    const finalScore = override
+      ? mapOverrideToScore(override, calculated)
+      : calculated;
+
+    await this.entityDAO.updateEntity(entityId, {
+      metadata: {
+        ...metadata,
+        importanceScore: calculated,
+      },
+    });
+
+    return finalScore;
+  }
+
+  async recalculateImportanceForCampaign(
+    campaignId: string
+  ): Promise<Map<string, number>> {
+    const startTime = Date.now();
+    console.log(
+      `[EntityImportance] Starting batch importance calculation for campaign: ${campaignId}`
+    );
+
+    const graphCalcStart = Date.now();
+    const [pagerank, betweenness] = await Promise.all([
+      this.calculatePageRank(campaignId, true),
+      this.calculateBetweennessCentrality(campaignId, true),
+    ]);
+
+    const graphCalcTime = Date.now() - graphCalcStart;
+    console.log(
+      `[EntityImportance] PageRank and Betweenness calculated in ${graphCalcTime}ms (${pagerank.size} entities)`
+    );
+
+    const entities = await this.entityDAO.listEntitiesByCampaign(campaignId);
+    const results = new Map<string, number>();
+
+    for (const entity of entities) {
+      const metadata = (entity.metadata as Record<string, unknown>) || {};
+      const pagerankScore = pagerank.get(entity.id) ?? 0;
+      const betweennessScore = betweenness.get(entity.id) ?? 0;
+      const hierarchyScore = await this.calculateHierarchyLevel(
+        campaignId,
+        entity.id
+      );
+
+      const calculated =
+        pagerankScore * 0.4 + betweennessScore * 0.4 + hierarchyScore * 0.2;
+      const finalScore = Math.max(0, Math.min(100, calculated));
+
+      const override = metadata.importanceOverride as
+        | ImportanceLevel
+        | null
+        | undefined;
+
+      const importanceScore = override
+        ? mapOverrideToScore(override, finalScore)
+        : finalScore;
+
+      await this.entityDAO.updateEntity(entity.id, {
+        metadata: {
+          ...metadata,
+          importanceScore: finalScore,
+        },
+      });
+
+      results.set(entity.id, importanceScore);
+    }
+
+    const totalTime = Date.now() - startTime;
+    console.log(
+      `[EntityImportance] Batch importance calculation completed for campaign ${campaignId}: ${results.size} entities processed in ${totalTime}ms`
+    );
+
+    return results;
+  }
+
+  private async buildGraph(
+    campaignId: string,
+    includeStaging: boolean
+  ): Promise<Graph> {
+    const nodes = new Map<string, GraphNode>();
+    const edges: Array<{ from: string; to: string; weight: number }> = [];
+
+    const relationshipRecords =
+      await this.entityDAO.getMinimalRelationshipsForCampaign(campaignId);
+
+    const entityRecords =
+      await this.entityDAO.getMinimalEntitiesForCampaign(campaignId);
+
+    const rejectedEntityIds = new Set<string>();
+    const rejectedRelationshipKeys = new Set<string>();
+
+    for (const record of entityRecords) {
+      try {
+        const metadata = record.metadata
+          ? (JSON.parse(record.metadata) as Record<string, unknown>)
+          : {};
+        const shardStatus = metadata.shardStatus;
+        const ignored = metadata.ignored === true;
+        const rejected = metadata.rejected === true;
+
+        if (
+          (!includeStaging && shardStatus === "staging") ||
+          shardStatus === "rejected" ||
+          ignored === true ||
+          rejected === true
+        ) {
+          rejectedEntityIds.add(record.id);
+        }
+      } catch (_error) {
+        console.warn(
+          `[EntityImportance] Failed to parse entity metadata, including it`
+        );
+      }
+    }
+
+    for (const rel of relationshipRecords) {
+      if (
+        rejectedEntityIds.has(rel.fromEntityId) ||
+        rejectedEntityIds.has(rel.toEntityId)
+      ) {
+        continue;
+      }
+
+      try {
+        const relMetadata = rel.metadata
+          ? (JSON.parse(rel.metadata) as Record<string, unknown>)
+          : {};
+        if (relMetadata.rejected === true || relMetadata.ignored === true) {
+          rejectedRelationshipKeys.add(`${rel.fromEntityId}-${rel.toEntityId}`);
+          continue;
+        }
+
+        const status = relMetadata.status as string | undefined;
+        if (!includeStaging && status === "staging") {
+          rejectedRelationshipKeys.add(`${rel.fromEntityId}-${rel.toEntityId}`);
+          continue;
+        }
+      } catch (_error) {
+        console.warn(
+          `[EntityImportance] Failed to parse relationship metadata, including it`
+        );
+      }
+
+      edges.push({
+        from: rel.fromEntityId,
+        to: rel.toEntityId,
+        weight: rel.strength ?? 1.0,
+      });
+
+      if (!nodes.has(rel.fromEntityId)) {
+        nodes.set(rel.fromEntityId, {
+          id: rel.fromEntityId,
+          neighbors: new Set(),
+          inDegree: 0,
+          outDegree: 0,
+        });
+      }
+
+      if (!nodes.has(rel.toEntityId)) {
+        nodes.set(rel.toEntityId, {
+          id: rel.toEntityId,
+          neighbors: new Set(),
+          inDegree: 0,
+          outDegree: 0,
+        });
+      }
+
+      const fromNode = nodes.get(rel.fromEntityId)!;
+      const toNode = nodes.get(rel.toEntityId)!;
+
+      fromNode.neighbors.add(rel.toEntityId);
+      fromNode.outDegree++;
+      toNode.inDegree++;
+    }
+
+    return { nodes, edges };
+  }
+
+  private normalizeScores(scores: Map<string, number>): Map<string, number> {
+    if (scores.size === 0) {
+      return scores;
+    }
+
+    const values = Array.from(scores.values());
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const range = max - min;
+
+    if (range === 0) {
+      for (const key of scores.keys()) {
+        scores.set(key, 50);
+      }
+      return scores;
+    }
+
+    const normalized = new Map<string, number>();
+    scores.forEach((value, key) => {
+      const normalizedValue = ((value - min) / range) * 100;
+      normalized.set(key, Math.max(0, Math.min(100, normalizedValue)));
+    });
+
+    return normalized;
+  }
+}

--- a/src/services/graph/rebuild-trigger-service.ts
+++ b/src/services/graph/rebuild-trigger-service.ts
@@ -1,0 +1,164 @@
+import type { CampaignDAO } from "@/dao/campaign-dao";
+import {
+  FULL_REBUILD_THRESHOLD,
+  PARTIAL_REBUILD_THRESHOLD,
+} from "@/lib/rebuild-config";
+
+export type RebuildType = "full" | "partial" | "none";
+
+export interface RebuildDecision {
+  shouldRebuild: boolean;
+  rebuildType: RebuildType;
+  cumulativeImpact: number;
+  affectedEntities?: string[];
+  timestamp: string;
+}
+
+export class RebuildTriggerService {
+  constructor(private readonly campaignDAO: CampaignDAO) {}
+
+  async recordImpact(campaignId: string, impactScore: number): Promise<number> {
+    const campaign = await this.campaignDAO.getCampaignById(campaignId);
+    if (!campaign) {
+      throw new Error(`Campaign ${campaignId} not found`);
+    }
+
+    let metadata: Record<string, unknown> = {};
+    if (campaign.metadata) {
+      try {
+        metadata = JSON.parse(campaign.metadata) as Record<string, unknown>;
+      } catch (_error) {
+        metadata = {};
+      }
+    }
+
+    const currentImpact = (metadata.cumulativeImpact as number) ?? 0;
+    const newImpact = currentImpact + impactScore;
+
+    await this.campaignDAO.updateCampaign(campaignId, {
+      metadata: {
+        ...metadata,
+        cumulativeImpact: newImpact,
+        lastImpactUpdate: new Date().toISOString(),
+      },
+    });
+
+    return newImpact;
+  }
+
+  async getCumulativeImpact(campaignId: string): Promise<number> {
+    const campaign = await this.campaignDAO.getCampaignById(campaignId);
+    if (!campaign) {
+      return 0;
+    }
+
+    let metadata: Record<string, unknown> = {};
+    if (campaign.metadata) {
+      try {
+        metadata = JSON.parse(campaign.metadata) as Record<string, unknown>;
+      } catch (_error) {
+        metadata = {};
+      }
+    }
+
+    return (metadata.cumulativeImpact as number) ?? 0;
+  }
+
+  async shouldTriggerRebuild(campaignId: string): Promise<boolean> {
+    const cumulativeImpact = await this.getCumulativeImpact(campaignId);
+    return cumulativeImpact >= FULL_REBUILD_THRESHOLD;
+  }
+
+  async getRebuildType(
+    campaignId: string,
+    affectedEntityIds?: string[]
+  ): Promise<RebuildType> {
+    const cumulativeImpact = await this.getCumulativeImpact(campaignId);
+
+    if (cumulativeImpact >= FULL_REBUILD_THRESHOLD) {
+      return "full";
+    }
+
+    if (cumulativeImpact >= PARTIAL_REBUILD_THRESHOLD) {
+      if (affectedEntityIds && affectedEntityIds.length > 0) {
+        return "partial";
+      }
+      return "none";
+    }
+
+    return "none";
+  }
+
+  async makeRebuildDecision(
+    campaignId: string,
+    affectedEntityIds?: string[]
+  ): Promise<RebuildDecision> {
+    const cumulativeImpact = await this.getCumulativeImpact(campaignId);
+    const rebuildType = await this.getRebuildType(
+      campaignId,
+      affectedEntityIds
+    );
+
+    const shouldRebuild = rebuildType !== "none";
+
+    const decision: RebuildDecision = {
+      shouldRebuild,
+      rebuildType,
+      cumulativeImpact,
+      affectedEntities: affectedEntityIds,
+      timestamp: new Date().toISOString(),
+    };
+
+    if (shouldRebuild) {
+      console.log(
+        `[RebuildTrigger] Rebuild decision for campaign ${campaignId}:`,
+        {
+          type: rebuildType,
+          cumulativeImpact,
+          affectedEntities: affectedEntityIds?.length ?? 0,
+        }
+      );
+    }
+
+    return decision;
+  }
+
+  async resetImpact(campaignId: string): Promise<void> {
+    const campaign = await this.campaignDAO.getCampaignById(campaignId);
+    if (!campaign) {
+      return;
+    }
+
+    let metadata: Record<string, unknown> = {};
+    if (campaign.metadata) {
+      try {
+        metadata = JSON.parse(campaign.metadata) as Record<string, unknown>;
+      } catch (_error) {
+        metadata = {};
+      }
+    }
+
+    await this.campaignDAO.updateCampaign(campaignId, {
+      metadata: {
+        ...metadata,
+        cumulativeImpact: 0,
+        lastRebuildAt: new Date().toISOString(),
+      },
+    });
+  }
+
+  async logRebuildDecision(
+    campaignId: string,
+    decision: RebuildDecision,
+    rebuildResult?: { success: boolean; communitiesCount?: number }
+  ): Promise<void> {
+    const logEntry = {
+      campaignId,
+      decision,
+      rebuildResult,
+      timestamp: new Date().toISOString(),
+    };
+
+    console.log(`[RebuildTrigger] Rebuild decision log:`, logEntry);
+  }
+}

--- a/src/shared-config.ts
+++ b/src/shared-config.ts
@@ -142,6 +142,8 @@ export const API_CONFIG = {
           `/campaigns/${campaignId}/entities/relationship-types`,
         GRAPH_NEIGHBORS: (campaignId: string, entityId: string) =>
           `/campaigns/${campaignId}/entities/${entityId}/graph/neighbors`,
+        IMPORTANCE: (campaignId: string, entityId: string) =>
+          `/campaigns/${campaignId}/entities/${entityId}/importance`,
         EXTRACT: (campaignId: string) =>
           `/campaigns/${campaignId}/entities/extract`,
         DEDUPLICATE: (campaignId: string) =>


### PR DESCRIPTION
Replace simple change-counting with narrative importance-based impact scores using PageRank, Betweenness Centrality, and Hierarchy Level calculations.

Core features:
- EntityImportanceService calculates importance scores (0-100) for all entities
- Batch importance calculation for performance (single graph traversal vs per-entity)
- RebuildTriggerService tracks cumulative impact and triggers rebuilds
- WorldStateChangelogService uses importance in impact score calculations

User controls:
- API endpoint for importance override (PATCH /campaigns/:id/entities/:id/importance)
- Importance dropdown UI in FlexibleShardCard and StructuredShardCard
- Override preserves calculated scores within categorical windows

Fixes:
- Normalize entity IDs in changelog to campaign-scoped format
- Batch recalculate importance after staging/approval/rejection
- Add ImportanceCalculationError for better error handling

Fixes #214