### PR TITLE
Implement Entity Importance Index (#215)

### DIFF
--- a/migrations/0000_clean_slate.sql
+++ b/migrations/0000_clean_slate.sql
@@ -182,6 +182,21 @@ CREATE TABLE IF NOT EXISTS communities (
   foreign key (parent_community_id) references communities(id) on delete set null
 );
 
+-- Create entity_importance table for storing precomputed centrality metrics
+CREATE TABLE IF NOT EXISTS entity_importance (
+  entity_id text primary key,
+  campaign_id text not null,
+  pagerank real not null,
+  betweenness_centrality real not null,
+  hierarchy_level integer not null,
+  importance_score real not null, -- Composite score
+  computed_at datetime default current_timestamp,
+  foreign key (entity_id) references entities(id) on delete cascade,
+  foreign key (campaign_id) references campaigns(id) on delete cascade
+);
+
+CREATE INDEX idx_importance_campaign ON entity_importance(campaign_id);
+CREATE INDEX idx_importance_score ON entity_importance(importance_score DESC);
 
 -- Create campaign context table
 CREATE TABLE IF NOT EXISTS campaign_context (

--- a/migrations/0003_entity_importance.sql
+++ b/migrations/0003_entity_importance.sql
@@ -1,0 +1,20 @@
+-- Entity importance index table for storing precomputed centrality metrics.
+-- See issue #215 for full specification.
+-- This table stores PageRank, betweenness centrality, hierarchy level, and composite
+-- importance scores for fast lookups and rebuild prioritization.
+
+CREATE TABLE IF NOT EXISTS entity_importance (
+  entity_id TEXT PRIMARY KEY,
+  campaign_id TEXT NOT NULL,
+  pagerank REAL NOT NULL,
+  betweenness_centrality REAL NOT NULL,
+  hierarchy_level INTEGER NOT NULL,
+  importance_score REAL NOT NULL, -- Composite score
+  computed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+  FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_importance_campaign ON entity_importance(campaign_id);
+CREATE INDEX idx_importance_score ON entity_importance(importance_score DESC);
+

--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -8,6 +8,7 @@ import { UserDAO } from "./user-dao";
 import { EntityDAO } from "./entity-dao";
 import { CommunityDAO } from "./community-dao";
 import { CommunitySummaryDAO } from "./community-summary-dao";
+import { EntityImportanceDAO } from "./entity-importance-dao";
 
 // Cache for DAO factory instances
 const daoFactoryCache = new Map<string, DAOFactory>();
@@ -25,6 +26,7 @@ export interface DAOFactory {
   entityDAO: EntityDAO;
   communityDAO: CommunityDAO;
   communitySummaryDAO: CommunitySummaryDAO;
+  entityImportanceDAO: EntityImportanceDAO;
 
   // Convenience methods for common operations
   storeOpenAIKey(username: string, apiKey: string): Promise<void>;
@@ -42,6 +44,7 @@ export class DAOFactoryImpl implements DAOFactory {
   public readonly entityDAO: EntityDAO;
   public readonly communityDAO: CommunityDAO;
   public readonly communitySummaryDAO: CommunitySummaryDAO;
+  public readonly entityImportanceDAO: EntityImportanceDAO;
 
   constructor(db: D1Database) {
     this.userDAO = new UserDAO(db);
@@ -51,6 +54,7 @@ export class DAOFactoryImpl implements DAOFactory {
     this.entityDAO = new EntityDAO(db);
     this.communityDAO = new CommunityDAO(db);
     this.communitySummaryDAO = new CommunitySummaryDAO(db);
+    this.entityImportanceDAO = new EntityImportanceDAO(db);
   }
 
   // Convenience methods for common operations

--- a/src/dao/entity-importance-dao.ts
+++ b/src/dao/entity-importance-dao.ts
@@ -1,0 +1,154 @@
+import { BaseDAOClass } from "./base-dao";
+
+// Raw row structure for the `entity_importance` table. Matches the D1 schema
+// exactly and is primarily used internally before normalization.
+export interface EntityImportanceRecord {
+  entity_id: string;
+  campaign_id: string;
+  pagerank: number;
+  betweenness_centrality: number;
+  hierarchy_level: number;
+  importance_score: number;
+  computed_at: string;
+}
+
+// Application-facing importance shape with camelCase keys.
+export interface EntityImportance {
+  entityId: string;
+  campaignId: string;
+  pagerank: number;
+  betweennessCentrality: number;
+  hierarchyLevel: number;
+  importanceScore: number;
+  computedAt: string;
+}
+
+export interface UpsertEntityImportanceInput {
+  entityId: string;
+  campaignId: string;
+  pagerank: number;
+  betweennessCentrality: number;
+  hierarchyLevel: number;
+  importanceScore: number;
+}
+
+export interface EntityImportanceQueryOptions {
+  limit?: number;
+  offset?: number;
+  minScore?: number;
+}
+
+export class EntityImportanceDAO extends BaseDAOClass {
+  async upsertImportance(input: UpsertEntityImportanceInput): Promise<void> {
+    const sql = `
+      INSERT INTO entity_importance (
+        entity_id,
+        campaign_id,
+        pagerank,
+        betweenness_centrality,
+        hierarchy_level,
+        importance_score,
+        computed_at
+      ) VALUES (
+        ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP
+      )
+      ON CONFLICT(entity_id) DO UPDATE SET
+        campaign_id = excluded.campaign_id,
+        pagerank = excluded.pagerank,
+        betweenness_centrality = excluded.betweenness_centrality,
+        hierarchy_level = excluded.hierarchy_level,
+        importance_score = excluded.importance_score,
+        computed_at = CURRENT_TIMESTAMP
+    `;
+
+    await this.execute(sql, [
+      input.entityId,
+      input.campaignId,
+      input.pagerank,
+      input.betweennessCentrality,
+      input.hierarchyLevel,
+      input.importanceScore,
+    ]);
+  }
+
+  async getImportance(entityId: string): Promise<EntityImportance | null> {
+    const sql = `
+      SELECT * FROM entity_importance
+      WHERE entity_id = ?
+    `;
+
+    const record = await this.queryFirst<EntityImportanceRecord>(sql, [
+      entityId,
+    ]);
+    return record ? this.mapRecord(record) : null;
+  }
+
+  async getImportanceForCampaign(
+    campaignId: string,
+    options: EntityImportanceQueryOptions = {}
+  ): Promise<EntityImportance[]> {
+    const conditions: string[] = ["campaign_id = ?"];
+    const params: any[] = [campaignId];
+
+    if (options.minScore !== undefined) {
+      conditions.push("importance_score >= ?");
+      params.push(options.minScore);
+    }
+
+    let sql = `
+      SELECT * FROM entity_importance
+      WHERE ${conditions.join(" AND ")}
+      ORDER BY importance_score DESC
+    `;
+
+    if (typeof options.limit === "number") {
+      sql += " LIMIT ?";
+      params.push(options.limit);
+    }
+
+    if (typeof options.offset === "number") {
+      sql += " OFFSET ?";
+      params.push(options.offset);
+    }
+
+    const records = await this.queryAll<EntityImportanceRecord>(sql, params);
+    return records.map((record) => this.mapRecord(record));
+  }
+
+  async getTopEntitiesByImportance(
+    campaignId: string,
+    limit: number = 10
+  ): Promise<EntityImportance[]> {
+    return this.getImportanceForCampaign(campaignId, { limit });
+  }
+
+  async deleteImportance(entityId: string): Promise<void> {
+    const sql = `
+      DELETE FROM entity_importance
+      WHERE entity_id = ?
+    `;
+
+    await this.execute(sql, [entityId]);
+  }
+
+  async deleteImportanceForCampaign(campaignId: string): Promise<void> {
+    const sql = `
+      DELETE FROM entity_importance
+      WHERE campaign_id = ?
+    `;
+
+    await this.execute(sql, [campaignId]);
+  }
+
+  private mapRecord(record: EntityImportanceRecord): EntityImportance {
+    return {
+      entityId: record.entity_id,
+      campaignId: record.campaign_id,
+      pagerank: record.pagerank,
+      betweennessCentrality: record.betweenness_centrality,
+      hierarchyLevel: record.hierarchy_level,
+      importanceScore: record.importance_score,
+      computedAt: record.computed_at,
+    };
+  }
+}

--- a/src/dao/index.ts
+++ b/src/dao/index.ts
@@ -33,3 +33,10 @@ export type {
 } from "./community-dao";
 // Community DAO
 export { CommunityDAO } from "./community-dao";
+export type {
+  EntityImportance,
+  UpsertEntityImportanceInput,
+  EntityImportanceQueryOptions,
+} from "./entity-importance-dao";
+// Entity Importance DAO
+export { EntityImportanceDAO } from "./entity-importance-dao";

--- a/src/routes/campaign-graphrag.ts
+++ b/src/routes/campaign-graphrag.ts
@@ -391,7 +391,8 @@ export async function handleApproveShards(c: ContextWithAuth) {
       try {
         const importanceService = new EntityImportanceService(
           daoFactory.entityDAO,
-          daoFactory.communityDAO
+          daoFactory.communityDAO,
+          daoFactory.entityImportanceDAO
         );
         console.log(
           `[Server] Batch recalculating importance for ${approvedCount} approved entities`
@@ -547,7 +548,8 @@ export async function handleRejectShards(c: ContextWithAuth) {
       try {
         const importanceService = new EntityImportanceService(
           daoFactory.entityDAO,
-          daoFactory.communityDAO
+          daoFactory.communityDAO,
+          daoFactory.entityImportanceDAO
         );
         console.log(
           `[Server] Batch recalculating importance for ${rejectedCount} rejected entities`

--- a/src/routes/register-routes.ts
+++ b/src/routes/register-routes.ts
@@ -61,6 +61,8 @@ import {
   handleCreateEntityRelationship,
   handleDeleteEntityRelationship,
   handleUpdateEntityImportance,
+  handleGetEntityImportance,
+  handleListTopEntitiesByImportance,
 } from "@/routes/entities";
 import {
   handleDetectCommunities,
@@ -352,6 +354,19 @@ export function registerRoutes(app: Hono<{ Bindings: Env }>) {
     ),
     requireUserJwt,
     handleUpdateEntityImportance
+  );
+  app.get(
+    API_CONFIG.ENDPOINTS.CAMPAIGNS.ENTITIES.IMPORTANCE(
+      ":campaignId",
+      ":entityId"
+    ),
+    requireUserJwt,
+    handleGetEntityImportance
+  );
+  app.get(
+    API_CONFIG.ENDPOINTS.CAMPAIGNS.ENTITIES.IMPORTANCE_TOP(":campaignId"),
+    requireUserJwt,
+    handleListTopEntitiesByImportance
   );
   app.post(
     API_CONFIG.ENDPOINTS.CAMPAIGNS.ENTITIES.RELATIONSHIPS(

--- a/src/services/campaign/entity-staging-service.ts
+++ b/src/services/campaign/entity-staging-service.ts
@@ -394,7 +394,8 @@ export async function stageEntitiesFromResource(
       try {
         const importanceService = new EntityImportanceService(
           daoFactory.entityDAO,
-          daoFactory.communityDAO
+          daoFactory.communityDAO,
+          daoFactory.entityImportanceDAO
         );
 
         console.log(

--- a/src/shared-config.ts
+++ b/src/shared-config.ts
@@ -144,6 +144,8 @@ export const API_CONFIG = {
           `/campaigns/${campaignId}/entities/${entityId}/graph/neighbors`,
         IMPORTANCE: (campaignId: string, entityId: string) =>
           `/campaigns/${campaignId}/entities/${entityId}/importance`,
+        IMPORTANCE_TOP: (campaignId: string) =>
+          `/campaigns/${campaignId}/entities/importance/top`,
         EXTRACT: (campaignId: string) =>
           `/campaigns/${campaignId}/entities/extract`,
         DEDUPLICATE: (campaignId: string) =>

--- a/tests/dao/entity-importance-dao.test.ts
+++ b/tests/dao/entity-importance-dao.test.ts
@@ -1,0 +1,173 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EntityImportanceDAO } from "@/dao/entity-importance-dao";
+
+const mockDB = {
+  prepare: vi.fn(),
+} as unknown as D1Database;
+
+describe("EntityImportanceDAO", () => {
+  let dao: EntityImportanceDAO;
+  let mockStatement: {
+    bind: ReturnType<typeof vi.fn>;
+    run: ReturnType<typeof vi.fn>;
+    all: ReturnType<typeof vi.fn>;
+    first: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStatement = {
+      bind: vi.fn().mockReturnThis(),
+      run: vi.fn(),
+      all: vi.fn(),
+      first: vi.fn(),
+    };
+    (mockDB.prepare as any).mockReturnValue(mockStatement);
+    dao = new EntityImportanceDAO(mockDB);
+  });
+
+  it("upserts importance data", async () => {
+    await dao.upsertImportance({
+      entityId: "entity-1",
+      campaignId: "campaign-123",
+      pagerank: 0.5,
+      betweennessCentrality: 0.3,
+      hierarchyLevel: 75,
+      importanceScore: 65.0,
+    });
+
+    expect(mockDB.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO entity_importance")
+    );
+    expect(mockStatement.bind).toHaveBeenCalledWith(
+      "entity-1",
+      "campaign-123",
+      0.5,
+      0.3,
+      75,
+      65.0
+    );
+    expect(mockStatement.run).toHaveBeenCalled();
+  });
+
+  it("gets importance for an entity", async () => {
+    const record = {
+      entity_id: "entity-1",
+      campaign_id: "campaign-123",
+      pagerank: 0.5,
+      betweenness_centrality: 0.3,
+      hierarchy_level: 75,
+      importance_score: 65.0,
+      computed_at: "2025-01-01T00:00:00Z",
+    };
+
+    mockStatement.first.mockResolvedValue(record);
+
+    const importance = await dao.getImportance("entity-1");
+
+    expect(mockDB.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("SELECT * FROM entity_importance")
+    );
+    expect(mockStatement.bind).toHaveBeenCalledWith("entity-1");
+    expect(importance).toMatchObject({
+      entityId: "entity-1",
+      campaignId: "campaign-123",
+      pagerank: 0.5,
+      betweennessCentrality: 0.3,
+      hierarchyLevel: 75,
+      importanceScore: 65.0,
+      computedAt: "2025-01-01T00:00:00Z",
+    });
+  });
+
+  it("returns null when importance not found", async () => {
+    mockStatement.first.mockResolvedValue(null);
+
+    const importance = await dao.getImportance("entity-1");
+
+    expect(importance).toBeNull();
+  });
+
+  it("gets importance for campaign with options", async () => {
+    const records = [
+      {
+        entity_id: "entity-1",
+        campaign_id: "campaign-123",
+        pagerank: 0.8,
+        betweenness_centrality: 0.6,
+        hierarchy_level: 90,
+        importance_score: 80.0,
+        computed_at: "2025-01-01T00:00:00Z",
+      },
+      {
+        entity_id: "entity-2",
+        campaign_id: "campaign-123",
+        pagerank: 0.5,
+        betweenness_centrality: 0.3,
+        hierarchy_level: 75,
+        importance_score: 65.0,
+        computed_at: "2025-01-01T00:00:00Z",
+      },
+    ];
+
+    mockStatement.all.mockResolvedValue({ results: records });
+
+    const importanceList = await dao.getImportanceForCampaign("campaign-123", {
+      limit: 10,
+      minScore: 60.0,
+    });
+
+    expect(mockDB.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE campaign_id = ?")
+    );
+    expect(mockStatement.bind).toHaveBeenCalledWith("campaign-123", 60.0, 10);
+    expect(importanceList).toHaveLength(2);
+    expect(importanceList[0].importanceScore).toBe(80.0);
+    expect(importanceList[1].importanceScore).toBe(65.0);
+  });
+
+  it("gets top entities by importance", async () => {
+    const records = [
+      {
+        entity_id: "entity-1",
+        campaign_id: "campaign-123",
+        pagerank: 0.8,
+        betweenness_centrality: 0.6,
+        hierarchy_level: 90,
+        importance_score: 80.0,
+        computed_at: "2025-01-01T00:00:00Z",
+      },
+    ];
+
+    mockStatement.all.mockResolvedValue({ results: records });
+
+    const topEntities = await dao.getTopEntitiesByImportance("campaign-123", 5);
+
+    expect(mockDB.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("ORDER BY importance_score DESC")
+    );
+    expect(mockStatement.bind).toHaveBeenCalledWith("campaign-123", 5);
+    expect(topEntities).toHaveLength(1);
+  });
+
+  it("deletes importance for an entity", async () => {
+    await dao.deleteImportance("entity-1");
+
+    expect(mockDB.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("DELETE FROM entity_importance")
+    );
+    expect(mockStatement.bind).toHaveBeenCalledWith("entity-1");
+    expect(mockStatement.run).toHaveBeenCalled();
+  });
+
+  it("deletes importance for a campaign", async () => {
+    await dao.deleteImportanceForCampaign("campaign-123");
+
+    expect(mockDB.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("DELETE FROM entity_importance")
+    );
+    expect(mockStatement.bind).toHaveBeenCalledWith("campaign-123");
+    expect(mockStatement.run).toHaveBeenCalled();
+  });
+});

--- a/tests/services/entity-importance-service.test.ts
+++ b/tests/services/entity-importance-service.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EntityImportanceService } from "@/services/graph/entity-importance-service";
+import type { EntityDAO } from "@/dao/entity-dao";
+import type { CommunityDAO } from "@/dao/community-dao";
+import type { EntityImportanceDAO } from "@/dao/entity-importance-dao";
+
+describe("EntityImportanceService", () => {
+  let mockEntityDAO: Partial<EntityDAO>;
+  let mockCommunityDAO: Partial<CommunityDAO>;
+  let mockImportanceDAO: Partial<EntityImportanceDAO>;
+  let service: EntityImportanceService;
+
+  beforeEach(() => {
+    mockEntityDAO = {
+      getEntityById: vi.fn(),
+      listEntitiesByCampaign: vi.fn(),
+      getMinimalRelationshipsForCampaign: vi.fn().mockResolvedValue([]),
+      getMinimalEntitiesForCampaign: vi.fn().mockResolvedValue([]),
+      updateEntity: vi.fn(),
+    };
+    mockCommunityDAO = {
+      findCommunitiesContainingEntity: vi.fn().mockResolvedValue([]),
+    };
+    mockImportanceDAO = {
+      getImportance: vi.fn(),
+      upsertImportance: vi.fn(),
+      getImportanceForCampaign: vi.fn(),
+    };
+    service = new EntityImportanceService(
+      mockEntityDAO as EntityDAO,
+      mockCommunityDAO as CommunityDAO,
+      mockImportanceDAO as EntityImportanceDAO
+    );
+  });
+
+  describe("getEntityImportance", () => {
+    it("reads from table when available", async () => {
+      const entity = {
+        id: "entity-1",
+        campaignId: "campaign-123",
+        entityType: "npc",
+        name: "Test Entity",
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+        metadata: {},
+      };
+
+      const importance = {
+        entityId: "entity-1",
+        campaignId: "campaign-123",
+        pagerank: 0.5,
+        betweennessCentrality: 0.3,
+        hierarchyLevel: 75,
+        importanceScore: 65.0,
+        computedAt: "2025-01-01T00:00:00Z",
+      };
+
+      (mockEntityDAO.getEntityById as any).mockResolvedValue(entity);
+      (mockImportanceDAO.getImportance as any).mockResolvedValue(importance);
+
+      const result = await service.getEntityImportance(
+        "campaign-123",
+        "entity-1"
+      );
+
+      expect(mockImportanceDAO.getImportance).toHaveBeenCalledWith("entity-1");
+      expect(result).toBe(65.0);
+      expect(mockEntityDAO.updateEntity).not.toHaveBeenCalled();
+    });
+
+    it("falls back to metadata when table entry not found", async () => {
+      const entity = {
+        id: "entity-1",
+        campaignId: "campaign-123",
+        entityType: "npc",
+        name: "Test Entity",
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+        metadata: {
+          importanceScore: 70.0,
+        },
+      };
+
+      (mockEntityDAO.getEntityById as any).mockResolvedValue(entity);
+      (mockImportanceDAO.getImportance as any).mockResolvedValue(null);
+
+      const result = await service.getEntityImportance(
+        "campaign-123",
+        "entity-1"
+      );
+
+      expect(mockImportanceDAO.getImportance).toHaveBeenCalledWith("entity-1");
+      expect(result).toBe(70.0);
+    });
+
+    it("calculates and stores in table when neither table nor metadata available", async () => {
+      const entity = {
+        id: "entity-1",
+        campaignId: "campaign-123",
+        entityType: "npc",
+        name: "Test Entity",
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+        metadata: {},
+      };
+
+      (mockEntityDAO.getEntityById as any).mockResolvedValue(entity);
+      (mockImportanceDAO.getImportance as any).mockResolvedValue(null);
+
+      const result = await service.getEntityImportance(
+        "campaign-123",
+        "entity-1",
+        true
+      );
+
+      expect(mockImportanceDAO.upsertImportance).toHaveBeenCalled();
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe("recalculateImportanceForCampaign", () => {
+    it("writes to table when importanceDAO is available", async () => {
+      const entities = [
+        {
+          id: "entity-1",
+          campaignId: "campaign-123",
+          entityType: "npc",
+          name: "Entity 1",
+          createdAt: "2025-01-01T00:00:00Z",
+          updatedAt: "2025-01-01T00:00:00Z",
+          metadata: {},
+        },
+        {
+          id: "entity-2",
+          campaignId: "campaign-123",
+          entityType: "npc",
+          name: "Entity 2",
+          createdAt: "2025-01-01T00:00:00Z",
+          updatedAt: "2025-01-01T00:00:00Z",
+          metadata: {},
+        },
+      ];
+
+      (mockEntityDAO.listEntitiesByCampaign as any).mockResolvedValue(entities);
+
+      const results =
+        await service.recalculateImportanceForCampaign("campaign-123");
+
+      expect(mockImportanceDAO.upsertImportance).toHaveBeenCalledTimes(2);
+      expect(results.size).toBe(2);
+      expect(results.has("entity-1")).toBe(true);
+      expect(results.has("entity-2")).toBe(true);
+    });
+  });
+
+  describe("backward compatibility", () => {
+    it("works without importanceDAO (metadata fallback)", async () => {
+      const serviceWithoutDAO = new EntityImportanceService(
+        mockEntityDAO as EntityDAO,
+        mockCommunityDAO as CommunityDAO
+      );
+
+      const entity = {
+        id: "entity-1",
+        campaignId: "campaign-123",
+        entityType: "npc",
+        name: "Test Entity",
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+        metadata: {
+          importanceScore: 70.0,
+        },
+      };
+
+      (mockEntityDAO.getEntityById as any).mockResolvedValue(entity);
+
+      const result = await serviceWithoutDAO.getEntityImportance(
+        "campaign-123",
+        "entity-1"
+      );
+
+      expect(result).toBe(70.0);
+      expect(mockEntityDAO.updateEntity).not.toHaveBeenCalled();
+    });
+
+    it("stores in metadata when importanceDAO not available", async () => {
+      const serviceWithoutDAO = new EntityImportanceService(
+        mockEntityDAO as EntityDAO,
+        mockCommunityDAO as CommunityDAO
+      );
+
+      const entities = [
+        {
+          id: "entity-1",
+          campaignId: "campaign-123",
+          entityType: "npc",
+          name: "Entity 1",
+          createdAt: "2025-01-01T00:00:00Z",
+          updatedAt: "2025-01-01T00:00:00Z",
+          metadata: {},
+        },
+      ];
+
+      (mockEntityDAO.listEntitiesByCampaign as any).mockResolvedValue(entities);
+
+      await serviceWithoutDAO.recalculateImportanceForCampaign("campaign-123");
+
+      expect(mockEntityDAO.updateEntity).toHaveBeenCalled();
+      expect(mockEntityDAO.updateEntity).toHaveBeenCalledWith(
+        "entity-1",
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            importanceScore: expect.any(Number),
+          }),
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
- Add entity_importance table with PageRank, betweenness centrality, and hierarchy level
- Create EntityImportanceDAO for fast lookups and batch operations
- Update EntityImportanceService to use table with metadata fallback
- Add API endpoints for querying importance scores
- Include performance logging and comprehensive tests