### PR TITLE
Implement session digest system with agent-guided recap creation

### DIFF
--- a/migrations/0004_session_digests.sql
+++ b/migrations/0004_session_digests.sql
@@ -1,0 +1,21 @@
+-- Session digests table for storing high-level session recaps and planning information.
+-- See issue #216 for full specification.
+-- This table stores session digests that capture key events, state changes, and planning context.
+
+CREATE TABLE IF NOT EXISTS session_digests (
+  id TEXT PRIMARY KEY,
+  campaign_id TEXT NOT NULL,
+  session_number INTEGER NOT NULL,
+  session_date DATE,
+  digest_data TEXT NOT NULL, -- JSON
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE,
+  UNIQUE(campaign_id, session_number)
+);
+
+-- Make indexes idempotent so this migration can safely be re-run
+CREATE INDEX IF NOT EXISTS idx_digests_campaign ON session_digests(campaign_id);
+CREATE INDEX IF NOT EXISTS idx_digests_session ON session_digests(campaign_id, session_number);
+CREATE INDEX IF NOT EXISTS idx_digests_date ON session_digests(session_date);
+

--- a/src/agents/campaign-help-agent.ts
+++ b/src/agents/campaign-help-agent.ts
@@ -7,11 +7,11 @@ import {
 } from "./systemPrompts";
 
 /**
- * System prompt configuration for the Onboarding & Guidance Agent.
- * Defines the agent's role in providing contextual guidance and onboarding.
+ * System prompt configuration for the Campaign Help Agent.
+ * Defines the agent's role in providing contextual guidance and campaign help.
  */
-const ONBOARDING_SYSTEM_PROMPT = buildSystemPrompt({
-  agentName: "Onboarding & Guidance Agent",
+const CAMPAIGN_HELP_SYSTEM_PROMPT = buildSystemPrompt({
+  agentName: "Campaign Help Agent",
   responsibilities: [
     "First-Time User Experience: Guide new users through the app's core value proposition and features",
     "Prompt Suggestions: Suggest useful prompts and actions users can try to get value from the app",
@@ -35,6 +35,9 @@ const ONBOARDING_SYSTEM_PROMPT = buildSystemPrompt({
     "IMPORTANT: Always start by calling the analyzeUserState tool to understand the user's current state (first-time, existing campaigns, resources, etc.)",
     "For first-time users: Explain the app's three core pillars (inspiration library, campaign context, session planning) and suggest their first prompt",
     "For returning users: Suggest new prompts and features they might not have tried yet",
+    "Campaign-Specific Guidance: When a campaign is selected, use getRecentSessionDigests to understand recent session history and provide context-aware suggestions",
+    "Next-Step Suggestions: Based on recent session digests, suggest actions like: chat more about the campaign to add more context, upload files to enrich your campaign world, record notes for a session, expand on important characters or locations that need more detail",
+    "Session Digest Context: Reference information from recent session digests when making suggestions (e.g., 'You mentioned X in your last session, consider following up on Y')",
     "Prompt Suggestions: Provide 3-5 specific prompts users can copy and try, formatted clearly",
     "Educational Content: When suggesting prompts, explain what kinds of things users should be thinking about (e.g., 'When planning a session, consider: NPC motivations, player character goals, environmental details, pacing, etc.')",
     "Campaign Planning Concepts: Educate users on important considerations like:",
@@ -55,6 +58,13 @@ const ONBOARDING_SYSTEM_PROMPT = buildSystemPrompt({
     "  - Social interaction opportunities",
     "  - Pacing considerations",
     "  - Backup plans for when players go off-script",
+    "Campaign-Specific Next Steps: When a campaign is selected, provide specific suggestions:",
+    "  - Review recent session digests to understand what happened",
+    "  - Suggest recording a session recap if one hasn't been created recently",
+    "  - Recommend expanding on characters, locations, or story elements mentioned in recent sessions",
+    "  - Suggest uploading files related to upcoming session content",
+    "  - Recommend chatting about the campaign to add more world details and context",
+    "  - Suggest focusing on important characters or locations that could use more development",
     "Feature Discovery: Introduce features through suggested prompts rather than explaining everything upfront",
     "Redirect Strategy: When users ask to do something specific (create campaign, update world state, etc.), suggest the prompt they should use rather than doing it yourself",
     "Format: Provide suggestions as numbered lists with clear, actionable prompts users can copy",
@@ -63,9 +73,9 @@ const ONBOARDING_SYSTEM_PROMPT = buildSystemPrompt({
 });
 
 /**
- * Onboarding & Guidance Agent for LoreSmith AI.
+ * Campaign Help Agent for LoreSmith AI.
  *
- * This agent focuses specifically on getting new users up and running by:
+ * This agent focuses specifically on helping users with campaign guidance by:
  * - Suggesting useful prompts they can try
  * - Educating users on campaign and session planning concepts
  * - Helping users understand what to think about when planning
@@ -80,12 +90,12 @@ const ONBOARDING_SYSTEM_PROMPT = buildSystemPrompt({
  *
  * @example
  * ```typescript
- * // Create an onboarding agent instance
- * const onboardingAgent = new OnboardingAgent(ctx, env, model);
+ * // Create a campaign help agent instance
+ * const campaignHelpAgent = new CampaignHelpAgent(ctx, env, model);
  *
  * // Process a guidance request
- * await onboardingAgent.onChatMessage((response) => {
- *   console.log('Onboarding response:', response);
+ * await campaignHelpAgent.onChatMessage((response) => {
+ *   console.log('Campaign help response:', response);
  * });
  * ```
  *
@@ -99,18 +109,18 @@ const ONBOARDING_SYSTEM_PROMPT = buildSystemPrompt({
  * // - "Suggest some prompts I can try"
  * ```
  */
-export class OnboardingAgent extends BaseAgent {
+export class CampaignHelpAgent extends BaseAgent {
   /** Agent metadata for registration and routing */
   static readonly agentMetadata = {
     type: "onboarding",
     description:
       "Helps new users get started by suggesting useful prompts and educating on campaign/session planning concepts. Focuses on onboarding and feature discovery rather than direct campaign operations.",
-    systemPrompt: ONBOARDING_SYSTEM_PROMPT,
+    systemPrompt: CAMPAIGN_HELP_SYSTEM_PROMPT,
     tools: onboardingTools,
   };
 
   /**
-   * Creates a new OnboardingAgent instance.
+   * Creates a new CampaignHelpAgent instance.
    *
    * @param ctx - The Durable Object state for persistence
    * @param env - The environment containing Cloudflare bindings
@@ -142,7 +152,9 @@ export class OnboardingAgent extends BaseAgent {
     // If we have a JWT, automatically call analyzeUserState first
     if (clientJwt) {
       try {
-        console.log("[OnboardingAgent] Automatically calling analyzeUserState");
+        console.log(
+          "[CampaignHelpAgent] Automatically calling analyzeUserState"
+        );
         const enhancedTools = this.createEnhancedTools(clientJwt, null);
         const analyzeUserStateTool = enhancedTools.analyzeUserState;
 
@@ -153,7 +165,7 @@ export class OnboardingAgent extends BaseAgent {
           );
 
           console.log(
-            "[OnboardingAgent] User state analysis result:",
+            "[CampaignHelpAgent] User state analysis result:",
             userStateResult
           );
 
@@ -173,7 +185,10 @@ export class OnboardingAgent extends BaseAgent {
           }
         }
       } catch (error) {
-        console.error("[OnboardingAgent] Failed to analyze user state:", error);
+        console.error(
+          "[CampaignHelpAgent] Failed to analyze user state:",
+          error
+        );
       }
     }
 

--- a/src/agents/session-digest-agent.ts
+++ b/src/agents/session-digest-agent.ts
@@ -1,0 +1,190 @@
+import type { StreamTextOnFinishCallback, ToolSet } from "ai";
+import { sessionDigestTools } from "../tools/session-digest";
+import { BaseAgent } from "./base-agent";
+import {
+  buildSystemPrompt,
+  createToolMappingFromObjects,
+} from "./systemPrompts";
+import {
+  updateEntityWorldStateTool,
+  updateRelationshipWorldStateTool,
+  recordWorldEventTool,
+} from "../tools/campaign-context/world-state-tools";
+import { getDAOFactory } from "@/dao/dao-factory";
+import { extractUsernameFromJwt } from "@/tools/utils";
+
+/**
+ * System prompt configuration for the Session Digest Agent.
+ * Defines the agent's role in guiding users through session recap creation.
+ */
+const SESSION_DIGEST_SYSTEM_PROMPT = buildSystemPrompt({
+  agentName: "Session Digest Agent",
+  responsibilities: [
+    "Session Recap Creation: Guide users through creating comprehensive session recaps",
+    "Structured Data Collection: Ask structured questions about key events, state changes, and open threads",
+    "PC Spotlight Tracking: Track which player characters had the spotlight and ensure balanced rotation between PCs",
+    "Individual Goal Progress: Monitor and record progress on each PC's personal goals and character arcs",
+    "Arc Integration: Help connect individual character arcs to the larger main story arc",
+    "World State Extraction: Extract and record world state changes from session recaps",
+    "Planning Context: Help users plan for upcoming sessions with focus on PC goal advancement",
+    "Incremental Building: Build session digests incrementally through conversation",
+  ],
+  tools: createToolMappingFromObjects({
+    ...sessionDigestTools,
+    updateEntityWorldStateTool,
+    updateRelationshipWorldStateTool,
+    recordWorldEventTool,
+  }),
+  workflowGuidelines: [
+    "Conversation Style: Be friendly and conversational - guide users naturally through the recap process",
+    "Structured Questions: Ask about key events, state changes (factions, locations, NPCs), and open threads",
+    "Incremental Building: Build the digest incrementally - don't ask for everything at once",
+    "World State Changes: When users mention state changes (e.g., 'the tavern burned down', 'NPC X died', 'faction Y allied with Z'), extract this information and use world state tools to record it",
+    "Session Planning: Ask about next session plans, objectives, beats, and if-then branches",
+    "Save Confirmation: Once you have gathered the minimum required information (session number, key events, and at least some planning context), ask the user: 'I have enough information to create the session digest. Should I save it now, or would you like to add more details?'",
+    "Save When Confirmed: Only call createSessionDigestTool after the user explicitly confirms they want to save (e.g., 'yes', 'save it', 'that's good', 'go ahead')",
+    "Continue Gathering: If the user wants to add more details, continue asking questions until they're ready to save",
+    "Ask Follow-ups: If information is unclear, ask clarifying questions before asking for confirmation to save",
+  ],
+  importantNotes: [
+    "CRITICAL - Campaign Context: The campaignId is automatically provided from the user's selected campaign. Always use the campaignId parameter when calling createSessionDigestTool - do NOT infer or guess the campaign ID from the user's message text. The campaignId is already available in the tool context.",
+    "IMPORTANT: Always start by asking which session number this recap is for and what date the session occurred",
+    "Date Parsing: When users provide relative dates like 'yesterday', 'last week', 'today', convert them to ISO date strings (YYYY-MM-DD format). For 'yesterday', calculate the date as one day before today. Always use the actual date, not the relative description.",
+    "Key Events: Ask about the most important events that happened in the session",
+    "State Changes: Specifically ask about changes to factions, locations, and NPCs - these are critical for world state tracking",
+    "Open Threads: Ask about unresolved plot threads or questions that came up",
+    "Next Session Planning: Ask about DM objectives, probable player goals, planned beats, and if-then branches",
+    "NPCs to Run: Ask which NPCs are likely to appear in the next session",
+    "Locations in Focus: Ask which locations will be important next session",
+    "Encounter Seeds: Ask about potential encounters or combat situations",
+    "Clues and Revelations: Ask about clues that were dropped or revelations that occurred",
+    "Treasure and Rewards: Ask about items, gold, or other rewards the party received",
+    "Todo Checklist: Ask about any preparation tasks the DM needs to complete",
+    "World State Integration: When users mention state changes, proactively use world state tools (updateEntityWorldStateTool, updateRelationshipWorldStateTool, recordWorldEventTool) to record them",
+    "If the user mentions 'the party did X to location Y' or 'NPC Z died' or 'faction A allied with faction B', extract this and create changelog entries",
+    "Don't wait for explicit requests - if state changes are mentioned, record them immediately",
+    "Save Flow: After gathering minimum required information (session number + key events), ask for confirmation before saving",
+    "Confirmation Examples: Ask 'Ready to save this session digest?' or 'Should I save this now?' and wait for user confirmation",
+    "User Confirmation: Only call createSessionDigestTool after user explicitly confirms (yes, save it, go ahead, that's good, etc.)",
+    "If user says 'not yet' or 'add more', continue gathering information",
+    "If a digest already exists for the session number, inform the user and ask if they want to update it (which would require using updateSessionDigestTool instead)",
+    "Be thorough but not overwhelming - break questions into natural conversation flow",
+    "Minimum Required: At minimum, you need session number and at least one key event before asking to save",
+  ],
+});
+
+/**
+ * Session Digest Agent for LoreSmith AI.
+ *
+ * This agent specializes in guiding users through creating session digests by:
+ * - Asking structured questions about session events
+ * - Extracting world state changes from recaps
+ * - Building comprehensive session digests incrementally
+ * - Helping with session planning
+ *
+ * @extends BaseAgent - Inherits common agent functionality
+ *
+ * @example
+ * ```typescript
+ * // Create a session digest agent instance
+ * const digestAgent = new SessionDigestAgent(ctx, env, model);
+ *
+ * // Process a session recap request
+ * await digestAgent.onChatMessage((response) => {
+ *   console.log('Digest response:', response);
+ * });
+ * ```
+ */
+export class SessionDigestAgent extends BaseAgent {
+  /** Agent metadata for registration and routing */
+  static readonly agentMetadata = {
+    type: "session-digest",
+    description:
+      "Guides users through creating session recaps and planning information. Extracts world state changes and builds comprehensive session digests.",
+    systemPrompt: SESSION_DIGEST_SYSTEM_PROMPT,
+    tools: {
+      ...sessionDigestTools,
+      updateEntityWorldStateTool,
+      updateRelationshipWorldStateTool,
+      recordWorldEventTool,
+    },
+  };
+
+  /**
+   * Creates a new SessionDigestAgent instance.
+   *
+   * @param ctx - The Durable Object state for persistence
+   * @param env - The environment containing Cloudflare bindings
+   * @param model - The AI model instance for generating responses
+   */
+  constructor(ctx: DurableObjectState, env: any, model: any) {
+    super(ctx, env, model, {
+      ...sessionDigestTools,
+      updateEntityWorldStateTool,
+      updateRelationshipWorldStateTool,
+      recordWorldEventTool,
+    });
+  }
+
+  /**
+   * Override onChatMessage to add campaign context
+   */
+  async onChatMessage(
+    onFinish: StreamTextOnFinishCallback<ToolSet>,
+    options?: { abortSignal?: AbortSignal }
+  ) {
+    // Extract campaignId from the last user message if available
+    const lastUserMessage = this.messages
+      .slice()
+      .reverse()
+      .find((msg) => msg.role === "user");
+
+    let campaignId: string | null = null;
+    if (lastUserMessage && "data" in lastUserMessage && lastUserMessage.data) {
+      const messageData = lastUserMessage.data as { campaignId?: string };
+      campaignId = messageData.campaignId || null;
+    }
+
+    // If we have a campaignId, fetch the campaign name and add it as context
+    if (campaignId) {
+      try {
+        const lastUserMsg = this.messages
+          .slice()
+          .reverse()
+          .find((msg) => msg.role === "user");
+        const jwt =
+          lastUserMsg && "data" in lastUserMsg && lastUserMsg.data
+            ? (lastUserMsg.data as { jwt?: string }).jwt
+            : null;
+
+        if (jwt) {
+          const daoFactory = getDAOFactory(this.env as any);
+          const userId = extractUsernameFromJwt(jwt);
+          if (userId) {
+            const campaign =
+              await daoFactory.campaignDAO.getCampaignByIdWithMapping(
+                campaignId,
+                userId
+              );
+            if (campaign) {
+              const contextMessage = `Campaign Context: You are creating a session digest for the campaign "${campaign.name}" (ID: ${campaignId}). Always use this campaignId when calling createSessionDigestTool.`;
+              this.messages.push({
+                role: "system",
+                content: contextMessage,
+              });
+            }
+          }
+        }
+      } catch (error) {
+        console.error(
+          "[SessionDigestAgent] Failed to fetch campaign context:",
+          error
+        );
+        // Continue anyway - the campaignId will still be available in tool context
+      }
+    }
+
+    // Now call the parent's onChatMessage with the enhanced context
+    return super.onChatMessage(onFinish, options);
+  }
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -282,6 +282,74 @@ export default function Chat() {
     }
   }, [append, authState.getStoredJwt, selectedCampaignId]);
 
+  // Handle session recap request
+  const handleSessionRecapRequest = useCallback(async () => {
+    console.log("[App] Session recap request triggered");
+
+    if (!selectedCampaignId) {
+      console.error("No campaign selected for session recap");
+      return;
+    }
+
+    try {
+      const jwt = authState.getStoredJwt();
+      if (!jwt) {
+        console.error("No JWT available for session recap request");
+        return;
+      }
+
+      // Send a message to trigger session digest agent
+      const recapMessage =
+        "I want to record a session recap. Can you guide me through creating a session digest?";
+
+      await append({
+        id: generateId(),
+        role: "user",
+        content: recapMessage,
+        data: {
+          jwt: jwt,
+          campaignId: selectedCampaignId,
+        },
+      });
+    } catch (error) {
+      console.error("Error requesting session recap:", error);
+    }
+  }, [append, authState.getStoredJwt, selectedCampaignId]);
+
+  // Handle next steps request
+  const handleNextStepsRequest = useCallback(async () => {
+    console.log("[App] Next steps request triggered");
+
+    if (!selectedCampaignId) {
+      console.error("No campaign selected for next steps");
+      return;
+    }
+
+    try {
+      const jwt = authState.getStoredJwt();
+      if (!jwt) {
+        console.error("No JWT available for next steps request");
+        return;
+      }
+
+      // Send a message to trigger onboarding agent with campaign context
+      const nextStepsMessage =
+        "What should I do next for this campaign? Can you analyze my current state and provide personalized suggestions based on my campaign?";
+
+      await append({
+        id: generateId(),
+        role: "user",
+        content: nextStepsMessage,
+        data: {
+          jwt: jwt,
+          campaignId: selectedCampaignId,
+        },
+      });
+    } catch (error) {
+      console.error("Error requesting next steps:", error);
+    }
+  }, [append, authState.getStoredJwt, selectedCampaignId]);
+
   // Scroll to bottom when messages change
   useEffect(() => {
     // Only scroll if there are messages and we're not in the initial load
@@ -478,6 +546,8 @@ export default function Chat() {
             onClearHistory={handleClearHistory}
             onHelpAction={handleHelpAction}
             onGuidanceRequest={handleGuidanceRequest}
+            onSessionRecapRequest={handleSessionRecapRequest}
+            onNextStepsRequest={handleNextStepsRequest}
             notifications={allNotifications}
             onDismissNotification={dismissNotification}
             onClearAllNotifications={clearAllNotifications}

--- a/src/components/app/AppHeader.tsx
+++ b/src/components/app/AppHeader.tsx
@@ -1,4 +1,10 @@
-import { Bug, MapPin, Trash } from "@phosphor-icons/react";
+import {
+  Bug,
+  MapPin,
+  Trash,
+  NotePencil,
+  Lightbulb,
+} from "@phosphor-icons/react";
 import { Button } from "@/components/button/Button";
 import { HelpButton } from "@/components/help/HelpButton";
 import { TopBarNotifications } from "@/components/notifications/TopBarNotifications";
@@ -13,6 +19,8 @@ interface AppHeaderProps {
   onClearHistory: () => void;
   onHelpAction: (action: string) => void;
   onGuidanceRequest: () => void;
+  onSessionRecapRequest?: () => void;
+  onNextStepsRequest?: () => void;
   notifications: (
     | NotificationPayload
     | {
@@ -39,6 +47,8 @@ export function AppHeader({
   onClearHistory,
   onHelpAction,
   onGuidanceRequest,
+  onSessionRecapRequest,
+  onNextStepsRequest,
   notifications,
   onDismissNotification,
   onClearAllNotifications,
@@ -103,6 +113,42 @@ export function AppHeader({
           onClick={onToggleDebug}
         />
       </div>
+
+      {onSessionRecapRequest && (
+        <Button
+          variant="ghost"
+          size="md"
+          shape="square"
+          className="rounded-full h-9 w-9"
+          onClick={onSessionRecapRequest}
+          disabled={!selectedCampaignId}
+          tooltip={
+            selectedCampaignId
+              ? "Record session recap"
+              : "Select a campaign to record a session recap"
+          }
+        >
+          <NotePencil size={20} />
+        </Button>
+      )}
+
+      {onNextStepsRequest && (
+        <Button
+          variant="ghost"
+          size="md"
+          shape="square"
+          className="rounded-full h-9 w-9"
+          onClick={onNextStepsRequest}
+          disabled={!selectedCampaignId}
+          tooltip={
+            selectedCampaignId
+              ? "What should I do next?"
+              : "Select a campaign to get next-step suggestions"
+          }
+        >
+          <Lightbulb size={20} />
+        </Button>
+      )}
 
       <HelpButton
         onActionClick={onHelpAction}

--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -9,6 +9,7 @@ import { EntityDAO } from "./entity-dao";
 import { CommunityDAO } from "./community-dao";
 import { CommunitySummaryDAO } from "./community-summary-dao";
 import { EntityImportanceDAO } from "./entity-importance-dao";
+import { SessionDigestDAO } from "./session-digest-dao";
 
 // Cache for DAO factory instances
 const daoFactoryCache = new Map<string, DAOFactory>();
@@ -27,6 +28,7 @@ export interface DAOFactory {
   communityDAO: CommunityDAO;
   communitySummaryDAO: CommunitySummaryDAO;
   entityImportanceDAO: EntityImportanceDAO;
+  sessionDigestDAO: SessionDigestDAO;
 
   // Convenience methods for common operations
   storeOpenAIKey(username: string, apiKey: string): Promise<void>;
@@ -45,6 +47,7 @@ export class DAOFactoryImpl implements DAOFactory {
   public readonly communityDAO: CommunityDAO;
   public readonly communitySummaryDAO: CommunitySummaryDAO;
   public readonly entityImportanceDAO: EntityImportanceDAO;
+  public readonly sessionDigestDAO: SessionDigestDAO;
 
   constructor(db: D1Database) {
     this.userDAO = new UserDAO(db);
@@ -55,6 +58,7 @@ export class DAOFactoryImpl implements DAOFactory {
     this.communityDAO = new CommunityDAO(db);
     this.communitySummaryDAO = new CommunitySummaryDAO(db);
     this.entityImportanceDAO = new EntityImportanceDAO(db);
+    this.sessionDigestDAO = new SessionDigestDAO(db);
   }
 
   // Convenience methods for common operations

--- a/src/dao/session-digest-dao.ts
+++ b/src/dao/session-digest-dao.ts
@@ -1,0 +1,241 @@
+import { BaseDAOClass } from "./base-dao";
+import type {
+  CreateSessionDigestInput,
+  SessionDigest,
+  SessionDigestData,
+  SessionDigestWithData,
+  UpdateSessionDigestInput,
+} from "@/types/session-digest";
+import { validateSessionDigestData } from "@/types/session-digest";
+
+export class SessionDigestDAO extends BaseDAOClass {
+  /**
+   * Create a new session digest
+   */
+  async createSessionDigest(
+    id: string,
+    input: CreateSessionDigestInput
+  ): Promise<void> {
+    let digestDataJson: string;
+    try {
+      digestDataJson = JSON.stringify(input.digestData);
+    } catch (error) {
+      console.error("[SessionDigestDAO] JSON serialization error:", error);
+      throw new Error(
+        `Failed to serialize digest data: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+    }
+
+    const sql = `
+      INSERT INTO session_digests (
+        id,
+        campaign_id,
+        session_number,
+        session_date,
+        digest_data,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `;
+
+    try {
+      await this.execute(sql, [
+        id,
+        input.campaignId,
+        input.sessionNumber,
+        input.sessionDate || null,
+        digestDataJson,
+      ]);
+    } catch (error) {
+      console.error("[SessionDigestDAO] Insert error:", {
+        id,
+        campaignId: input.campaignId,
+        sessionNumber: input.sessionNumber,
+        sessionDate: input.sessionDate,
+        digestDataSize: digestDataJson.length,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Get a session digest by ID
+   */
+  async getSessionDigestById(
+    digestId: string
+  ): Promise<SessionDigestWithData | null> {
+    const sql = `
+      SELECT 
+        id,
+        campaign_id,
+        session_number,
+        session_date,
+        digest_data,
+        created_at,
+        updated_at
+      FROM session_digests
+      WHERE id = ?
+    `;
+
+    const record = await this.queryFirst<SessionDigest>(sql, [digestId]);
+    if (!record) {
+      return null;
+    }
+
+    return this.mapRecord(record);
+  }
+
+  /**
+   * Get a session digest by campaign ID and session number
+   */
+  async getSessionDigestByCampaignAndSession(
+    campaignId: string,
+    sessionNumber: number
+  ): Promise<SessionDigestWithData | null> {
+    const sql = `
+      SELECT 
+        id,
+        campaign_id,
+        session_number,
+        session_date,
+        digest_data,
+        created_at,
+        updated_at
+      FROM session_digests
+      WHERE campaign_id = ? AND session_number = ?
+    `;
+
+    const record = await this.queryFirst<SessionDigest>(sql, [
+      campaignId,
+      sessionNumber,
+    ]);
+    if (!record) {
+      return null;
+    }
+
+    return this.mapRecord(record);
+  }
+
+  /**
+   * Get all session digests for a campaign
+   */
+  async getSessionDigestsByCampaign(
+    campaignId: string
+  ): Promise<SessionDigestWithData[]> {
+    const sql = `
+      SELECT 
+        id,
+        campaign_id,
+        session_number,
+        session_date,
+        digest_data,
+        created_at,
+        updated_at
+      FROM session_digests
+      WHERE campaign_id = ?
+      ORDER BY session_number DESC, created_at DESC
+    `;
+
+    const records = await this.queryAll<SessionDigest>(sql, [campaignId]);
+    return records.map((record) => this.mapRecord(record));
+  }
+
+  /**
+   * Update a session digest
+   */
+  async updateSessionDigest(
+    digestId: string,
+    input: UpdateSessionDigestInput
+  ): Promise<void> {
+    const updates: string[] = [];
+    const params: any[] = [];
+
+    if (input.sessionDate !== undefined) {
+      updates.push("session_date = ?");
+      params.push(input.sessionDate || null);
+    }
+
+    if (input.digestData !== undefined) {
+      updates.push("digest_data = ?");
+      params.push(JSON.stringify(input.digestData));
+    }
+
+    if (updates.length === 0) {
+      return;
+    }
+
+    updates.push("updated_at = CURRENT_TIMESTAMP");
+    params.push(digestId);
+
+    const sql = `
+      UPDATE session_digests
+      SET ${updates.join(", ")}
+      WHERE id = ?
+    `;
+
+    await this.execute(sql, params);
+  }
+
+  /**
+   * Delete a session digest
+   */
+  async deleteSessionDigest(digestId: string): Promise<void> {
+    const sql = "DELETE FROM session_digests WHERE id = ?";
+    await this.execute(sql, [digestId]);
+  }
+
+  /**
+   * Map database record to SessionDigestWithData
+   */
+  private mapRecord(record: SessionDigest): SessionDigestWithData {
+    let digestData: SessionDigestData;
+    try {
+      const parsed = JSON.parse(record.digest_data);
+      if (!validateSessionDigestData(parsed)) {
+        throw new Error("Invalid digest data structure");
+      }
+      digestData = parsed;
+    } catch (error) {
+      console.error(
+        "[SessionDigestDAO] Failed to parse digest_data:",
+        error,
+        record
+      );
+      // Return empty structure if parsing fails
+      digestData = {
+        last_session_recap: {
+          key_events: [],
+          state_changes: {
+            factions: [],
+            locations: [],
+            npcs: [],
+          },
+          open_threads: [],
+        },
+        next_session_plan: {
+          objectives_dm: [],
+          probable_player_goals: [],
+          beats: [],
+          if_then_branches: [],
+        },
+        npcs_to_run: [],
+        locations_in_focus: [],
+        encounter_seeds: [],
+        clues_and_revelations: [],
+        treasure_and_rewards: [],
+        todo_checklist: [],
+      };
+    }
+
+    return {
+      id: record.id,
+      campaignId: record.campaign_id,
+      sessionNumber: record.session_number,
+      sessionDate: record.session_date,
+      digestData,
+      createdAt: record.created_at,
+      updatedAt: record.updated_at,
+    };
+  }
+}

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -74,8 +74,13 @@ export class AgentRegistryService {
       const { CharacterSheetAgent } = await import(
         "../agents/character-sheet-agent"
       );
-      const { OnboardingAgent } = await import("../agents/onboarding-agent");
+      const { CampaignHelpAgent } = await import(
+        "../agents/campaign-help-agent"
+      );
       const { ResourceAgent } = await import("../agents/resource-agent");
+      const { SessionDigestAgent } = await import(
+        "../agents/session-digest-agent"
+      );
       const { AgentRouter } = await import("./agent-router");
 
       // Register Campaign Agent
@@ -105,13 +110,13 @@ export class AgentRegistryService {
         CharacterSheetAgent.agentMetadata.description
       );
 
-      // Register Onboarding Agent
+      // Register Campaign Help Agent
       AgentRouter.registerAgent(
-        OnboardingAgent.agentMetadata.type as AgentType,
-        OnboardingAgent,
-        OnboardingAgent.agentMetadata.tools,
-        OnboardingAgent.agentMetadata.systemPrompt,
-        OnboardingAgent.agentMetadata.description
+        CampaignHelpAgent.agentMetadata.type as AgentType,
+        CampaignHelpAgent,
+        CampaignHelpAgent.agentMetadata.tools,
+        CampaignHelpAgent.agentMetadata.systemPrompt,
+        CampaignHelpAgent.agentMetadata.description
       );
 
       // Register Resource Agent
@@ -121,6 +126,15 @@ export class AgentRegistryService {
         ResourceAgent.agentMetadata.tools,
         ResourceAgent.agentMetadata.systemPrompt,
         ResourceAgent.agentMetadata.description
+      );
+
+      // Register Session Digest Agent
+      AgentRouter.registerAgent(
+        SessionDigestAgent.agentMetadata.type as AgentType,
+        SessionDigestAgent,
+        SessionDigestAgent.agentMetadata.tools,
+        SessionDigestAgent.agentMetadata.systemPrompt,
+        SessionDigestAgent.agentMetadata.description
       );
 
       AgentRegistryService.initialized = true;

--- a/src/lib/agent-router.ts
+++ b/src/lib/agent-router.ts
@@ -8,6 +8,7 @@ export type AgentType =
   | "character-sheets"
   | "onboarding"
   | "resources"
+  | "session-digest"
   | "shards";
 
 export interface AgentIntent {
@@ -155,6 +156,7 @@ Important routing rules:
 - If the message mentions "campaign" or campaign management → route to "campaign"
 - If the message mentions "character" or character sheets → route to "campaign-context"
 - If the message is asking for help or guidance → route to "onboarding"
+- If the message mentions "session recap", "record session", "session digest", "what happened last session", or similar session recap requests → route to "session-digest"
 - For file upload completion messages or processing status inquiries → route to "resources"
 
 Respond with only the agent name (${registeredAgents.join(", ")}) and a confidence score 0-100.
@@ -166,7 +168,9 @@ Examples:
 - "When will my uploaded file be searchable?" → resources|90|AutoRAG processing inquiry
 - "show me all campaigns" → campaign|85|Campaign listing request
 - "create a new campaign" → campaign|90|Campaign creation
-- "upload a character sheet" → campaign-context|85|Character sheet upload`;
+- "upload a character sheet" → campaign-context|85|Character sheet upload
+- "I want to record a session recap" → session-digest|95|Session recap request
+- "Let's create a session digest" → session-digest|90|Session digest creation`;
 
     try {
       // Use a simple LLM call to determine intent

--- a/src/routes/register-routes.ts
+++ b/src/routes/register-routes.ts
@@ -81,6 +81,13 @@ import {
   handleListWorldStateChangelog,
 } from "@/routes/world-state";
 import {
+  handleCreateSessionDigest,
+  handleGetSessionDigest,
+  handleGetSessionDigests,
+  handleUpdateSessionDigest,
+  handleDeleteSessionDigest,
+} from "@/routes/session-digests";
+import {
   handleGetExternalResourceRecommendations,
   handleGetExternalResourceSearch,
   handleGetGmResources,
@@ -314,6 +321,41 @@ export function registerRoutes(app: Hono<{ Bindings: Env }>) {
     API_CONFIG.ENDPOINTS.CAMPAIGNS.WORLD_STATE.OVERLAY(":campaignId"),
     requireUserJwt,
     handleGetWorldStateOverlay
+  );
+
+  app.post(
+    API_CONFIG.ENDPOINTS.CAMPAIGNS.SESSION_DIGESTS.BASE(":campaignId"),
+    requireUserJwt,
+    handleCreateSessionDigest
+  );
+  app.get(
+    API_CONFIG.ENDPOINTS.CAMPAIGNS.SESSION_DIGESTS.BASE(":campaignId"),
+    requireUserJwt,
+    handleGetSessionDigests
+  );
+  app.get(
+    API_CONFIG.ENDPOINTS.CAMPAIGNS.SESSION_DIGESTS.DETAILS(
+      ":campaignId",
+      ":digestId"
+    ),
+    requireUserJwt,
+    handleGetSessionDigest
+  );
+  app.put(
+    API_CONFIG.ENDPOINTS.CAMPAIGNS.SESSION_DIGESTS.DETAILS(
+      ":campaignId",
+      ":digestId"
+    ),
+    requireUserJwt,
+    handleUpdateSessionDigest
+  );
+  app.delete(
+    API_CONFIG.ENDPOINTS.CAMPAIGNS.SESSION_DIGESTS.DETAILS(
+      ":campaignId",
+      ":digestId"
+    ),
+    requireUserJwt,
+    handleDeleteSessionDigest
   );
 
   app.get(

--- a/src/routes/session-digests.ts
+++ b/src/routes/session-digests.ts
@@ -1,0 +1,266 @@
+import type { Context } from "hono";
+import { generateId } from "ai";
+import { getDAOFactory } from "@/dao/dao-factory";
+import type { Env } from "@/middleware/auth";
+import type { AuthPayload } from "@/services/core/auth-service";
+import { UserAuthenticationMissingError } from "@/lib/errors";
+import type {
+  CreateSessionDigestInput,
+  SessionDigestData,
+  UpdateSessionDigestInput,
+} from "@/types/session-digest";
+import { validateSessionDigestData } from "@/types/session-digest";
+
+type ContextWithAuth = Context<{ Bindings: Env }> & {
+  userAuth?: AuthPayload;
+};
+
+function getUserAuth(c: ContextWithAuth): AuthPayload {
+  const userAuth = (c as any).userAuth;
+  if (!userAuth) {
+    throw new UserAuthenticationMissingError();
+  }
+  return userAuth;
+}
+
+async function ensureCampaignAccess(
+  c: ContextWithAuth,
+  campaignId: string,
+  username: string
+): Promise<boolean> {
+  const daoFactory = getDAOFactory(c.env);
+  const campaign = await daoFactory.campaignDAO.getCampaignByIdWithMapping(
+    campaignId,
+    username
+  );
+  return Boolean(campaign);
+}
+
+// Create a new session digest
+export async function handleCreateSessionDigest(c: ContextWithAuth) {
+  try {
+    const auth = getUserAuth(c);
+    const campaignId = c.req.param("campaignId");
+    const hasAccess = await ensureCampaignAccess(c, campaignId, auth.username);
+    if (!hasAccess) {
+      return c.json({ error: "Campaign not found" }, 404);
+    }
+
+    const body = (await c.req.json()) as {
+      sessionNumber: number;
+      sessionDate?: string | null;
+      digestData: SessionDigestData;
+    };
+
+    if (!body.sessionNumber || typeof body.sessionNumber !== "number") {
+      return c.json(
+        { error: "sessionNumber is required and must be a number" },
+        400
+      );
+    }
+
+    if (!body.digestData || !validateSessionDigestData(body.digestData)) {
+      return c.json({ error: "Invalid digestData structure" }, 400);
+    }
+
+    const daoFactory = getDAOFactory(c.env);
+    const existing =
+      await daoFactory.sessionDigestDAO.getSessionDigestByCampaignAndSession(
+        campaignId,
+        body.sessionNumber
+      );
+
+    if (existing) {
+      return c.json(
+        {
+          error:
+            "Session digest already exists for this campaign and session number",
+        },
+        409
+      );
+    }
+
+    const digestId = generateId();
+    const input: CreateSessionDigestInput = {
+      campaignId,
+      sessionNumber: body.sessionNumber,
+      sessionDate: body.sessionDate || null,
+      digestData: body.digestData,
+    };
+
+    await daoFactory.sessionDigestDAO.createSessionDigest(digestId, input);
+
+    const created =
+      await daoFactory.sessionDigestDAO.getSessionDigestById(digestId);
+    if (!created) {
+      return c.json({ error: "Failed to retrieve created digest" }, 500);
+    }
+
+    return c.json({ digest: created }, 201);
+  } catch (error) {
+    console.error("[SessionDigest] Failed to create digest:", error);
+    return c.json(
+      { error: "Failed to create session digest" },
+      error instanceof Error && /required|must/i.test(error.message) ? 400 : 500
+    );
+  }
+}
+
+// Get a specific session digest
+export async function handleGetSessionDigest(c: ContextWithAuth) {
+  try {
+    const auth = getUserAuth(c);
+    const campaignId = c.req.param("campaignId");
+    const digestId = c.req.param("digestId");
+
+    const hasAccess = await ensureCampaignAccess(c, campaignId, auth.username);
+    if (!hasAccess) {
+      return c.json({ error: "Campaign not found" }, 404);
+    }
+
+    const daoFactory = getDAOFactory(c.env);
+    const digest =
+      await daoFactory.sessionDigestDAO.getSessionDigestById(digestId);
+
+    if (!digest) {
+      return c.json({ error: "Session digest not found" }, 404);
+    }
+
+    if (digest.campaignId !== campaignId) {
+      return c.json(
+        { error: "Session digest does not belong to this campaign" },
+        404
+      );
+    }
+
+    return c.json({ digest });
+  } catch (error) {
+    console.error("[SessionDigest] Failed to get digest:", error);
+    return c.json({ error: "Failed to get session digest" }, 500);
+  }
+}
+
+// Get all session digests for a campaign
+export async function handleGetSessionDigests(c: ContextWithAuth) {
+  try {
+    const auth = getUserAuth(c);
+    const campaignId = c.req.param("campaignId");
+
+    const hasAccess = await ensureCampaignAccess(c, campaignId, auth.username);
+    if (!hasAccess) {
+      return c.json({ error: "Campaign not found" }, 404);
+    }
+
+    const daoFactory = getDAOFactory(c.env);
+    const digests =
+      await daoFactory.sessionDigestDAO.getSessionDigestsByCampaign(campaignId);
+
+    return c.json({ digests });
+  } catch (error) {
+    console.error("[SessionDigest] Failed to list digests:", error);
+    return c.json({ error: "Failed to list session digests" }, 500);
+  }
+}
+
+// Update a session digest
+export async function handleUpdateSessionDigest(c: ContextWithAuth) {
+  try {
+    const auth = getUserAuth(c);
+    const campaignId = c.req.param("campaignId");
+    const digestId = c.req.param("digestId");
+
+    const hasAccess = await ensureCampaignAccess(c, campaignId, auth.username);
+    if (!hasAccess) {
+      return c.json({ error: "Campaign not found" }, 404);
+    }
+
+    const daoFactory = getDAOFactory(c.env);
+    const existing =
+      await daoFactory.sessionDigestDAO.getSessionDigestById(digestId);
+
+    if (!existing) {
+      return c.json({ error: "Session digest not found" }, 404);
+    }
+
+    if (existing.campaignId !== campaignId) {
+      return c.json(
+        { error: "Session digest does not belong to this campaign" },
+        404
+      );
+    }
+
+    const body = (await c.req.json()) as {
+      sessionDate?: string | null;
+      digestData?: SessionDigestData;
+    };
+
+    const input: UpdateSessionDigestInput = {};
+
+    if (body.sessionDate !== undefined) {
+      input.sessionDate = body.sessionDate;
+    }
+
+    if (body.digestData !== undefined) {
+      if (!validateSessionDigestData(body.digestData)) {
+        return c.json({ error: "Invalid digestData structure" }, 400);
+      }
+      input.digestData = body.digestData;
+    }
+
+    if (Object.keys(input).length === 0) {
+      return c.json({ error: "No fields to update" }, 400);
+    }
+
+    await daoFactory.sessionDigestDAO.updateSessionDigest(digestId, input);
+
+    const updated =
+      await daoFactory.sessionDigestDAO.getSessionDigestById(digestId);
+    if (!updated) {
+      return c.json({ error: "Failed to retrieve updated digest" }, 500);
+    }
+
+    return c.json({ digest: updated });
+  } catch (error) {
+    console.error("[SessionDigest] Failed to update digest:", error);
+    return c.json(
+      { error: "Failed to update session digest" },
+      error instanceof Error && /required|must/i.test(error.message) ? 400 : 500
+    );
+  }
+}
+
+// Delete a session digest
+export async function handleDeleteSessionDigest(c: ContextWithAuth) {
+  try {
+    const auth = getUserAuth(c);
+    const campaignId = c.req.param("campaignId");
+    const digestId = c.req.param("digestId");
+
+    const hasAccess = await ensureCampaignAccess(c, campaignId, auth.username);
+    if (!hasAccess) {
+      return c.json({ error: "Campaign not found" }, 404);
+    }
+
+    const daoFactory = getDAOFactory(c.env);
+    const existing =
+      await daoFactory.sessionDigestDAO.getSessionDigestById(digestId);
+
+    if (!existing) {
+      return c.json({ error: "Session digest not found" }, 404);
+    }
+
+    if (existing.campaignId !== campaignId) {
+      return c.json(
+        { error: "Session digest does not belong to this campaign" },
+        404
+      );
+    }
+
+    await daoFactory.sessionDigestDAO.deleteSessionDigest(digestId);
+
+    return c.json({ success: true });
+  } catch (error) {
+    console.error("[SessionDigest] Failed to delete digest:", error);
+    return c.json({ error: "Failed to delete session digest" }, 500);
+  }
+}

--- a/src/shared-config.ts
+++ b/src/shared-config.ts
@@ -180,6 +180,12 @@ export const API_CONFIG = {
         OVERLAY: (campaignId: string) =>
           `/campaigns/${campaignId}/world-state/overlay`,
       },
+      SESSION_DIGESTS: {
+        BASE: (campaignId: string) =>
+          `/campaigns/${campaignId}/session-digests`,
+        DETAILS: (campaignId: string, digestId: string) =>
+          `/campaigns/${campaignId}/session-digests/${digestId}`,
+      },
     },
     CHARACTER_SHEETS: {
       // NOTE: Character sheets are currently handled as a separate entity type.

--- a/src/tools/onboarding/index.ts
+++ b/src/tools/onboarding/index.ts
@@ -13,10 +13,12 @@ import {
   getCampaignReadinessTool,
   getUserActivityTool,
 } from "./state-analysis-tools";
+import { getRecentSessionDigestsTool } from "./session-digest-tools";
 
 export * from "./external-resources-tools";
 export * from "./guidance-tools";
 export * from "./state-analysis-tools";
+export * from "./session-digest-tools";
 
 // Export the tools object for the agent
 export const onboardingTools = {
@@ -34,4 +36,7 @@ export const onboardingTools = {
   recommendExternalTools: recommendExternalToolsTool,
   suggestInspirationSources: suggestInspirationSourcesTool,
   recommendGMResources: recommendGMResourcesTool,
+
+  // Session digest tools
+  getRecentSessionDigests: getRecentSessionDigestsTool,
 } as const;

--- a/src/tools/onboarding/session-digest-tools.ts
+++ b/src/tools/onboarding/session-digest-tools.ts
@@ -1,0 +1,107 @@
+import { tool } from "ai";
+import { z } from "zod";
+import {
+  commonSchemas,
+  createToolError,
+  createToolSuccess,
+  extractUsernameFromJwt,
+} from "../utils";
+import { getDAOFactory } from "@/dao/dao-factory";
+import type { ToolResult } from "../../app-constants";
+
+/**
+ * Tool: Get recent session digests for a campaign
+ */
+export const getRecentSessionDigestsTool = tool({
+  description:
+    "Get recent session digests for a campaign. Use this to understand what happened in recent sessions and provide context-aware next-step suggestions.",
+  parameters: z.object({
+    campaignId: commonSchemas.campaignId,
+    jwt: commonSchemas.jwt,
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(10)
+      .optional()
+      .default(3)
+      .describe("Maximum number of recent digests to retrieve"),
+  }),
+  execute: async (
+    { campaignId, jwt, limit },
+    context?: any
+  ): Promise<ToolResult> => {
+    const toolCallId = context?.toolCallId || crypto.randomUUID();
+
+    try {
+      if (!jwt) {
+        return createToolError(
+          "Authentication required",
+          "JWT token is required",
+          401,
+          toolCallId
+        );
+      }
+
+      const userId = extractUsernameFromJwt(jwt);
+      if (!userId) {
+        return createToolError(
+          "Invalid authentication token",
+          "Authentication failed",
+          401,
+          toolCallId
+        );
+      }
+
+      const env = context?.env;
+      if (!env) {
+        return createToolError(
+          "Environment not available",
+          "Server environment is required",
+          500,
+          toolCallId
+        );
+      }
+
+      const daoFactory = getDAOFactory(env);
+      const campaign = await daoFactory.campaignDAO.getCampaignByIdWithMapping(
+        campaignId,
+        userId
+      );
+
+      if (!campaign) {
+        return createToolError(
+          "Campaign not found",
+          "Campaign not found or access denied",
+          404,
+          toolCallId
+        );
+      }
+
+      const allDigests =
+        await daoFactory.sessionDigestDAO.getSessionDigestsByCampaign(
+          campaignId
+        );
+
+      const recentDigests = allDigests.slice(0, limit);
+
+      return createToolSuccess(
+        `Retrieved ${recentDigests.length} recent session digest(s)`,
+        {
+          digests: recentDigests,
+          count: recentDigests.length,
+          total: allDigests.length,
+        },
+        toolCallId
+      );
+    } catch (error) {
+      console.error("[getRecentSessionDigestsTool] Error:", error);
+      return createToolError(
+        "Failed to get recent session digests",
+        error instanceof Error ? error.message : "Unknown error",
+        500,
+        toolCallId
+      );
+    }
+  },
+});

--- a/src/tools/session-digest/digest-tools.ts
+++ b/src/tools/session-digest/digest-tools.ts
@@ -1,0 +1,557 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { generateId } from "ai";
+import {
+  createToolError,
+  createToolSuccess,
+  extractUsernameFromJwt,
+} from "@/tools/utils";
+import { getDAOFactory } from "@/dao/dao-factory";
+import { validateSessionDigestData } from "@/types/session-digest";
+import type { UpdateSessionDigestInput } from "@/types/session-digest";
+import type { ToolResult } from "@/app-constants";
+
+const commonSchemas = {
+  campaignId: z.string().describe("The campaign ID"),
+  jwt: z.string().optional().describe("JWT token for authentication"),
+  digestId: z.string().describe("The session digest ID"),
+  sessionNumber: z
+    .number()
+    .int()
+    .positive()
+    .describe("The session number (e.g., 1, 2, 3)"),
+  sessionDate: z
+    .string()
+    .optional()
+    .nullable()
+    .describe(
+      "ISO date string for the session date (YYYY-MM-DD format). Convert relative dates like 'yesterday' to actual dates. For example, if today is 2024-11-17 and the user says 'yesterday', use '2024-11-16'."
+    ),
+  digestData: z
+    .object({
+      last_session_recap: z.object({
+        key_events: z.array(z.string()).default([]),
+        state_changes: z
+          .object({
+            factions: z.array(z.string()).default([]),
+            locations: z.array(z.string()).default([]),
+            npcs: z.array(z.string()).default([]),
+          })
+          .default({ factions: [], locations: [], npcs: [] }),
+        open_threads: z.array(z.string()).default([]),
+      }),
+      next_session_plan: z.object({
+        objectives_dm: z.array(z.string()).default([]),
+        probable_player_goals: z.array(z.string()).default([]),
+        beats: z.array(z.string()).default([]),
+        if_then_branches: z.array(z.string()).default([]),
+      }),
+      npcs_to_run: z.array(z.string()).default([]),
+      locations_in_focus: z.array(z.string()).default([]),
+      encounter_seeds: z.array(z.string()).default([]),
+      clues_and_revelations: z.array(z.string()).default([]),
+      treasure_and_rewards: z.array(z.string()).default([]),
+      todo_checklist: z.array(z.string()).default([]),
+    })
+    .describe(
+      "The session digest data structure. The last_session_recap and next_session_plan objects are required, but all arrays within them are optional and will default to empty arrays if not provided."
+    ),
+};
+
+export const createSessionDigestTool = tool({
+  description:
+    "Create a new session digest for a campaign. Session digests capture high-level recaps and planning information for D&D sessions.",
+  parameters: z.object({
+    campaignId: commonSchemas.campaignId,
+    sessionNumber: commonSchemas.sessionNumber,
+    sessionDate: commonSchemas.sessionDate,
+    digestData: commonSchemas.digestData,
+    jwt: commonSchemas.jwt,
+  }),
+  execute: async (
+    { campaignId, sessionNumber, sessionDate, digestData, jwt },
+    context?: any
+  ): Promise<ToolResult> => {
+    const toolCallId = context?.toolCallId || crypto.randomUUID();
+
+    try {
+      if (!jwt) {
+        return createToolError(
+          "Authentication required",
+          "JWT token is required",
+          401,
+          toolCallId
+        );
+      }
+
+      const userId = extractUsernameFromJwt(jwt);
+      if (!userId) {
+        return createToolError(
+          "Invalid authentication token",
+          "Authentication failed",
+          401,
+          toolCallId
+        );
+      }
+
+      if (!validateSessionDigestData(digestData)) {
+        // Provide detailed validation feedback
+        const validationErrors: string[] = [];
+        if (!digestData || typeof digestData !== "object") {
+          validationErrors.push("digestData must be an object");
+        } else {
+          const obj = digestData as Record<string, unknown>;
+          if (
+            !obj.last_session_recap ||
+            typeof obj.last_session_recap !== "object"
+          ) {
+            validationErrors.push(
+              "last_session_recap is required and must be an object"
+            );
+          }
+          if (
+            !obj.next_session_plan ||
+            typeof obj.next_session_plan !== "object"
+          ) {
+            validationErrors.push(
+              "next_session_plan is required and must be an object"
+            );
+          }
+          const requiredArrays = [
+            "npcs_to_run",
+            "locations_in_focus",
+            "encounter_seeds",
+            "clues_and_revelations",
+            "treasure_and_rewards",
+            "todo_checklist",
+          ];
+          for (const key of requiredArrays) {
+            if (!Array.isArray(obj[key])) {
+              validationErrors.push(`${key} must be an array`);
+            }
+          }
+        }
+
+        console.error("[createSessionDigestTool] Validation failed:", {
+          validationErrors,
+          digestDataKeys: digestData
+            ? Object.keys(digestData as Record<string, unknown>)
+            : [],
+        });
+
+        return createToolError(
+          "Invalid digest data structure",
+          `The digest data does not match the required schema. Issues: ${validationErrors.join("; ")}`,
+          400,
+          toolCallId
+        );
+      }
+
+      const env = context?.env;
+      if (!env) {
+        return createToolError(
+          "Environment not available",
+          "Server environment is required",
+          500,
+          toolCallId
+        );
+      }
+
+      const daoFactory = getDAOFactory(env);
+      const campaign = await daoFactory.campaignDAO.getCampaignByIdWithMapping(
+        campaignId,
+        userId
+      );
+
+      if (!campaign) {
+        return createToolError(
+          "Campaign not found",
+          "Campaign not found or access denied",
+          404,
+          toolCallId
+        );
+      }
+
+      // Check if digest already exists for this session number
+      const existing =
+        await daoFactory.sessionDigestDAO.getSessionDigestByCampaignAndSession(
+          campaignId,
+          sessionNumber
+        );
+
+      if (existing) {
+        return createToolError(
+          "Session digest already exists",
+          `A session digest already exists for session ${sessionNumber}. Ask the user whether they want to append to the existing digest or replace it entirely. If they want to append, use the updateSessionDigest tool. If they want to replace, confirm with the user first, then use the updateSessionDigest tool with the new data.`,
+          409,
+          toolCallId
+        );
+      }
+
+      const digestId = generateId();
+
+      await daoFactory.sessionDigestDAO.createSessionDigest(digestId, {
+        campaignId,
+        sessionNumber,
+        sessionDate: sessionDate || null,
+        digestData,
+      });
+
+      const created =
+        await daoFactory.sessionDigestDAO.getSessionDigestById(digestId);
+      if (!created) {
+        return createToolError(
+          "Failed to retrieve created digest",
+          "Digest was created but could not be retrieved",
+          500,
+          toolCallId
+        );
+      }
+
+      return createToolSuccess(
+        `Session digest created successfully for session ${sessionNumber}`,
+        { digest: created },
+        toolCallId
+      );
+    } catch (error) {
+      const errorDetails: Record<string, unknown> = {
+        error: error instanceof Error ? error.message : String(error),
+        errorName: error instanceof Error ? error.name : typeof error,
+        errorStack: error instanceof Error ? error.stack : undefined,
+        campaignId,
+        sessionNumber,
+        sessionDate,
+        hasDigestData: !!digestData,
+      };
+
+      console.error("[createSessionDigestTool] Error:", errorDetails);
+
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+
+      return createToolError(
+        "Failed to create session digest",
+        errorMessage,
+        500,
+        toolCallId
+      );
+    }
+  },
+});
+
+export const getSessionDigestTool = tool({
+  description:
+    "Get a session digest by campaign ID and session number. Returns the full digest data including recap and planning information.",
+  parameters: z.object({
+    campaignId: commonSchemas.campaignId,
+    sessionNumber: commonSchemas.sessionNumber,
+    jwt: commonSchemas.jwt,
+  }),
+  execute: async (
+    { campaignId, sessionNumber, jwt },
+    context?: any
+  ): Promise<ToolResult> => {
+    const toolCallId = context?.toolCallId || crypto.randomUUID();
+
+    try {
+      if (!jwt) {
+        return createToolError(
+          "Authentication required",
+          "JWT token is required",
+          401,
+          toolCallId
+        );
+      }
+
+      const userId = extractUsernameFromJwt(jwt);
+      if (!userId) {
+        return createToolError(
+          "Invalid authentication token",
+          "Authentication failed",
+          401,
+          toolCallId
+        );
+      }
+
+      const env = context?.env;
+      if (!env) {
+        return createToolError(
+          "Environment not available",
+          "Server environment is required",
+          500,
+          toolCallId
+        );
+      }
+
+      const daoFactory = getDAOFactory(env);
+      const campaign = await daoFactory.campaignDAO.getCampaignByIdWithMapping(
+        campaignId,
+        userId
+      );
+
+      if (!campaign) {
+        return createToolError(
+          "Campaign not found",
+          "Campaign not found or access denied",
+          404,
+          toolCallId
+        );
+      }
+
+      const digest =
+        await daoFactory.sessionDigestDAO.getSessionDigestByCampaignAndSession(
+          campaignId,
+          sessionNumber
+        );
+
+      if (!digest) {
+        return createToolError(
+          "Session digest not found",
+          `No session digest found for session ${sessionNumber} in this campaign`,
+          404,
+          toolCallId
+        );
+      }
+
+      return createToolSuccess(
+        `Session digest retrieved successfully for session ${sessionNumber}`,
+        { digest },
+        toolCallId
+      );
+    } catch (error) {
+      console.error("[getSessionDigestTool] Error:", error);
+      return createToolError(
+        "Failed to get session digest",
+        error instanceof Error ? error.message : "Unknown error",
+        500,
+        toolCallId
+      );
+    }
+  },
+});
+
+export const listSessionDigestsTool = tool({
+  description:
+    "List all session digests for a campaign. Returns digests ordered by session number (newest first).",
+  parameters: z.object({
+    campaignId: commonSchemas.campaignId,
+    jwt: commonSchemas.jwt,
+  }),
+  execute: async ({ campaignId, jwt }, context?: any): Promise<ToolResult> => {
+    const toolCallId = context?.toolCallId || crypto.randomUUID();
+
+    try {
+      if (!jwt) {
+        return createToolError(
+          "Authentication required",
+          "JWT token is required",
+          401,
+          toolCallId
+        );
+      }
+
+      const userId = extractUsernameFromJwt(jwt);
+      if (!userId) {
+        return createToolError(
+          "Invalid authentication token",
+          "Authentication failed",
+          401,
+          toolCallId
+        );
+      }
+
+      const env = context?.env;
+      if (!env) {
+        return createToolError(
+          "Environment not available",
+          "Server environment is required",
+          500,
+          toolCallId
+        );
+      }
+
+      const daoFactory = getDAOFactory(env);
+      const campaign = await daoFactory.campaignDAO.getCampaignByIdWithMapping(
+        campaignId,
+        userId
+      );
+
+      if (!campaign) {
+        return createToolError(
+          "Campaign not found",
+          "Campaign not found or access denied",
+          404,
+          toolCallId
+        );
+      }
+
+      const digests =
+        await daoFactory.sessionDigestDAO.getSessionDigestsByCampaign(
+          campaignId
+        );
+
+      return createToolSuccess(
+        `Found ${digests.length} session digest(s)`,
+        { digests, count: digests.length },
+        toolCallId
+      );
+    } catch (error) {
+      console.error("[listSessionDigestsTool] Error:", error);
+      return createToolError(
+        "Failed to list session digests",
+        error instanceof Error ? error.message : "Unknown error",
+        500,
+        toolCallId
+      );
+    }
+  },
+});
+
+export const updateSessionDigestTool = tool({
+  description:
+    "Update an existing session digest for a campaign. Use campaignId and sessionNumber to identify which digest to update. Typically, the agent should first fetch the existing digest, merge in any new recap details, then call this tool with the updated digest data.",
+  parameters: z.object({
+    campaignId: commonSchemas.campaignId,
+    sessionNumber: commonSchemas.sessionNumber,
+    sessionDate: commonSchemas.sessionDate.optional(),
+    digestData: commonSchemas.digestData.optional(),
+    jwt: commonSchemas.jwt,
+  }),
+  execute: async (
+    { campaignId, sessionNumber, sessionDate, digestData, jwt },
+    context?: any
+  ): Promise<ToolResult> => {
+    const toolCallId = context?.toolCallId || crypto.randomUUID();
+
+    try {
+      if (!jwt) {
+        return createToolError(
+          "Authentication required",
+          "JWT token is required",
+          401,
+          toolCallId
+        );
+      }
+
+      const userId = extractUsernameFromJwt(jwt);
+      if (!userId) {
+        return createToolError(
+          "Invalid authentication token",
+          "Authentication failed",
+          401,
+          toolCallId
+        );
+      }
+
+      const env = context?.env;
+      if (!env) {
+        return createToolError(
+          "Environment not available",
+          "Server environment is required",
+          500,
+          toolCallId
+        );
+      }
+
+      const daoFactory = getDAOFactory(env);
+      const campaign = await daoFactory.campaignDAO.getCampaignByIdWithMapping(
+        campaignId,
+        userId
+      );
+
+      if (!campaign) {
+        return createToolError(
+          "Campaign not found",
+          "Campaign not found or access denied",
+          404,
+          toolCallId
+        );
+      }
+
+      // Get the existing digest by sessionNumber (there's only one per session)
+      const existing =
+        await daoFactory.sessionDigestDAO.getSessionDigestByCampaignAndSession(
+          campaignId,
+          sessionNumber
+        );
+
+      if (!existing) {
+        return createToolError(
+          "Session digest not found",
+          `No session digest found for session ${sessionNumber} in this campaign`,
+          404,
+          toolCallId
+        );
+      }
+
+      const updateInput: UpdateSessionDigestInput = {};
+
+      if (sessionDate !== undefined) {
+        updateInput.sessionDate = sessionDate || null;
+      }
+
+      if (digestData !== undefined) {
+        if (!validateSessionDigestData(digestData)) {
+          return createToolError(
+            "Invalid digest data structure",
+            "The digest data does not match the required schema",
+            400,
+            toolCallId
+          );
+        }
+        updateInput.digestData = digestData;
+      }
+
+      if (Object.keys(updateInput).length === 0) {
+        return createToolError(
+          "No fields to update",
+          "Provide at least one field (sessionDate or digestData) to update",
+          400,
+          toolCallId
+        );
+      }
+
+      // Use existing.id since we've already found the digest
+      const targetDigestId = existing.id;
+
+      await daoFactory.sessionDigestDAO.updateSessionDigest(
+        targetDigestId,
+        updateInput
+      );
+
+      const updated =
+        await daoFactory.sessionDigestDAO.getSessionDigestById(targetDigestId);
+
+      if (!updated) {
+        return createToolError(
+          "Failed to retrieve updated digest",
+          "Session digest was updated but could not be retrieved",
+          500,
+          toolCallId
+        );
+      }
+
+      return createToolSuccess(
+        "Session digest updated successfully",
+        { digest: updated },
+        toolCallId
+      );
+    } catch (error) {
+      console.error("[updateSessionDigestTool] Error:", error);
+      console.error("[updateSessionDigestTool] Error details:", {
+        campaignId,
+        sessionNumber,
+        hasSessionDate: sessionDate !== undefined,
+        hasDigestData: digestData !== undefined,
+        errorMessage: error instanceof Error ? error.message : String(error),
+        errorStack: error instanceof Error ? error.stack : undefined,
+      });
+      return createToolError(
+        "Failed to update session digest",
+        error instanceof Error ? error.message : "Unknown error",
+        500,
+        toolCallId
+      );
+    }
+  },
+});

--- a/src/tools/session-digest/index.ts
+++ b/src/tools/session-digest/index.ts
@@ -1,0 +1,15 @@
+import {
+  createSessionDigestTool,
+  getSessionDigestTool,
+  listSessionDigestsTool,
+  updateSessionDigestTool,
+} from "./digest-tools";
+
+export * from "./digest-tools";
+
+export const sessionDigestTools = {
+  createSessionDigest: createSessionDigestTool,
+  getSessionDigest: getSessionDigestTool,
+  listSessionDigests: listSessionDigestsTool,
+  updateSessionDigest: updateSessionDigestTool,
+} as const;

--- a/src/types/session-digest.ts
+++ b/src/types/session-digest.ts
@@ -1,0 +1,141 @@
+/**
+ * Session digest data structure matching the JSON schema from issue #216
+ */
+export interface SessionDigestData {
+  last_session_recap: {
+    key_events: string[];
+    state_changes: SessionDigestStateChanges;
+    open_threads: string[];
+  };
+  next_session_plan: {
+    objectives_dm: string[];
+    probable_player_goals: string[];
+    beats: string[];
+    if_then_branches: string[];
+  };
+  npcs_to_run: string[];
+  locations_in_focus: string[];
+  encounter_seeds: string[];
+  clues_and_revelations: string[];
+  treasure_and_rewards: string[];
+  todo_checklist: string[];
+}
+
+/**
+ * State changes structure within session digest
+ */
+export interface SessionDigestStateChanges {
+  factions: string[];
+  locations: string[];
+  npcs: string[];
+}
+
+/**
+ * Database record structure for session_digests table
+ */
+export interface SessionDigest {
+  id: string;
+  campaign_id: string;
+  session_number: number;
+  session_date: string | null;
+  digest_data: string; // JSON string
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Mapped session digest with parsed digest_data
+ */
+export interface SessionDigestWithData {
+  id: string;
+  campaignId: string;
+  sessionNumber: number;
+  sessionDate: string | null;
+  digestData: SessionDigestData;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Input for creating a new session digest
+ */
+export interface CreateSessionDigestInput {
+  campaignId: string;
+  sessionNumber: number;
+  sessionDate?: string | null;
+  digestData: SessionDigestData;
+}
+
+/**
+ * Input for updating a session digest
+ */
+export interface UpdateSessionDigestInput {
+  sessionDate?: string | null;
+  digestData?: SessionDigestData;
+}
+
+/**
+ * Validate that an object matches the SessionDigestData structure
+ */
+export function validateSessionDigestData(
+  data: unknown
+): data is SessionDigestData {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  // Check last_session_recap
+  if (!obj.last_session_recap || typeof obj.last_session_recap !== "object") {
+    return false;
+  }
+  const recap = obj.last_session_recap as Record<string, unknown>;
+  if (
+    !Array.isArray(recap.key_events) ||
+    !Array.isArray(recap.open_threads) ||
+    !recap.state_changes ||
+    typeof recap.state_changes !== "object"
+  ) {
+    return false;
+  }
+  const stateChanges = recap.state_changes as Record<string, unknown>;
+  if (
+    !Array.isArray(stateChanges.factions) ||
+    !Array.isArray(stateChanges.locations) ||
+    !Array.isArray(stateChanges.npcs)
+  ) {
+    return false;
+  }
+
+  // Check next_session_plan
+  if (!obj.next_session_plan || typeof obj.next_session_plan !== "object") {
+    return false;
+  }
+  const plan = obj.next_session_plan as Record<string, unknown>;
+  if (
+    !Array.isArray(plan.objectives_dm) ||
+    !Array.isArray(plan.probable_player_goals) ||
+    !Array.isArray(plan.beats) ||
+    !Array.isArray(plan.if_then_branches)
+  ) {
+    return false;
+  }
+
+  // Check remaining arrays
+  const requiredArrays = [
+    "npcs_to_run",
+    "locations_in_focus",
+    "encounter_seeds",
+    "clues_and_revelations",
+    "treasure_and_rewards",
+    "todo_checklist",
+  ];
+  for (const key of requiredArrays) {
+    if (!Array.isArray(obj[key])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/tests/dao/session-digest-dao.test.ts
+++ b/tests/dao/session-digest-dao.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { SessionDigestDAO } from "@/dao/session-digest-dao";
+import type { D1Database } from "@cloudflare/workers-types";
+
+describe("SessionDigestDAO", () => {
+  let dao: SessionDigestDAO;
+  let mockDB: D1Database;
+
+  beforeEach(() => {
+    mockDB = {
+      prepare: vi.fn(),
+    } as unknown as D1Database;
+    dao = new SessionDigestDAO(mockDB);
+  });
+
+  it("should create a session digest", async () => {
+    const mockStmt = {
+      bind: vi.fn().mockReturnThis(),
+      run: vi.fn().mockResolvedValue({}),
+    };
+    (mockDB.prepare as any).mockReturnValue(mockStmt);
+
+    await dao.createSessionDigest("test-id", {
+      campaignId: "campaign-1",
+      sessionNumber: 1,
+      sessionDate: "2024-01-01",
+      digestData: {
+        last_session_recap: {
+          key_events: [],
+          state_changes: { factions: [], locations: [], npcs: [] },
+          open_threads: [],
+        },
+        next_session_plan: {
+          objectives_dm: [],
+          probable_player_goals: [],
+          beats: [],
+          if_then_branches: [],
+        },
+        npcs_to_run: [],
+        locations_in_focus: [],
+        encounter_seeds: [],
+        clues_and_revelations: [],
+        treasure_and_rewards: [],
+        todo_checklist: [],
+      },
+    });
+
+    expect(mockDB.prepare).toHaveBeenCalled();
+    expect(mockStmt.bind).toHaveBeenCalled();
+    expect(mockStmt.run).toHaveBeenCalled();
+  });
+
+  it("should get session digest by ID", async () => {
+    const mockStmt = {
+      bind: vi.fn().mockReturnThis(),
+      first: vi.fn().mockResolvedValue({
+        id: "test-id",
+        campaign_id: "campaign-1",
+        session_number: 1,
+        session_date: "2024-01-01",
+        digest_data: JSON.stringify({
+          last_session_recap: {
+            key_events: [],
+            state_changes: { factions: [], locations: [], npcs: [] },
+            open_threads: [],
+          },
+          next_session_plan: {
+            objectives_dm: [],
+            probable_player_goals: [],
+            beats: [],
+            if_then_branches: [],
+          },
+          npcs_to_run: [],
+          locations_in_focus: [],
+          encounter_seeds: [],
+          clues_and_revelations: [],
+          treasure_and_rewards: [],
+          todo_checklist: [],
+        }),
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      }),
+    };
+    (mockDB.prepare as any).mockReturnValue(mockStmt);
+
+    const result = await dao.getSessionDigestById("test-id");
+
+    expect(result).toBeTruthy();
+    expect(result?.id).toBe("test-id");
+    expect(result?.campaignId).toBe("campaign-1");
+  });
+});

--- a/tests/routes/session-digests.test.ts
+++ b/tests/routes/session-digests.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Context } from "hono";
+import {
+  handleCreateSessionDigest,
+  handleGetSessionDigests,
+} from "@/routes/session-digests";
+
+const mockContext = {
+  req: {
+    param: vi.fn(),
+    json: vi.fn(),
+  },
+  env: {
+    DB: {} as any,
+  },
+  json: vi.fn(),
+} as unknown as Context;
+
+describe("session-digests routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should handle creating a session digest", async () => {
+    (mockContext.req.param as any).mockReturnValue("campaign-1");
+    (mockContext.req.json as any).mockResolvedValue({
+      sessionNumber: 1,
+      sessionDate: "2024-01-01",
+      digestData: {
+        last_session_recap: {
+          key_events: [],
+          state_changes: { factions: [], locations: [], npcs: [] },
+          open_threads: [],
+        },
+        next_session_plan: {
+          objectives_dm: [],
+          probable_player_goals: [],
+          beats: [],
+          if_then_branches: [],
+        },
+        npcs_to_run: [],
+        locations_in_focus: [],
+        encounter_seeds: [],
+        clues_and_revelations: [],
+        treasure_and_rewards: [],
+        todo_checklist: [],
+      },
+    });
+    (mockContext as any).userAuth = { username: "test-user" };
+
+    await handleCreateSessionDigest(mockContext as any);
+
+    expect(mockContext.req.param).toHaveBeenCalledWith("campaignId");
+  });
+
+  it("should handle getting session digests", async () => {
+    (mockContext.req.param as any).mockReturnValue("campaign-1");
+    (mockContext as any).userAuth = { username: "test-user" };
+
+    await handleGetSessionDigests(mockContext as any);
+
+    expect(mockContext.req.param).toHaveBeenCalledWith("campaignId");
+  });
+});


### PR DESCRIPTION
- Add database schema, DAO, API routes, and tools for session digests
- Create SessionDigestAgent for conversational session recap gathering
- Add UI buttons for session recap and campaign help
- Simplify tool interface to use sessionNumber as primary identifier
- Make schema arrays optional with defaults to fix validation errors
- Improve error handling and remove verbose debug logging