### PR TITLE
Include entity name/title in shard object for UI display

### DIFF
--- a/src/agents/campaign-agent.ts
+++ b/src/agents/campaign-agent.ts
@@ -4,6 +4,7 @@ import {
   buildSystemPrompt,
   createToolMappingFromObjects,
 } from "./system-prompts";
+import { CAMPAIGN_PLANNING_CHECKLIST } from "../lib/campaign-planning-checklist";
 
 /**
  * System prompt configuration for the Campaign Management Agent.
@@ -89,8 +90,15 @@ const getCampaignSystemPrompt = () =>
       "  - Prefer updateEntityWorldStateTool for single-entity changes, updateRelationshipWorldStateTool for faction/NPC relationship shifts, and recordWorldEventTool when multiple updates/new entities need to be stored together",
       "  - If you're missing a key detail (e.g., entity name or status), ask a short clarifying question before calling the tool; otherwise act proactively so the campaign stays synchronized with player actions",
     ],
-    specialization:
-      "You are a conversational campaign creation expert who makes every interaction feel personal and natural. Never use templates or formal structures - just chat naturally about campaign ideas and use your tools when ready.",
+    specialization: `You are a conversational campaign creation expert who makes every interaction feel personal and natural. Never use templates or formal structures - just chat naturally about campaign ideas and use your tools when ready.
+
+## Campaign Planning Checklist Reference:
+
+Use this comprehensive checklist to guide your planning suggestions and readiness assessments:
+
+${CAMPAIGN_PLANNING_CHECKLIST}
+
+When providing campaign planning suggestions or readiness assessments, reference specific sections from this checklist. Identify which checklist items are missing or incomplete based on the campaign's current state, and prioritize recommendations based on logical dependencies (e.g., setting basics before factions, starting location before first arc, etc.).`,
   });
 
 /**

--- a/src/agents/campaign-analysis-agent.ts
+++ b/src/agents/campaign-analysis-agent.ts
@@ -4,6 +4,7 @@ import {
   buildSystemPrompt,
   createToolMappingFromObjects,
 } from "./system-prompts";
+import { CAMPAIGN_PLANNING_CHECKLIST } from "../lib/campaign-planning-checklist";
 
 /**
  * System prompt configuration for the Campaign Analysis Agent.
@@ -27,7 +28,15 @@ const CAMPAIGN_ANALYSIS_SYSTEM_PROMPT = buildSystemPrompt({
     "When analyzing campaigns, provide detailed scoring across narrative, character, plot hooks, and session readiness",
     "Provide actionable recommendations based on campaign assessment scores",
     "Focus on high-impact areas when providing campaign improvement suggestions",
+    "Campaign Planning Checklist: Use the Campaign Planning Checklist to provide structured, prioritized recommendations. Reference specific checklist sections when suggesting what to work on next, prioritizing foundational elements (Campaign Foundation, World & Setting Basics, Starting Location) before later stages.",
   ],
+  specialization: `## Campaign Planning Checklist Reference:
+
+Use this comprehensive checklist as a framework for assessment and recommendations:
+
+${CAMPAIGN_PLANNING_CHECKLIST}
+
+When providing campaign readiness assessments and suggestions, reference specific sections from this checklist. Identify which checklist items are missing or incomplete based on the campaign's current state, and prioritize recommendations based on logical dependencies (e.g., setting basics before factions, starting location before first arc, etc.).`,
 });
 
 /**

--- a/src/agents/campaign-help-agent.ts
+++ b/src/agents/campaign-help-agent.ts
@@ -5,6 +5,7 @@ import {
   buildSystemPrompt,
   createToolMappingFromObjects,
 } from "./system-prompts";
+import { CAMPAIGN_PLANNING_CHECKLIST } from "../lib/campaign-planning-checklist";
 
 /**
  * System prompt configuration for the Campaign Help Agent.
@@ -39,25 +40,8 @@ const CAMPAIGN_HELP_SYSTEM_PROMPT = buildSystemPrompt({
     "Next-Step Suggestions: Based on recent session digests, suggest actions like: chat more about the campaign to add more context, upload files to enrich your campaign world, record notes for a session, expand on important characters or locations that need more detail",
     "Session Digest Context: Reference information from recent session digests when making suggestions (e.g., 'You mentioned X in your last session, consider following up on Y')",
     "Prompt Suggestions: Provide 3-5 specific prompts users can copy and try, formatted clearly",
-    "Educational Content: When suggesting prompts, explain what kinds of things users should be thinking about (e.g., 'When planning a session, consider: NPC motivations, player character goals, environmental details, pacing, etc.')",
-    "Campaign Planning Concepts: Educate users on important considerations like:",
-    "  - NPC motivations and goals",
-    "  - Player character backstories and goals",
-    "  - World consistency and continuity",
-    "  - Session pacing and structure",
-    "  - Plot hooks and story beats",
-    "  - Environmental details and atmosphere",
-    "  - Faction relationships and politics",
-    "  - Resource management and preparation",
-    "Session Planning Concepts: Educate users on what makes a good session plan:",
-    "  - Clear objectives and goals",
-    "  - Multiple paths for player agency",
-    "  - Prepared NPCs with motivations",
-    "  - Environmental descriptions",
-    "  - Potential combat encounters",
-    "  - Social interaction opportunities",
-    "  - Pacing considerations",
-    "  - Backup plans for when players go off-script",
+    "Educational Content: When suggesting prompts, explain what kinds of things users should be thinking about by referencing the Campaign Planning Checklist",
+    "Campaign Planning Checklist: Use the comprehensive Campaign Planning Checklist to guide your educational content and suggestions. Reference specific sections (Campaign Foundation, World & Setting Basics, Starting Location, Factions, Player Integration, First Story Arc, Session-by-Session Prep, etc.) when educating users about planning considerations. The full checklist is provided below for your reference:",
     "Campaign-Specific Next Steps: When a campaign is selected, provide specific suggestions:",
     "  - Review recent session digests to understand what happened",
     "  - Suggest recording a session recap if one hasn't been created recently",
@@ -70,6 +54,13 @@ const CAMPAIGN_HELP_SYSTEM_PROMPT = buildSystemPrompt({
     "Format: Provide suggestions as numbered lists with clear, actionable prompts users can copy",
     "Always be encouraging and supportive",
   ],
+  specialization: `## Campaign Planning Checklist Reference:
+
+Use this comprehensive checklist to guide your educational content and suggestions. Reference specific sections when helping users understand what to think about when planning campaigns and sessions:
+
+${CAMPAIGN_PLANNING_CHECKLIST}
+
+When educating users about campaign or session planning, reference relevant sections from this checklist. For example, when discussing campaign foundation, reference section 1. When discussing session prep, reference section 7. When suggesting next steps, identify which checklist items would be most valuable based on the user's current campaign state.`,
 });
 
 /**

--- a/src/agents/session-digest-agent.ts
+++ b/src/agents/session-digest-agent.ts
@@ -5,6 +5,7 @@ import {
   buildSystemPrompt,
   createToolMappingFromObjects,
 } from "./system-prompts";
+import { CAMPAIGN_PLANNING_CHECKLIST } from "../lib/campaign-planning-checklist";
 import {
   updateEntityWorldStateTool,
   updateRelationshipWorldStateTool,
@@ -79,7 +80,15 @@ const SESSION_DIGEST_SYSTEM_PROMPT = buildSystemPrompt({
     "Minimum Required: At minimum, you need session number and at least one key event before asking to save",
     "Automated Generation Notes: When using generateDigestFromNotesTool, the generated digest will have status 'draft' and generatedByAi=true. Review it with the user and offer to make changes before saving.",
     "Quality Validation: Generated digests may have quality scores calculated. Mention this to users so they understand the system can help validate digest quality.",
+    "Campaign Planning Checklist: Reference the Campaign Planning Checklist (especially section 7: Session-by-Session Prep and section 13: Post-Session Review) when helping users plan for upcoming sessions and create session recaps. Use the checklist to ensure comprehensive coverage of session planning elements.",
   ],
+  specialization: `## Campaign Planning Checklist Reference - Session Planning:
+
+Use this comprehensive checklist, especially sections 7 (Session-by-Session Prep) and 13 (Post-Session Review), to guide your session planning questions and recommendations:
+
+${CAMPAIGN_PLANNING_CHECKLIST}
+
+When helping users plan for upcoming sessions or creating session recaps, reference relevant sections from this checklist. For example, section 7 covers: strong opening scenes, flexible encounters, secrets to reveal, ways to move the story forward, and session end beats. Section 13 covers post-session review elements like recaps, what players enjoyed, pacing issues, and updating NPCs/factions based on events.`,
 });
 
 /**

--- a/src/hooks/useActivityTracking.ts
+++ b/src/hooks/useActivityTracking.ts
@@ -1,0 +1,106 @@
+import { useCallback } from "react";
+
+const LAST_ACTIVITY_STORAGE_KEY = "loresmith-last-activity";
+const RECAP_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour in milliseconds
+
+/**
+ * Get the last recap timestamp for a specific campaign
+ */
+export function getLastRecapTimestamp(campaignId: string): number | null {
+  const key = `loresmith-recap-${campaignId}`;
+  const stored = localStorage.getItem(key);
+  return stored ? parseInt(stored, 10) : null;
+}
+
+/**
+ * Set the last recap timestamp for a specific campaign
+ */
+export function setLastRecapTimestamp(
+  campaignId: string,
+  timestamp: number
+): void {
+  const key = `loresmith-recap-${campaignId}`;
+  localStorage.setItem(key, timestamp.toString());
+}
+
+/**
+ * Check if a recap should be shown for a campaign
+ * Returns true if no recap has been shown for this campaign OR > 1 hour since last recap
+ */
+export function shouldShowRecap(campaignId: string | null): boolean {
+  if (!campaignId) {
+    return false;
+  }
+
+  const lastRecap = getLastRecapTimestamp(campaignId);
+  if (!lastRecap) {
+    // No recap shown yet for this campaign
+    return true;
+  }
+
+  const now = Date.now();
+  const timeSinceLastRecap = now - lastRecap;
+  return timeSinceLastRecap >= RECAP_COOLDOWN_MS;
+}
+
+/**
+ * Get the last activity timestamp
+ */
+export function getLastActivityTimestamp(): number | null {
+  const stored = localStorage.getItem(LAST_ACTIVITY_STORAGE_KEY);
+  return stored ? parseInt(stored, 10) : null;
+}
+
+/**
+ * Update the last activity timestamp to now
+ */
+export function updateActivityTimestamp(): void {
+  localStorage.setItem(LAST_ACTIVITY_STORAGE_KEY, Date.now().toString());
+}
+
+/**
+ * Check if user has been away for more than the inactivity threshold
+ */
+export function hasBeenAway(thresholdMs: number = RECAP_COOLDOWN_MS): boolean {
+  const lastActivity = getLastActivityTimestamp();
+  if (!lastActivity) {
+    // No activity recorded, consider user as returning
+    return true;
+  }
+
+  const now = Date.now();
+  const timeSinceActivity = now - lastActivity;
+  return timeSinceActivity >= thresholdMs;
+}
+
+/**
+ * Hook for activity tracking
+ * Provides functions to update activity and check if recaps should be shown
+ */
+export function useActivityTracking() {
+  const updateActivity = useCallback(() => {
+    updateActivityTimestamp();
+  }, []);
+
+  const checkShouldShowRecap = useCallback(
+    (campaignId: string | null): boolean => {
+      return shouldShowRecap(campaignId);
+    },
+    []
+  );
+
+  const markRecapShown = useCallback((campaignId: string) => {
+    setLastRecapTimestamp(campaignId, Date.now());
+  }, []);
+
+  const checkHasBeenAway = useCallback((thresholdMs?: number): boolean => {
+    return hasBeenAway(thresholdMs);
+  }, []);
+
+  return {
+    updateActivity,
+    checkShouldShowRecap,
+    markRecapShown,
+    checkHasBeenAway,
+  };
+}

--- a/src/lib/campaign-planning-checklist.ts
+++ b/src/lib/campaign-planning-checklist.ts
@@ -1,0 +1,117 @@
+/**
+ * Comprehensive campaign planning checklist for D&D campaigns
+ * This checklist helps DMs plan and organize their campaigns systematically.
+ *
+ * Used by agents throughout the app to:
+ * - Assess campaign readiness
+ * - Suggest next planning steps
+ * - Guide campaign recap and planning recommendations
+ * - Provide structured guidance for campaign building
+ */
+export const CAMPAIGN_PLANNING_CHECKLIST = `
+# D&D Campaign Planning Checklist
+
+## 1. Campaign Foundation
+- Define campaign tone (heroic, grim, cozy, political, mythic, etc.)
+- Define core themes (power, faith, legacy, found family, corruption, etc.)
+- Define intended player fantasy (heroes, outcasts, scholars, rebels, etc.)
+- Define initial scope (single town, region, city, wilderness)
+- Write a 1–2 sentence campaign elevator pitch
+- Decide campaign length expectation (short arc, long-running, open-ended)
+
+## 2. World & Setting Basics
+- Name the world or region
+- Define one dominant cultural trait
+- Define one unusual or defining feature (magical, historical, environmental)
+- Decide how common magic is and how people react to it
+- Define one unresolved historical event
+- Decide how gods, faith, or belief function in the setting
+- Identify one mystery you do NOT intend to explain immediately
+
+## 3. Starting Location (Hub Area)
+- Name the starting town / city / enclave
+- Decide why people live here
+- Identify a visible problem or tension
+- Create 3–5 NPCs with names, roles, goals or fears
+- Define 2 nearby adventure locations
+- Define 1 hidden secret about the location
+- Decide how the location might change over time
+
+## 4. Factions, Powers & Threats
+- Define at least 2 factions with conflicting goals
+- Define what each faction wants right now
+- Define how each faction operates (force, manipulation, faith, trade, etc.)
+- Decide what happens if the PCs do nothing
+- Identify one emerging or distant threat (no full villain needed yet)
+- Decide what each faction thinks of the PCs (initially)
+
+## 5. Player Integration & Session Zero
+- Collect character backstories
+- Tie each PC to one NPC, one unresolved problem, and one rumor (true or false)
+- Establish party relationships (how they know each other)
+- Align player expectations on tone and boundaries
+- Discuss table rules, safety tools, and house rules
+- Confirm play format (in-person, VTT, hybrid)
+
+## 6. First Story Arc (Levels 1–3)
+- Define the initial unstable situation
+- Identify multiple approaches to resolving it
+- Plan 2–3 key encounters (combat, social, exploration)
+- Decide what clues point toward a larger story
+- Plan consequences for success and failure
+- Decide how the world reacts after the arc concludes
+
+## 7. Session-by-Session Prep
+- Write a strong opening scene
+- Prepare 3–5 NPCs the party might interact with
+- Prepare flexible encounters (can move locations)
+- List secrets or information that may be revealed
+- Prepare 2 ways to move the story forward if players stall
+- Plan a session end beat (reveal, choice, cliffhanger)
+
+## 8. Music & Audio (Atmosphere)
+- Create a general campaign playlist
+- Create location-based playlists (town, wilderness, dungeon)
+- Create combat music playlists (light, intense, boss)
+- Identify theme music for major factions or NPCs (nice-to-have)
+- Decide how music will be played (speaker, bot, VTT)
+- Test volume levels before play
+
+## 9. Visuals, Minis & Terrain
+- Decide mini style (official, proxy, paper, tokens)
+- Prepare minis for PCs
+- Prepare generic enemy minis
+- Prepare terrain or battle maps (town, dungeon/interior, wilderness)
+- Decide grid vs theater-of-the-mind per encounter
+- Prepare stand-ins for unexpected combat (coins, dice, tokens)
+
+## 10. Handouts & Props
+- Prepare physical or digital maps
+- Prepare letters, notes, or contracts (optional but immersive)
+- Prepare faction symbols or visual references
+- Prepare item cards or magic item handouts
+- Prepare player-facing lore summaries (1 page max)
+- Decide how handouts are delivered (paper, PDF, VTT)
+
+## 11. DM Reference & Organization
+- Keep NPC list with names and traits
+- Track faction goals and changes
+- Track unresolved plot threads
+- Keep a session recap log
+- Track player decisions and consequences
+- Keep random tables for names, rumors, and encounters
+
+## 12. Flexibility & Long-Term Planning
+- Identify moments where players can reshape the world
+- Leave blank spaces in the map for future ideas
+- Identify themes you want to reinforce later
+- Decide when to introduce higher-stakes threats
+- Periodically check player engagement and adjust
+
+## 13. Post-Session Review
+- Write a short recap
+- Note what players enjoyed most
+- Note rules or pacing issues
+- Update NPCs and factions based on events
+- Adjust upcoming plans based on player choices
+`;

--- a/src/lib/prompts/recap-prompts.ts
+++ b/src/lib/prompts/recap-prompts.ts
@@ -1,0 +1,107 @@
+import type { ContextRecapData } from "@/services/core/recap-service";
+import { CAMPAIGN_PLANNING_CHECKLIST } from "@/lib/campaign-planning-checklist";
+
+/**
+ * Generate a prompt for the AI agent to create a friendly context recap message
+ * @param recap - The context recap data containing recent activity, session digests, world state changes, and goals
+ * @returns A formatted prompt string for the AI agent
+ */
+export function formatContextRecapPrompt(recap: ContextRecapData): string {
+  // Build detailed session digest information
+  const sessionDigestsDetails =
+    recap.recentSessionDigests && recap.recentSessionDigests.length > 0
+      ? recap.recentSessionDigests
+          .map((digest) => {
+            const sessionDate = digest.sessionDate
+              ? new Date(digest.sessionDate).toLocaleDateString()
+              : "No date";
+            const keyEvents =
+              digest.digestData?.last_session_recap?.key_events || [];
+            const openThreads =
+              digest.digestData?.last_session_recap?.open_threads || [];
+            return `Session ${digest.sessionNumber} (${sessionDate}):\n  Key Events: ${keyEvents.length > 0 ? keyEvents.join("; ") : "None"}\n  Open Threads: ${openThreads.length > 0 ? openThreads.join("; ") : "None"}`;
+          })
+          .join("\n\n")
+      : "";
+
+  // Build world state changes summary
+  const worldStateChangesSummary =
+    recap.worldStateChanges && recap.worldStateChanges.length > 0
+      ? recap.worldStateChanges
+          .slice(0, 10)
+          .map((entry) => {
+            const changes: string[] = [];
+            if (entry.payload.entity_updates?.length > 0) {
+              changes.push(
+                `${entry.payload.entity_updates.length} entity update(s)`
+              );
+            }
+            if (entry.payload.relationship_updates?.length > 0) {
+              changes.push(
+                `${entry.payload.relationship_updates.length} relationship update(s)`
+              );
+            }
+            if (entry.payload.new_entities?.length > 0) {
+              changes.push(
+                `${entry.payload.new_entities.length} new entity/entities`
+              );
+            }
+            return `- ${new Date(entry.timestamp).toLocaleDateString()}: ${changes.join(", ") || "Unknown changes"}`;
+          })
+          .join("\n")
+      : "";
+
+  // Check if there's minimal campaign data
+  const hasSessionDigests =
+    recap.recentSessionDigests && recap.recentSessionDigests.length > 0;
+  const hasWorldStateChanges =
+    recap.worldStateChanges && recap.worldStateChanges.length > 0;
+  const hasTodos =
+    recap.inProgressGoals?.todoChecklist &&
+    recap.inProgressGoals.todoChecklist.length > 0;
+  const hasOpenThreads =
+    recap.inProgressGoals?.openThreads &&
+    recap.inProgressGoals.openThreads.length > 0;
+  const hasMinimalData =
+    !hasSessionDigests && !hasWorldStateChanges && !hasTodos && !hasOpenThreads;
+
+  if (hasMinimalData) {
+    return `This campaign is still in its early stages with minimal planning data.
+
+Please provide a friendly welcome message and assess what's most important to work on next using this comprehensive campaign planning checklist:
+
+${CAMPAIGN_PLANNING_CHECKLIST}
+
+IMPORTANT: Before suggesting checklist items, use the searchCampaignContext tool to check if any of these items are already covered in the campaign data. Search for key checklist concepts like "campaign tone", "world name", "themes", "starting location", "factions", etc. to verify what's already been established.
+
+Only recommend checklist items that you've verified are missing or incomplete through your search. Analyze what appears to be missing or incomplete based on the search results, and suggest 3-5 prioritized next steps from the checklist that would be most valuable to tackle. Focus on foundational elements first (Campaign Foundation, World & Setting Basics, Starting Location) before moving to later stages.
+
+Be encouraging and helpful, framing these as exciting opportunities to build their campaign world. Prioritize based on logical dependencies (e.g., setting basics before factions, starting location before first arc, etc.).`;
+  }
+
+  return `Please provide a friendly context recap for this campaign. Here's what happened:
+
+${recap.recentActivity && recap.recentActivity.length > 0 ? `Recent Activity (${recap.recentActivity.length} items):\n${recap.recentActivity.map((a) => `- ${a.type}: ${a.details || "N/A"}`).join("\n")}\n` : ""}
+
+${sessionDigestsDetails ? `Recent Session Digests:\n${sessionDigestsDetails}\n\n` : ""}
+
+${worldStateChangesSummary ? `World State Changes (${recap.worldStateChanges?.length || 0} total, showing first 10):\n${worldStateChangesSummary}\n` : ""}
+
+${recap.inProgressGoals?.todoChecklist && recap.inProgressGoals.todoChecklist.length > 0 ? `In-Progress Todos:\n${recap.inProgressGoals.todoChecklist.map((todo) => `- ${todo}`).join("\n")}\n` : ""}
+
+${recap.inProgressGoals?.openThreads && recap.inProgressGoals.openThreads.length > 0 ? `Open Story Threads:\n${recap.inProgressGoals.openThreads.map((thread) => `- ${thread}`).join("\n")}\n` : ""}
+
+Please generate a friendly recap message starting directly with "Since you were away..." and summarizing the key highlights from the recent session digests, world state changes, and ongoing story threads. Do not include any introductory text or headings before the recap message - just provide the recap content itself.
+
+After the recap, please also assess what would be most valuable to plan next using this comprehensive campaign planning checklist:
+
+${CAMPAIGN_PLANNING_CHECKLIST}
+
+IMPORTANT: Before suggesting checklist items, use the searchCampaignContext tool to verify what's already been established in the campaign. Search for key concepts related to any checklist items you're considering recommending (e.g., search for "campaign tone" if you're thinking of recommending tone definition, search for "factions" if recommending faction creation, etc.). Only recommend checklist items that are genuinely missing or incomplete based on your search results.
+
+Based on the search results and current campaign state, suggest 2-3 prioritized next steps from the checklist that would be most valuable to tackle. Focus on what logically follows from where the campaign currently stands, and prioritize based on dependencies (e.g., setting basics before factions, starting location before first arc, etc.). Make sure your recommendations are informed by what actually exists in the campaign data, not assumptions.`;
+}
+
+export const RECAP_PROMPTS = {
+  formatContextRecapPrompt,
+};

--- a/src/routes/campaign-graphrag.ts
+++ b/src/routes/campaign-graphrag.ts
@@ -243,8 +243,12 @@ export async function handleGetStagedShards(c: ContextWithAuth) {
       }
 
       // Convert entity to shard format for UI compatibility (UI uses "shard" terminology)
+      // Use metadata.title if available (for conversational shards), otherwise use entity name
+      const shardTitle = (metadata.title as string) || entity.name;
       const shard = {
         id: entity.id,
+        name: shardTitle, // Include name so UI doesn't fall back to showing the ID
+        title: shardTitle, // Also include as title for maximum compatibility
         text: JSON.stringify(entity.content),
         metadata: {
           ...metadata,

--- a/src/services/core/recap-service.ts
+++ b/src/services/core/recap-service.ts
@@ -1,0 +1,92 @@
+import { AssessmentDAO } from "@/dao/assessment-dao";
+import { WorldStateChangelogDAO } from "@/dao/world-state-changelog-dao";
+import { getDAOFactory } from "@/dao/dao-factory";
+import type { ActivityType } from "@/dao/assessment-dao";
+import type { WorldStateChangelogEntry } from "@/types/world-state";
+import type { SessionDigestWithData } from "@/types/session-digest";
+import type { Env } from "@/middleware/auth";
+
+export interface ContextRecapData {
+  recentActivity: ActivityType[];
+  worldStateChanges: WorldStateChangelogEntry[];
+  recentSessionDigests: SessionDigestWithData[];
+  inProgressGoals: {
+    todoChecklist: string[];
+    openThreads: string[];
+  };
+}
+
+/**
+ * Service for gathering context recap data when users return to the app
+ */
+export class RecapService {
+  private assessmentDAO: AssessmentDAO;
+  private worldStateChangelogDAO: WorldStateChangelogDAO;
+  private daoFactory: ReturnType<typeof getDAOFactory>;
+
+  constructor(env: Env) {
+    this.assessmentDAO = new AssessmentDAO(env.DB);
+    this.worldStateChangelogDAO = new WorldStateChangelogDAO(env.DB);
+    this.daoFactory = getDAOFactory(env);
+  }
+
+  /**
+   * Get context recap data for a campaign since a specific timestamp
+   * @param campaignId - The campaign ID to get recap data for
+   * @param username - The username (for filtering activity)
+   * @param sinceTimestamp - ISO timestamp string to get data since (defaults to 1 hour ago)
+   * @returns Structured recap data object
+   */
+  async getContextRecap(
+    campaignId: string,
+    username: string,
+    sinceTimestamp?: string
+  ): Promise<ContextRecapData> {
+    // Default to 1 hour ago if not specified
+    const since =
+      sinceTimestamp || new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+    // Get recent activity for the user (filtered to since timestamp)
+    const allRecentActivity =
+      await this.assessmentDAO.getRecentActivity(username);
+    const recentActivity = allRecentActivity.filter(
+      (activity) => new Date(activity.timestamp) >= new Date(since)
+    );
+
+    // Get world state changes since timestamp
+    const worldStateChanges =
+      await this.worldStateChangelogDAO.listEntriesForCampaign(campaignId, {
+        fromTimestamp: since,
+        limit: 50, // Limit to most recent 50 changes
+      });
+
+    // Get recent session digests (last 5)
+    const recentSessionDigests =
+      await this.daoFactory.sessionDigestDAO.getRecentSessionDigests(
+        campaignId,
+        5
+      );
+
+    // Extract in-progress goals from most recent session digest
+    let inProgressGoals = {
+      todoChecklist: [] as string[],
+      openThreads: [] as string[],
+    };
+
+    if (recentSessionDigests.length > 0) {
+      const mostRecentDigest = recentSessionDigests[0];
+      inProgressGoals = {
+        todoChecklist: mostRecentDigest.digestData.todo_checklist || [],
+        openThreads:
+          mostRecentDigest.digestData.last_session_recap?.open_threads || [],
+      };
+    }
+
+    return {
+      recentActivity,
+      worldStateChanges,
+      recentSessionDigests,
+      inProgressGoals,
+    };
+  }
+}

--- a/src/tools/campaign-context/context-capture-tools.ts
+++ b/src/tools/campaign-context/context-capture-tools.ts
@@ -149,7 +149,8 @@ export const captureConversationalContext = tool({
         content,
         contextType,
         confidence,
-        sourceMessageId
+        sourceMessageId,
+        env
       );
 
       console.log("[captureConversationalContext] Created staging shard:", {
@@ -286,7 +287,8 @@ export const saveContextExplicitly = tool({
         content,
         contextType,
         0.95, // High confidence for explicit user requests
-        undefined // No specific source message
+        undefined, // No specific source message
+        env
       );
 
       console.log("[saveContextExplicitly] Created staging shard:", {

--- a/src/tools/general/index.ts
+++ b/src/tools/general/index.ts
@@ -1,13 +1,16 @@
 // Import all general tools
 import { validateAdminKey } from "./auth-tools";
 import { fileRecommendationTools } from "./file-recommendation-tools";
+import { generateContextRecapTool } from "./recap-tools";
 
 // Export all general tools
 export { validateAdminKey } from "./auth-tools";
 export { fileRecommendationTools } from "./file-recommendation-tools";
+export { generateContextRecapTool } from "./recap-tools";
 
 // Export the tools object for backward compatibility
 export const generalTools = {
   validateAdminKey,
   ...fileRecommendationTools,
+  generateContextRecap: generateContextRecapTool,
 };

--- a/src/tools/general/recap-tools.ts
+++ b/src/tools/general/recap-tools.ts
@@ -1,0 +1,120 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { ToolResult } from "../../app-constants";
+import {
+  commonSchemas,
+  createToolError,
+  createToolSuccess,
+  extractUsernameFromJwt,
+} from "../utils";
+import { RecapService } from "../../services/core/recap-service";
+
+// Helper function to get environment from context
+function getEnvFromContext(context: any): any {
+  if (context?.env) {
+    return context.env;
+  }
+  if (typeof globalThis !== "undefined" && "env" in globalThis) {
+    return (globalThis as any).env;
+  }
+  return null;
+}
+
+/**
+ * Tool to generate context recap data for a campaign
+ * Returns recent activity, world state changes, session digests, and in-progress goals
+ */
+export const generateContextRecapTool = tool({
+  description:
+    "Generate a context recap for a campaign summarizing recent activity, world state changes, session digests, and in-progress goals. Use this when a user returns to the app after being away or when they switch campaigns.",
+  parameters: z.object({
+    campaignId: commonSchemas.campaignId,
+    jwt: commonSchemas.jwt,
+    sinceTimestamp: z
+      .string()
+      .optional()
+      .describe(
+        "ISO timestamp string to get data since (defaults to 1 hour ago)"
+      ),
+  }),
+  execute: async (
+    { campaignId, jwt, sinceTimestamp },
+    context?: any
+  ): Promise<ToolResult> => {
+    const toolCallId = context?.toolCallId || crypto.randomUUID();
+
+    try {
+      if (!jwt) {
+        return createToolError(
+          "Authentication required",
+          "JWT token is required",
+          401,
+          toolCallId
+        );
+      }
+
+      const env = getEnvFromContext(context);
+      if (!env) {
+        return createToolError(
+          "Environment not available",
+          "Server environment is required",
+          500,
+          toolCallId
+        );
+      }
+
+      const userId = extractUsernameFromJwt(jwt);
+      if (!userId) {
+        return createToolError(
+          "Invalid authentication token",
+          "Authentication failed",
+          401,
+          toolCallId
+        );
+      }
+
+      // Verify campaign exists and belongs to user
+      const { getDAOFactory } = await import("../../dao/dao-factory");
+      const daoFactory = getDAOFactory(env);
+      const campaign = await daoFactory.campaignDAO.getCampaignByIdWithMapping(
+        campaignId,
+        userId
+      );
+
+      if (!campaign) {
+        return createToolError(
+          "Campaign not found",
+          "Campaign not found or access denied",
+          404,
+          toolCallId
+        );
+      }
+
+      // Get recap data
+      const recapService = new RecapService(env);
+      const recapData = await recapService.getContextRecap(
+        campaignId,
+        userId,
+        sinceTimestamp
+      );
+
+      return createToolSuccess(
+        `Generated context recap for campaign "${campaign.name}"`,
+        {
+          campaignId,
+          campaignName: campaign.name,
+          recap: recapData,
+        },
+        toolCallId
+      );
+    } catch (error) {
+      console.error("[generateContextRecapTool] Error:", error);
+      return createToolError(
+        "Failed to generate context recap",
+        error instanceof Error ? error.message : String(error),
+        500,
+        toolCallId
+      );
+    }
+  },
+});


### PR DESCRIPTION
- Add name and title fields when converting entities to shards
- Use metadata.title if available (conversational shards), otherwise use entity name
- Prevents UI components from falling back to displaying UUIDs
- FlexibleShardCard.getShardTitle() now finds name/title fields before using ID
- Ensures conversational shards show meaningful titles instead of random UUIDs