### PR TITLE
CI build: always read index.html from process.cwd() in load()

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function ensureHtmlStringPlugin() {
   const indexHtmlAbsolute = path.resolve(__dirname, "index.html");
+  const indexHtmlFromCwd = path.join(process.cwd(), "index.html");
   return {
     name: "vite:ensure-html-string",
     enforce: "pre" as const,
@@ -29,11 +30,10 @@ function ensureHtmlStringPlugin() {
         idPath === "index.html" ||
         idPath.endsWith("/index.html") ||
         idPath.endsWith("\\index.html") ||
-        path.resolve(idPath) === indexHtmlAbsolute;
+        path.resolve(idPath) === indexHtmlAbsolute ||
+        path.resolve(idPath) === indexHtmlFromCwd;
       if (!isIndexHtml) return null;
-      const filePath = path.isAbsolute(idPath)
-        ? idPath
-        : path.resolve(process.cwd(), idPath);
+      const filePath = path.join(process.cwd(), "index.html");
       let code = fs.readFileSync(filePath, "utf8");
       if (code.length > 0 && code.charCodeAt(0) === 0xfeff) {
         code = code.slice(1);


### PR DESCRIPTION
- In ensureHtmlStringPlugin load(), use path.join(process.cwd(), 'index.html') so CI does not depend on __dirname for the file path
- Match id that resolves to indexHtmlFromCwd so we handle cwd-based ids
- Keeps resolveId returning absolute path so output stays index.html (virtual id caused null-byte output path error)