### PR TITLE
Fix CI build: post-phase HTML string + CI-only JS entry path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,11 +2,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { cloudflare } from "@cloudflare/vite-plugin";
+import type { OutputBundle, OutputChunk } from "rollup";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin, type UserConfig } from "vite";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const isCI = process.env.CI === "true" || process.env.CF_PAGES === "1";
 
 function ensureHtmlStringPlugin() {
   const indexHtmlAbsolute = path.resolve(__dirname, "index.html");
@@ -40,15 +43,70 @@ function ensureHtmlStringPlugin() {
   };
 }
 
+/** Post-phase transform: ensure index.html module code is a string (CI Rollup setSource InvalidArg). */
+function ensureHtmlStringPostPlugin() {
+  return {
+    name: "vite:ensure-html-string-post",
+    enforce: "post" as const,
+    transform(code: string | Buffer | undefined, id: string) {
+      const idPath = id.replace(/\?.*$/, "").replace(/#.*$/, "");
+      const isIndexHtml =
+        idPath === "index.html" ||
+        idPath.endsWith("/index.html") ||
+        idPath.endsWith("\\index.html");
+      if (!isIndexHtml) return null;
+      return typeof code === "string" ? code : String(code ?? "");
+    },
+  };
+}
+
+/** When CI: use JS entry and emit index.html in bundle to avoid vite:build-html load/transform InvalidArg. */
+function ciHtmlEntryPlugin(): Plugin {
+  return {
+    name: "vite:ci-html-entry",
+    enforce: "post" as const,
+    config(config: UserConfig) {
+      if (!isCI) return;
+      const root = config.root ?? process.cwd();
+      return {
+        build: {
+          rollupOptions: {
+            ...config.build?.rollupOptions,
+            input: path.resolve(root, "src/client.tsx"),
+          },
+        },
+      };
+    },
+    generateBundle(_outputOptions, bundle: OutputBundle) {
+      if (!isCI) return;
+      const entryChunk = Object.values(bundle).find(
+        (o): o is OutputChunk =>
+          o.type === "chunk" && (o as OutputChunk).isEntry === true
+      );
+      if (!entryChunk) return;
+      const scriptHref = `/${entryChunk.fileName}`;
+      const indexPath = path.join(process.cwd(), "index.html");
+      let html = fs.readFileSync(indexPath, "utf8");
+      html = html.replace(
+        /(\bsrc=)(["'])(?:\/src\/client\.tsx|\.\/src\/client\.tsx)\2/,
+        `$1$2${scriptHref}$2`
+      );
+      this.emitFile({ type: "asset", fileName: "index.html", source: html });
+    },
+  };
+}
+
 export default defineConfig({
   plugins: [
     ensureHtmlStringPlugin(),
+    ensureHtmlStringPostPlugin(),
     react(),
     cloudflare({
       configPath: "./wrangler.dev.jsonc",
       persistState: false, // Don't persist state
     }),
     tailwindcss(),
+    ciHtmlEntryPlugin(),
   ],
   ssr: {
     noExternal: ["agents", "ai", "cron-schedule", "mimetext"],


### PR DESCRIPTION
- Add ensureHtmlStringPostPlugin (enforce: post) to normalize index.html module code to a string in transform (handles build-html transform return).
- Add ciHtmlEntryPlugin: when CI or CF_PAGES, use src/client.tsx as Rollup input and emit index.html in generateBundle with correct script src.
- Avoids vite:build-html load/transform InvalidArg on Cloudflare CI.
- Local builds unchanged; CI=true builds use JS entry and inject index.html.