### PR TITLE
Set base config Rollup input to client.tsx for Cloudflare CI

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,7 +58,8 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
-      input: path.resolve(__dirname, "index.html"),
+      // JS entry avoids vite:build-html load/transform InvalidArg on Cloudflare CI; index.html is emitted in generateBundle.
+      input: path.resolve(__dirname, "src/client.tsx"),
       external: ["cloudflare:email", "cloudflare:workers"],
       output: {
         manualChunks: {


### PR DESCRIPTION
- build.rollupOptions.input in defineConfig now points to src/client.tsx so the JS entry is the default even when plugin config merge order differs on CI (avoids vite:build-html InvalidArg).