### PR TITLE
Fix CI: set environments.client.build.rollupOptions.input to JS entry

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,6 +43,8 @@ function ciHtmlEntryPlugin(): Plugin {
   };
 }
 
+const clientEntry = path.resolve(__dirname, "src/client.tsx");
+
 export default defineConfig({
   plugins: [
     react(),
@@ -56,10 +58,19 @@ export default defineConfig({
   ssr: {
     noExternal: ["agents", "ai", "cron-schedule", "mimetext"],
   },
+  // Explicit client environment input so @cloudflare/vite-plugin uses JS entry (avoids vite:build-html InvalidArg on CI).
+  environments: {
+    client: {
+      build: {
+        rollupOptions: {
+          input: clientEntry,
+        },
+      },
+    },
+  },
   build: {
     rollupOptions: {
-      // JS entry avoids vite:build-html load/transform InvalidArg on Cloudflare CI; index.html is emitted in generateBundle.
-      input: path.resolve(__dirname, "src/client.tsx"),
+      input: clientEntry,
       external: ["cloudflare:email", "cloudflare:workers"],
       output: {
         manualChunks: {


### PR DESCRIPTION
- Add explicit environments.client.build.rollupOptions.input (client.tsx) so @cloudflare/vite-plugin uses JS entry when building client env.
- Cloudflare plugin builds client from clientEnvironment.config; without this, client env can use Vite default (index.html) and hit InvalidArg.
- Use shared clientEntry for environments.client and build.rollupOptions.