### PR TITLE
fix: align worker entry point types with Cloudflare Workers API (#341)

### DIFF
--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -288,7 +288,7 @@ export async function queue(
 }
 
 export async function scheduled(
-  _event: ScheduledEvent,
+  _event: ScheduledController,
   env: Env
 ): Promise<void> {
   // Clean up old staging files every hour
@@ -491,9 +491,7 @@ async function checkAndTriggerRebuilds(env: Env): Promise<void> {
             );
 
             // Get OpenAI API key from environment
-            const openaiApiKey = (env as any).OPENAI_API_KEY as
-              | string
-              | undefined;
+            const openaiApiKey = env.OPENAI_API_KEY as string | undefined;
 
             if (openaiApiKey) {
               // Create summary service

--- a/src/routes/register-routes.ts
+++ b/src/routes/register-routes.ts
@@ -179,12 +179,13 @@ import {
   handleUploadStatus,
   handleCleanupStuckFiles,
 } from "@/routes/upload";
+import type { EnvWithSecrets } from "@/lib/env-utils";
 import { AuthService } from "@/services/core/auth-service";
 import type { AuthEnv } from "@/services/core/auth-service";
 import { API_CONFIG } from "@/shared-config";
 import { routeAgentRequest } from "agents";
 
-export interface Env extends AuthEnv {
+export interface Env extends AuthEnv, EnvWithSecrets {
   ADMIN_SECRET?: string;
   OPENAI_API_KEY?: string;
   R2: R2Bucket;
@@ -197,6 +198,7 @@ export interface Env extends AuthEnv {
   ASSETS: Fetcher;
   FILE_PROCESSING_QUEUE: Queue;
   FILE_PROCESSING_DLQ: Queue;
+  GRAPH_REBUILD_QUEUE: Queue;
 }
 
 export function registerRoutes(app: Hono<{ Bindings: Env }>) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,12 @@
 import { Hono } from "hono";
 import { UploadSessionDO } from "@/durable-objects/upload-session";
-import { queue as queueFn, scheduled as scheduledFn } from "@/queue-consumer";
+import {
+  queue as queueFn,
+  scheduled as scheduledFn,
+  type ProcessingMessage,
+} from "@/queue-consumer";
 import { registerRoutes, type Env } from "@/routes/register-routes";
+import type { RebuildQueueMessage } from "@/types/rebuild-queue";
 
 export { Chat } from "@/durable-objects/chat";
 export { NotificationHub } from "./durable-objects";
@@ -46,10 +51,14 @@ export default {
   fetch: (request: Request, env: Env, ctx: ExecutionContext) => {
     return app.fetch(request, env, ctx);
   },
-  queue: (batch: MessageBatch<unknown>, env: Env, _ctx?: ExecutionContext) => {
-    return queueFn(batch as any, env as any);
+  queue: (
+    batch: MessageBatch<ProcessingMessage | RebuildQueueMessage>,
+    env: Env,
+    ctx: ExecutionContext
+  ) => {
+    return queueFn(batch, env);
   },
-  scheduled: (event: ScheduledEvent, env: Env, _ctx?: ExecutionContext) => {
-    return scheduledFn(event as any, env as any);
+  scheduled: (event: ScheduledController, env: Env, ctx: ExecutionContext) => {
+    return scheduledFn(event, env);
   },
 };


### PR DESCRIPTION
- Add GRAPH_REBUILD_QUEUE to Env interface
- Extend Env with EnvWithSecrets for index signature compatibility
- Use ScheduledController for scheduled handler
- Type queue handler MessageBatch with ProcessingMessage | RebuildQueueMessage
- Remove (env as any) casts in queue-consumer