### PR TITLE
feat(ux): show file processing status after upload (#351)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,9 @@ dist
 # MacOS
 .DS_Store
 
+# Claude worktrees
+.claude/
+
 # Cloudflare
 .wrangler
 .dev.vars

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -242,8 +242,8 @@ export default function Chat() {
       updateActivity(); // Update activity timestamp on file upload
       addLocalNotification(
         NOTIFICATION_TYPES.SUCCESS,
-        "File Uploaded Successfully",
-        `"${filename}" has been uploaded and is being processed.`
+        "File uploaded",
+        `"${filename}" has been uploaded and we're preparing it for your campaigns.`
       );
     },
     onUploadStart: () => {

--- a/src/components/app/AppModals.tsx
+++ b/src/components/app/AppModals.tsx
@@ -290,7 +290,7 @@ export function AppModals({
         onUpdate={handleCampaignUpdate}
         onAddFileToCampaign={async (fileKey: string, fileName: string) => {
           if (modalState.selectedCampaign) {
-            await addFileToCampaigns(
+            return await addFileToCampaigns(
               { file_key: fileKey, file_name: fileName } as any,
               [modalState.selectedCampaign.campaignId],
               authState.getStoredJwt,

--- a/src/components/resource-side-panel/CampaignDetailsModal.tsx
+++ b/src/components/resource-side-panel/CampaignDetailsModal.tsx
@@ -34,7 +34,10 @@ interface CampaignDetailsModalProps {
     updates: { name?: string; description?: string }
   ) => Promise<void>;
   _isLoading?: boolean;
-  onAddFileToCampaign?: (fileKey: string, fileName: string) => Promise<void>;
+  onAddFileToCampaign?: (
+    fileKey: string,
+    fileName: string
+  ) => Promise<string | void>;
 }
 
 export function CampaignDetailsModal({
@@ -770,16 +773,21 @@ export function CampaignDetailsModal({
 
                       setIsAddingResources(true);
                       try {
-                        // Add each selected resource
+                        // Add each selected resource (optimistically mark as processing)
                         for (const fileKey of selectedResourceKeys) {
                           const file = libraryFiles.find(
                             (f: any) => f.file_key === fileKey
                           );
-                          if (file) {
-                            await onAddFileToCampaign(
+                          if (file && onAddFileToCampaign) {
+                            const resourceId = await onAddFileToCampaign(
                               file.file_key,
                               file.file_name
                             );
+                            if (resourceId) {
+                              setProcessingResources((prev) =>
+                                new Set(prev).add(resourceId)
+                              );
+                            }
                           }
                         }
 

--- a/src/components/resource-side-panel/LibrarySection.tsx
+++ b/src/components/resource-side-panel/LibrarySection.tsx
@@ -1,9 +1,14 @@
 import { CaretDown, CaretRight, Plus } from "@phosphor-icons/react";
+import { useEffect } from "react";
 import { Card } from "@/components/card/Card";
 import { StorageTracker } from "@/components/storage-tracker";
 import { ResourceList } from "@/components/upload/ResourceList";
+import { useAuthReady } from "@/hooks/useAuthReady";
+import { useResourceFiles } from "@/hooks/useResourceFiles";
 import type { Campaign } from "@/types/campaign";
 import type { ResourceFileWithCampaigns } from "@/hooks/useResourceFiles";
+import { AuthService, getStoredJwt } from "@/services/core/auth-service";
+import { APP_EVENT_TYPE } from "@/lib/app-events";
 import libraryIcon from "@/assets/library.png";
 
 interface LibrarySectionProps {
@@ -23,10 +28,92 @@ export function LibrarySection({
   onAddToLibrary,
   onAddToCampaign,
   onEditFile,
-  campaigns,
+  campaigns = [],
   campaignAdditionProgress = {},
   isAddingToCampaigns = false,
 }: LibrarySectionProps) {
+  const authReady = useAuthReady();
+  const {
+    files,
+    loading,
+    error,
+    fetchResources,
+    setFiles,
+    setError,
+    setLoading,
+    processingCount,
+  } = useResourceFiles({ campaigns });
+
+  useEffect(() => {
+    if (authReady) {
+      setLoading(true);
+      setError(null);
+      fetchResources();
+    } else {
+      const jwt = getStoredJwt();
+      if (jwt) {
+        setError(null);
+        setLoading(false);
+      } else {
+        setError("Please authenticate to view resources.");
+        setLoading(false);
+      }
+    }
+  }, [authReady, fetchResources, setLoading, setError]);
+
+  useEffect(() => {
+    const handleJwtChanged = () => {
+      const jwt = getStoredJwt();
+      if (jwt && !AuthService.isJwtExpired(jwt)) {
+        setLoading(true);
+        setError(null);
+        fetchResources();
+      }
+    };
+    window.addEventListener(
+      APP_EVENT_TYPE.JWT_CHANGED,
+      handleJwtChanged as EventListener
+    );
+    return () => {
+      window.removeEventListener(
+        APP_EVENT_TYPE.JWT_CHANGED,
+        handleJwtChanged as EventListener
+      );
+    };
+  }, [fetchResources, setLoading, setError]);
+
+  useEffect(() => {
+    const handleCampaignChange = () => {
+      fetchResources();
+    };
+    window.addEventListener(
+      APP_EVENT_TYPE.CAMPAIGN_CREATED,
+      handleCampaignChange as EventListener
+    );
+    window.addEventListener(
+      APP_EVENT_TYPE.CAMPAIGN_FILE_ADDED,
+      handleCampaignChange as EventListener
+    );
+    window.addEventListener(
+      APP_EVENT_TYPE.CAMPAIGN_FILE_REMOVED,
+      handleCampaignChange as EventListener
+    );
+    return () => {
+      window.removeEventListener(
+        APP_EVENT_TYPE.CAMPAIGN_CREATED,
+        handleCampaignChange as EventListener
+      );
+      window.removeEventListener(
+        APP_EVENT_TYPE.CAMPAIGN_FILE_ADDED,
+        handleCampaignChange as EventListener
+      );
+      window.removeEventListener(
+        APP_EVENT_TYPE.CAMPAIGN_FILE_REMOVED,
+        handleCampaignChange as EventListener
+      );
+    };
+  }, [fetchResources]);
+
   return (
     <Card className="tour-library-section p-0 border-t border-neutral-200 dark:border-neutral-700">
       <button
@@ -37,6 +124,14 @@ export function LibrarySection({
         <div className="flex items-center gap-2">
           <img src={libraryIcon} alt="Library" className="w-8 h-8" />
           <span className="font-medium text-sm">Your resource library</span>
+          {processingCount > 0 && (
+            <span
+              className="text-xs px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
+              title={`${processingCount} file${processingCount === 1 ? "" : "s"} preparing`}
+            >
+              {processingCount} preparing
+            </span>
+          )}
         </div>
         {isOpen ? <CaretDown size={16} /> : <CaretRight size={16} />}
       </button>
@@ -55,6 +150,13 @@ export function LibrarySection({
           </div>
           <div className="border-t border-neutral-200 dark:border-neutral-700">
             <ResourceList
+              files={files}
+              setFiles={setFiles}
+              loading={loading}
+              error={error}
+              setError={setError}
+              setLoading={setLoading}
+              fetchResources={fetchResources}
               onAddToCampaign={onAddToCampaign}
               onEditFile={onEditFile}
               campaigns={campaigns}

--- a/src/components/upload/FileStatusIndicator.tsx
+++ b/src/components/upload/FileStatusIndicator.tsx
@@ -67,7 +67,7 @@ export function FileStatusIndicator({
       icon: CheckCircle,
       color: "text-green-500",
       text: "Ready",
-      title: "File is indexed and searchable",
+      title: "Ready for your campaigns",
       spinning: false,
     },
     [FileDAO.STATUS.UPLOADING]: {
@@ -88,7 +88,7 @@ export function FileStatusIndicator({
       icon: Spinner,
       color: "text-blue-500",
       text: "Syncing",
-      title: "Starting indexing job",
+      title: "Preparing file",
       spinning: true,
     },
     [FileDAO.STATUS.PROCESSING]: {
@@ -96,8 +96,8 @@ export function FileStatusIndicator({
       color: "text-blue-500",
       text: timeEstimate ? `Processing (~${timeEstimate})` : "Processing",
       title: timeEstimate
-        ? `File is being processed. Estimated time: ${timeEstimate}`
-        : "File is being processed",
+        ? `File is being prepared. Estimated time: ${timeEstimate}`
+        : "File is being prepared",
       spinning: true,
     },
     [FileDAO.STATUS.INDEXING]: {
@@ -105,15 +105,15 @@ export function FileStatusIndicator({
       color: "text-blue-500",
       text: timeEstimate ? `Indexing (~${timeEstimate})` : "Indexing",
       title: timeEstimate
-        ? `File is being indexed for search. Estimated time: ${timeEstimate}`
-        : "File is being indexed for search",
+        ? `File is being prepared. Estimated time: ${timeEstimate}`
+        : "File is being prepared",
       spinning: true,
     },
     [FileDAO.STATUS.UNINDEXED]: {
       icon: XCircle,
       color: "text-orange-500",
-      text: "Not Indexed",
-      title: "File not indexed - shard generation will fail",
+      text: "Not ready",
+      title: "Needs processing before shards can be extracted",
       spinning: false,
     },
   };

--- a/src/components/upload/ResourceList.tsx
+++ b/src/components/upload/ResourceList.tsx
@@ -1,14 +1,12 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { API_CONFIG } from "@/shared-config";
 import {
   authenticatedFetchWithExpiration,
   getStoredJwt,
-  AuthService,
 } from "@/services/core/auth-service";
 import type { Campaign } from "@/types/campaign";
 import { useAuthReady } from "@/hooks/useAuthReady";
 import { Button } from "@/components/button/Button";
-import { useResourceFiles } from "@/hooks/useResourceFiles";
 import { useResourceFileEvents } from "@/hooks/useResourceFileEvents";
 import { ResourceFileItem } from "./ResourceFileItem";
 import type { ResourceFileWithCampaigns } from "@/hooks/useResourceFiles";
@@ -17,6 +15,13 @@ import { logger } from "@/lib/logger";
 import { FileDAO } from "@/dao";
 
 interface ResourceListProps {
+  files: ResourceFileWithCampaigns[];
+  setFiles: React.Dispatch<React.SetStateAction<ResourceFileWithCampaigns[]>>;
+  loading: boolean;
+  error: string | null;
+  setError: React.Dispatch<React.SetStateAction<string | null>>;
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  fetchResources: () => Promise<void>;
   onAddToCampaign?: (file: ResourceFileWithCampaigns) => void;
   onEditFile?: (file: ResourceFileWithCampaigns) => void;
   campaigns?: Campaign[];
@@ -28,6 +33,13 @@ interface ResourceListProps {
  * ResourceList component - displays a list of uploaded files with their status and details
  */
 export function ResourceList({
+  files,
+  setFiles,
+  loading,
+  error,
+  setError,
+  setLoading,
+  fetchResources,
   onAddToCampaign,
   onEditFile,
   campaigns = [],
@@ -39,17 +51,6 @@ export function ResourceList({
     Record<string, number>
   >({});
   const authReady = useAuthReady();
-
-  // File data management
-  const {
-    files,
-    loading,
-    error,
-    fetchResources,
-    setFiles,
-    setError,
-    setLoading,
-  } = useResourceFiles({ campaigns });
 
   // File event handling - manages progress state internally and via prop setter
   useResourceFileEvents({
@@ -225,106 +226,6 @@ export function ResourceList({
       return newExpandedFiles;
     });
   }, []);
-
-  // Initial load - run when authentication becomes ready
-  useEffect(() => {
-    if (authReady) {
-      // Reset loading state and fetch resources when auth becomes ready
-      const log = logger.scope("[ResourceList]");
-      log.debug("Auth ready, fetching resources");
-      setLoading(true);
-      setError(null);
-      fetchResources();
-    } else {
-      // If auth is not ready (e.g., JWT expired), clear loading state
-      // to prevent infinite "Loading resources..." display
-      const jwt = getStoredJwt();
-      if (jwt) {
-        // JWT exists but is expired - clear loading state
-        // The auth modal will be shown by useAppState
-        setError(null);
-        setLoading(false);
-      } else {
-        // No JWT - clear loading state and set error
-        setError("Please authenticate to view resources.");
-        setLoading(false);
-      }
-    }
-  }, [authReady, fetchResources, setLoading, setError]);
-
-  // Also listen for jwt-changed events to refresh immediately after authentication
-  useEffect(() => {
-    const handleJwtChanged = () => {
-      const log = logger.scope("[ResourceList]");
-      const jwt = getStoredJwt();
-      log.debug("JWT changed event received", { hasJwt: !!jwt, authReady });
-      // Check if JWT exists and is valid (not expired)
-      if (jwt) {
-        const isExpired = AuthService.isJwtExpired(jwt);
-        if (!isExpired) {
-          // JWT is valid - refresh resources immediately
-          // authReady will update shortly via useAuthReady's polling
-          log.info("JWT is valid, refreshing resources after authentication");
-          setLoading(true);
-          setError(null);
-          fetchResources();
-        } else {
-          log.debug("JWT changed but is expired, waiting for authReady");
-        }
-      }
-    };
-
-    window.addEventListener(
-      APP_EVENT_TYPE.JWT_CHANGED,
-      handleJwtChanged as EventListener
-    );
-    return () => {
-      window.removeEventListener(
-        APP_EVENT_TYPE.JWT_CHANGED,
-        handleJwtChanged as EventListener
-      );
-    };
-  }, [fetchResources, setLoading, setError, authReady]);
-
-  // Listen for campaign changes to refresh campaign associations
-  useEffect(() => {
-    const handleCampaignChange = () => {
-      console.log(
-        "[ResourceList] Received campaign change event, refreshing campaign data"
-      );
-      // Re-fetch campaign associations for all files
-      fetchResources();
-    };
-
-    // Listen for campaign-related events
-    window.addEventListener(
-      APP_EVENT_TYPE.CAMPAIGN_CREATED,
-      handleCampaignChange as EventListener
-    );
-    window.addEventListener(
-      APP_EVENT_TYPE.CAMPAIGN_FILE_ADDED,
-      handleCampaignChange as EventListener
-    );
-    window.addEventListener(
-      APP_EVENT_TYPE.CAMPAIGN_FILE_REMOVED,
-      handleCampaignChange as EventListener
-    );
-
-    return () => {
-      window.removeEventListener(
-        APP_EVENT_TYPE.CAMPAIGN_CREATED,
-        handleCampaignChange as EventListener
-      );
-      window.removeEventListener(
-        APP_EVENT_TYPE.CAMPAIGN_FILE_ADDED,
-        handleCampaignChange as EventListener
-      );
-      window.removeEventListener(
-        APP_EVENT_TYPE.CAMPAIGN_FILE_REMOVED,
-        handleCampaignChange as EventListener
-      );
-    };
-  }, [fetchResources]);
 
   if (loading) {
     return (

--- a/src/hooks/useCampaignAddition.ts
+++ b/src/hooks/useCampaignAddition.ts
@@ -61,6 +61,7 @@ export function useCampaignAddition() {
           return;
         }
 
+        let lastResourceId: string | undefined;
         // Add file to each selected campaign with progress updates
         for (let i = 0; i < campaignIds.length; i++) {
           const campaignId = campaignIds[i];
@@ -104,6 +105,13 @@ export function useCampaignAddition() {
             const parsedError = parseErrorResponse(errorText, response.status);
             throw new Error(formatErrorForNotification(parsedError));
           }
+
+          const data = (await response.json()) as {
+            resource?: { id?: string };
+          };
+          if (data?.resource?.id) {
+            lastResourceId = data.resource.id;
+          }
         }
 
         // Complete progress
@@ -143,6 +151,8 @@ export function useCampaignAddition() {
           });
           setIsAddingToCampaigns(false);
         }, 1500);
+
+        return lastResourceId;
       } catch (error) {
         console.error("Error adding file to campaigns:", error);
         const errorMessage =

--- a/src/hooks/useResourceFiles.ts
+++ b/src/hooks/useResourceFiles.ts
@@ -1,10 +1,11 @@
-import { useCallback, useState, useRef } from "react";
+import { useCallback, useMemo, useState, useRef } from "react";
 import { ERROR_MESSAGES } from "@/app-constants";
 import {
   authenticatedFetchWithExpiration,
   getStoredJwt,
 } from "@/services/core/auth-service";
 import { API_CONFIG } from "@/shared-config";
+import { FileDAO } from "@/dao";
 import type { Campaign } from "@/types/campaign";
 
 export interface ResourceFile {
@@ -29,6 +30,14 @@ interface UseResourceFilesOptions {
   campaigns?: Campaign[];
 }
 
+const PROCESSING_STATUSES: Set<string> = new Set([
+  FileDAO.STATUS.UPLOADING,
+  FileDAO.STATUS.UPLOADED,
+  FileDAO.STATUS.SYNCING,
+  FileDAO.STATUS.PROCESSING,
+  FileDAO.STATUS.INDEXING,
+]);
+
 interface UseResourceFilesReturn {
   files: ResourceFileWithCampaigns[];
   loading: boolean;
@@ -37,6 +46,7 @@ interface UseResourceFilesReturn {
   setFiles: React.Dispatch<React.SetStateAction<ResourceFileWithCampaigns[]>>;
   setError: React.Dispatch<React.SetStateAction<string | null>>;
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  processingCount: number;
 }
 
 /**
@@ -195,6 +205,11 @@ export function useResourceFiles(
     }
   }, [fetchResourceCampaigns, campaigns]);
 
+  const processingCount = useMemo(
+    () => files.filter((f) => PROCESSING_STATUSES.has(f.status)).length,
+    [files]
+  );
+
   return {
     files,
     loading,
@@ -203,5 +218,6 @@ export function useResourceFiles(
     setFiles,
     setError,
     setLoading,
+    processingCount,
   };
 }

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -108,17 +108,17 @@ export async function notifyShardGeneration(
   let message: string;
 
   if (isNone) {
-    title = "No Shards Found";
+    title = "No shards found";
     message = `🔎 No shards were discovered from "${fileName}" in "${campaignName}".`;
     // Include error message if provided (e.g., all chunks failed)
     if (context?.errorMessage) {
       message += ` ${context.errorMessage}`;
     }
   } else if (isStreaming) {
-    title = "Shards Discovered";
-    message = `📦 ${shardCount} shards found in chunk ${context.chunkNumber} from "${fileName}" in "${campaignName}".`;
+    title = "Shards discovered";
+    message = `📦 ${shardCount} shards found from "${fileName}" in "${campaignName}".`;
   } else {
-    title = "New Shards Ready!";
+    title = "New shards ready";
     message = `🎉 ${shardCount} new shards generated from "${fileName}" in "${campaignName}"!`;
     // Include warning if there were partial failures
     if (context?.errorMessage) {
@@ -266,8 +266,8 @@ export async function notifyIndexingStarted(
   try {
     await notifyUser(env, userId, {
       type: NOTIFICATION_TYPES.INDEXING_STARTED,
-      title: "Indexing Begun",
-      message: `📜 We're scribing "${fileName}" into your library.`,
+      title: "Preparing your lore",
+      message: `📜 We're adding "${fileName}" to your library.`,
       data: {
         fileName,
         ...(fileKey && { fileKey }),
@@ -294,8 +294,8 @@ export async function notifyIndexingCompleted(
 ): Promise<void> {
   await notifyUser(env, userId, {
     type: NOTIFICATION_TYPES.INDEXING_COMPLETED,
-    title: "Indexing Complete",
-    message: `✨ "${fileName}" is now searchable in your tome.`,
+    title: "Ready",
+    message: `✨ "${fileName}" is ready for your campaigns.`,
     data: { fileName },
   });
 }
@@ -310,8 +310,8 @@ export async function notifyIndexingFailed(
 ): Promise<void> {
   await notifyUser(env, userId, {
     type: NOTIFICATION_TYPES.INDEXING_FAILED,
-    title: "Indexing Failed",
-    message: `🛑 Our quill slipped while indexing "${fileName}". Please try again later.`,
+    title: "Couldn't prepare file",
+    message: `🛑 Our quill slipped while preparing "${fileName}". Please try again later.`,
     data: {
       fileName,
       ...(fileKey && { fileKey }),

--- a/tests/components/ResourceSidePanel.test.tsx
+++ b/tests/components/ResourceSidePanel.test.tsx
@@ -15,7 +15,10 @@ vi.mock("@/hooks/useCampaignManagement", () => ({
 vi.mock("@/services/core/auth-service", () => ({
   AuthService: {
     getUsernameFromStoredJwt: vi.fn(() => "testuser"),
+    isJwtExpired: vi.fn(() => false),
   },
+  getStoredJwt: vi.fn(() => "mock-jwt"),
+  isJwtExpired: vi.fn(() => false),
 }));
 
 describe("ResourceSidePanel", () => {

--- a/tests/notifications/notifications.test.ts
+++ b/tests/notifications/notifications.test.ts
@@ -93,7 +93,7 @@ describe("Notification Helpers", () => {
       const body = (await request.json()) as Record<string, any>;
 
       expect(body.type).toBe("shards_generated");
-      expect(body.title).toBe("New Shards Ready!");
+      expect(body.title).toBe("New shards ready");
       expect(body.message).toContain(
         '5 new shards generated from "test-file.pdf"'
       );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     },
   },
   test: {
+    exclude: ["**/node_modules/**", "**/.claude/**"],
     testTimeout: 30000, // 30 second timeout per test
     hookTimeout: 30000, // 30 second timeout for hooks
     setupFiles: ["./tests/setup.ts"],


### PR DESCRIPTION
- Add global 'N preparing' badge in Library sidebar
- Refactor LibrarySection to own resource files state
- Update copy to GM-focused, non-technical language
- Add optimistic UI for campaign resource additions
- Retain 'shards' as thematic term throughout
- Fix PROCESSING_STATUSES Set type for ResourceFile.status
- Add .claude to gitignore, exclude from vitest