### PR TITLE
fix: replace saturated purple selection states with neutral styling

### DIFF
--- a/.cursor/rules/no-bright-purple-selection.mdc
+++ b/.cursor/rules/no-bright-purple-selection.mdc
@@ -1,0 +1,28 @@
+---
+description: Never use bright purple for selected/active state backgrounds
+globs: ["**/*.tsx", "**/*.jsx", "**/*.css"]
+alwaysApply: true
+---
+
+# No bright purple for selection/active state
+
+## Rule
+
+**NEVER** use bright or saturated purple backgrounds for selected, active, or current-item states in the UI.
+
+### Banned (do not use for selection/active background or strong emphasis)
+
+- `bg-purple-50` (light mode selected background)
+- `bg-purple-950` or `bg-purple-950/30` or similar (dark mode selected background)
+- `border-l-purple-500` or any bright purple border for selected state
+- `text-purple-700` / `text-purple-300` for selected item text when combined with purple background
+
+These create a loud, harsh look. Do not use them.
+
+### Use instead (simple, subtle)
+
+- **Selected/active background:** `bg-neutral-100 dark:bg-neutral-800` (lighter gray)
+- **Optional subtle accent:** very muted lavender only if needed, e.g. `bg-neutral-100` with a barely-there tint—never saturated purple
+- **Selected text:** `text-neutral-800 dark:text-neutral-200` or keep default gray
+
+Keep selection and active states **simple**: lighter gray or very subtle lavender only. No bright purple backgrounds, no purple borders for selection.

--- a/src/components/app/ChatArea.tsx
+++ b/src/components/app/ChatArea.tsx
@@ -84,7 +84,7 @@ export function ChatArea({
       <div className="px-8 py-3 flex-shrink-0">
         <select
           id="campaign-select"
-          className="tour-campaign-selector rounded-md border border-neutral-300 bg-purple-600/10 px-3 py-1.5 text-sm text-neutral-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-600 dark:border-neutral-700 dark:bg-purple-400/10 dark:text-neutral-100 dark:focus:ring-purple-400"
+          className="tour-campaign-selector rounded-md border border-neutral-300 bg-neutral-100 px-3 py-1.5 text-sm text-neutral-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100 dark:focus:ring-neutral-500"
           value={selectedCampaignId ?? ""}
           onChange={handleCampaignChange}
         >

--- a/src/components/chat/shard/ShardActionBar.tsx
+++ b/src/components/chat/shard/ShardActionBar.tsx
@@ -22,9 +22,9 @@ export const ShardActionBar: React.FC<ShardActionBarProps> = ({
   if (selectedCount === 0) return null;
 
   return (
-    <div className="bg-purple-900 dark:bg-purple-900 border border-purple-700 dark:border-purple-700 rounded-lg p-3">
+    <div className="bg-neutral-800 dark:bg-neutral-800 border border-neutral-600 dark:border-neutral-600 rounded-lg p-3">
       <div className="flex items-center justify-between">
-        <p className="text-purple-600 dark:text-purple-400">
+        <p className="text-neutral-200 dark:text-neutral-200">
           {selectedCount} shard{selectedCount !== 1 ? "s" : ""} selected
         </p>
         <div className="flex space-x-2">

--- a/src/components/resource-side-panel/CampaignResourcesTab.tsx
+++ b/src/components/resource-side-panel/CampaignResourcesTab.tsx
@@ -96,7 +96,7 @@ export function CampaignResourcesTab({
                         toggleExpand();
                       }}
                       type="button"
-                      className="flex-shrink-0 p-1 rounded-md bg-neutral-200 dark:bg-neutral-800 hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors duration-200"
+                      className="flex-shrink-0 p-1 rounded-md bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors duration-200"
                     >
                       {isExpanded ? (
                         <CaretDownIcon

--- a/src/components/upload/ResourceFileDetails.tsx
+++ b/src/components/upload/ResourceFileDetails.tsx
@@ -116,7 +116,7 @@ export function ResourceFileDetails({
             {file.campaigns.map((campaign) => (
               <span
                 key={campaign.campaignId}
-                className="px-2 py-1 text-xs bg-purple-100 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400 rounded"
+                className="px-2 py-1 text-xs bg-neutral-200 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded"
               >
                 {campaign.name}
               </span>

--- a/src/components/upload/ResourceFileItem.tsx
+++ b/src/components/upload/ResourceFileItem.tsx
@@ -132,7 +132,7 @@ export function ResourceFileItem({
               onToggleExpand();
             }}
             type="button"
-            className="flex-shrink-0 p-1 rounded-md bg-neutral-200 dark:bg-neutral-800 hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors duration-200"
+            className="flex-shrink-0 p-1 rounded-md bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors duration-200"
           >
             {isExpanded ? (
               <CaretDownIcon

--- a/src/components/upload/ResourceUpload.tsx
+++ b/src/components/upload/ResourceUpload.tsx
@@ -432,8 +432,8 @@ export const ResourceUpload = ({
                                   "px-3 py-1.5 text-sm transition-colors rounded border-2",
                                   "focus:outline-none",
                                   isSelected
-                                    ? "font-medium bg-purple-200 dark:bg-purple-800/40 text-purple-600 dark:text-purple-400 border-neutral-300 dark:border-neutral-700 hover:bg-purple-300 dark:hover:bg-purple-800/50"
-                                    : "font-normal bg-purple-50/30 dark:bg-purple-900/10 text-purple-600 dark:text-purple-400 border-neutral-300 dark:border-neutral-700 hover:bg-purple-50/50 dark:hover:bg-purple-900/15"
+                                    ? "font-medium bg-neutral-200 dark:bg-neutral-700 text-neutral-800 dark:text-neutral-200 border-neutral-300 dark:border-neutral-700 hover:bg-neutral-300 dark:hover:bg-neutral-600"
+                                    : "font-normal bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 border-neutral-300 dark:border-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-700"
                                 )}
                               >
                                 {campaign.name}


### PR DESCRIPTION
Apply a consistent neutral palette for selected/active UI states and codify the rule to avoid bright purple backgrounds so selection treatment matches the rest of the app.