### PR TITLE
Improve non-interactive pipeline model selection and structured outputs.

### DIFF
--- a/src/app-constants.ts
+++ b/src/app-constants.ts
@@ -185,8 +185,14 @@ export const MODEL_CONFIG = {
 	OPENAI: {
 		// Primary model for chat and general tasks
 		PRIMARY: "gpt-5-mini",
+		// Model for user-facing interactive chat/tool orchestration
+		INTERACTIVE: "gpt-5-mini",
 		// Model for metadata generation and analysis
 		ANALYSIS: "gpt-5-mini",
+		// Model for non-interactive structured/background pipeline steps
+		PIPELINE_STRUCTURED: "gpt-5-mini",
+		// Model for non-interactive analysis/evaluation pipeline steps
+		PIPELINE_ANALYSIS: "gpt-5-mini",
 		// Model for metadata analysis (checklist coverage, campaign readiness)
 		METADATA_ANALYSIS: "gpt-5-mini",
 		// Model for session planning and script generation

--- a/src/lib/model-config.ts
+++ b/src/lib/model-config.ts
@@ -39,7 +39,7 @@ export function createModel(
  * Get the primary model for chat and general tasks
  */
 export function getPrimaryModel(apiKey?: string) {
-	return createModel(MODEL_CONFIG.OPENAI.PRIMARY, apiKey);
+	return createModel(MODEL_CONFIG.OPENAI.INTERACTIVE, apiKey);
 }
 
 /**

--- a/src/lib/model-manager.ts
+++ b/src/lib/model-manager.ts
@@ -45,7 +45,7 @@ export class ModelManager {
 
 		try {
 			// Create the model instance
-			this.model = openai(MODEL_CONFIG.OPENAI.PRIMARY as any);
+			this.model = openai(MODEL_CONFIG.OPENAI.INTERACTIVE as any);
 			this.apiKey = trimmedKey;
 
 			console.log("[ModelManager] Model initialized with user API key");

--- a/src/services/graph/community-summary-service.ts
+++ b/src/services/graph/community-summary-service.ts
@@ -14,7 +14,7 @@ import { createLLMProvider } from "@/services/llm/llm-provider-factory";
  */
 const SUMMARY_CONFIG = {
 	// LLM Configuration
-	DEFAULT_MODEL: MODEL_CONFIG.OPENAI.ANALYSIS,
+	DEFAULT_MODEL: MODEL_CONFIG.OPENAI.PIPELINE_STRUCTURED,
 	DEFAULT_TEMPERATURE: 0.3,
 	DEFAULT_MAX_TOKENS: 2000,
 	LLM_PROVIDER: "openai" as const,
@@ -418,20 +418,32 @@ export class CommunitySummaryService {
 		options: CommunitySummaryOptions = {}
 	): Promise<CommunitySummaryResult[]> {
 		const results: CommunitySummaryResult[] = [];
-
-		// Generate summaries sequentially to avoid rate limits
-		for (const community of communities) {
-			try {
-				const result = await this.generateOrGetSummary(community, options);
-				results.push(result);
-			} catch (error) {
-				console.error(
-					`[CommunitySummaryService] Failed to generate summary for community ${community.id}:`,
-					error
-				);
-				// Continue with other communities even if one fails
+		// Use bounded concurrency to improve throughput while avoiding bursty spikes.
+		const maxConcurrent = 3;
+		let index = 0;
+		const workers = Array.from(
+			{ length: Math.min(maxConcurrent, communities.length) },
+			async () => {
+				while (true) {
+					const currentIndex = index++;
+					if (currentIndex >= communities.length) {
+						return;
+					}
+					const community = communities[currentIndex];
+					try {
+						const result = await this.generateOrGetSummary(community, options);
+						results.push(result);
+					} catch (error) {
+						console.error(
+							`[CommunitySummaryService] Failed to generate summary for community ${community.id}:`,
+							error
+						);
+						// Continue with remaining communities even if one fails
+					}
+				}
 			}
-		}
+		);
+		await Promise.all(workers);
 
 		return results;
 	}

--- a/src/services/llm/openai-provider.ts
+++ b/src/services/llm/openai-provider.ts
@@ -8,6 +8,23 @@ import type {
 	StructuredOutputOptions,
 } from "./llm-provider";
 
+function parseStructuredSchema(
+	schema?: string
+): Record<string, unknown> | null {
+	if (!schema || !schema.trim()) {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse(schema) as Record<string, unknown>;
+		if (!parsed || typeof parsed !== "object") {
+			return null;
+		}
+		return parsed;
+	} catch (_error) {
+		return null;
+	}
+}
+
 /**
  * OpenAI provider implementation for LLM generation
  */
@@ -30,8 +47,8 @@ export class OpenAIProvider implements LLMProvider {
 		}
 
 		this.apiKey = apiKey;
-		// Default to centralized primary model for general-purpose calls; callers can override per-use.
-		this.defaultModel = options.defaultModel || MODEL_CONFIG.OPENAI.PRIMARY;
+		// Default to interactive tier; background pipelines should pass explicit defaults.
+		this.defaultModel = options.defaultModel || MODEL_CONFIG.OPENAI.INTERACTIVE;
 		this.defaultTemperature = options.defaultTemperature ?? 0.3;
 		this.defaultMaxTokens = options.defaultMaxTokens ?? 2000;
 	}
@@ -118,23 +135,90 @@ export class OpenAIProvider implements LLMProvider {
 			const finalPrompt = hasJsonInstruction
 				? prompt
 				: `Respond with valid JSON only.\n\n${prompt}`;
+			const parsedSchema = parseStructuredSchema(options.schema);
 
 			// Reasoning models (gpt-5-mini, gpt-5.2, etc.) do not support temperature
 			console.log("[OpenAIProvider] Structured output request (AI SDK chat)", {
 				model: modelId,
 				maxTokens,
 				promptLength: finalPrompt.length,
+				hasSchema: Boolean(parsedSchema),
 			});
 
-			const result = await generateText({
-				model,
-				prompt: finalPrompt,
-				maxOutputTokens: maxTokens,
-				output: Output.json(),
-				...(!MODEL_CONFIG.isReasoningModel(modelId) && {
-					temperature,
-				}),
-			});
+			let result: Awaited<ReturnType<typeof generateText>>;
+			if (parsedSchema) {
+				try {
+					// Prefer schema-enforced structured outputs for JSON-only pipeline steps.
+					const requestWithSchema: Parameters<typeof generateText>[0] = {
+						model,
+						prompt: finalPrompt,
+						maxOutputTokens: maxTokens,
+						output: Output.json(),
+						providerOptions: {
+							openai: {
+								responseFormat: {
+									type: "json_schema",
+									json_schema: {
+										name: "structured_output",
+										strict: true,
+										schema: parsedSchema as any,
+									},
+								},
+								response_format: {
+									type: "json_schema",
+									json_schema: {
+										name: "structured_output",
+										strict: true,
+										schema: parsedSchema as any,
+									},
+								},
+							},
+						},
+						...(!MODEL_CONFIG.isReasoningModel(modelId) && {
+							temperature,
+						}),
+					};
+					result = await generateText(requestWithSchema);
+				} catch (schemaError) {
+					console.warn(
+						"[OpenAIProvider] Schema-structured output failed, falling back to json_object path:",
+						schemaError
+					);
+					const fallbackRequest: Parameters<typeof generateText>[0] = {
+						model,
+						prompt: finalPrompt,
+						maxOutputTokens: maxTokens,
+						output: Output.json(),
+						providerOptions: {
+							openai: {
+								responseFormat: { type: "json_object" },
+								response_format: { type: "json_object" },
+							},
+						},
+						...(!MODEL_CONFIG.isReasoningModel(modelId) && {
+							temperature,
+						}),
+					};
+					result = await generateText(fallbackRequest);
+				}
+			} else {
+				const request: Parameters<typeof generateText>[0] = {
+					model,
+					prompt: finalPrompt,
+					maxOutputTokens: maxTokens,
+					output: Output.json(),
+					providerOptions: {
+						openai: {
+							responseFormat: { type: "json_object" },
+							response_format: { type: "json_object" },
+						},
+					},
+					...(!MODEL_CONFIG.isReasoningModel(modelId) && {
+						temperature,
+					}),
+				};
+				result = await generateText(request);
+			}
 
 			const output = result.output;
 			if (output === undefined || output === null) {

--- a/src/services/rag/entity-extraction-service.ts
+++ b/src/services/rag/entity-extraction-service.ts
@@ -308,8 +308,8 @@ CONTENT END`;
 			const llmProvider = createLLMProvider({
 				provider: "openai",
 				apiKey,
-				// Use centralized session planning / heavy-structured model
-				defaultModel: MODEL_CONFIG.OPENAI.SESSION_PLANNING,
+				// Use non-interactive structured pipeline tier for extraction
+				defaultModel: MODEL_CONFIG.OPENAI.PIPELINE_STRUCTURED,
 				defaultTemperature: 0.1,
 				defaultMaxTokens: MAX_EXTRACTION_RESPONSE_TOKENS,
 			});
@@ -318,7 +318,7 @@ CONTENT END`;
 			const result = await llmProvider.generateStructuredOutput<
 				z.infer<typeof EntityExtractionSchema>
 			>(prompt, {
-				model: MODEL_CONFIG.OPENAI.SESSION_PLANNING,
+				model: MODEL_CONFIG.OPENAI.PIPELINE_STRUCTURED,
 				temperature: 0.1,
 				maxTokens: MAX_EXTRACTION_RESPONSE_TOKENS,
 				username: usageOptions?.username,

--- a/src/services/session-digest/digest-quality-service.ts
+++ b/src/services/session-digest/digest-quality-service.ts
@@ -62,33 +62,19 @@ export class DigestQualityService {
 	): Promise<DigestQualityResult> {
 		const completeness = this.checkCompleteness(digestData);
 
-		// Specificity check requires LLM, so it's optional
 		let specificity = { score: 10, issues: [] as string[] };
-		if (this.openaiApiKey) {
-			try {
-				specificity = await this.checkSpecificity(digestData);
-			} catch (error) {
-				console.warn(
-					"[DigestQualityService] Failed to check specificity:",
-					error
-				);
-				// Don't fail if specificity check fails, just skip it
-			}
-		}
-
 		const consistency = await this.checkConsistency(digestData, campaignId);
-
-		// Relevance check requires LLM, so it's optional
 		let relevance = { score: 10, issues: [] as string[] };
 		if (this.openaiApiKey) {
 			try {
-				relevance = await this.checkRelevance(digestData);
+				const combined = await this.checkSpecificityAndRelevance(digestData);
+				specificity = combined.specificity;
+				relevance = combined.relevance;
 			} catch (error) {
 				console.warn(
-					"[DigestQualityService] Failed to check relevance:",
+					"[DigestQualityService] Failed to run combined specificity/relevance check:",
 					error
 				);
-				// Don't fail if relevance check fails, just skip it
 			}
 		}
 
@@ -200,49 +186,101 @@ export class DigestQualityService {
 	}
 
 	/**
-	 * Check specificity - ensures entries are specific, not vague
-	 * Uses LLM to assess whether entries are concrete and actionable
+	 * Combined check for specificity + relevance in a single LLM request.
+	 * Reduces round-trips in non-interactive quality evaluation paths.
 	 */
-	private async checkSpecificity(digestData: SessionDigestData): Promise<{
-		score: number;
-		issues: string[];
+	private async checkSpecificityAndRelevance(
+		digestData: SessionDigestData
+	): Promise<{
+		specificity: { score: number; issues: string[] };
+		relevance: { score: number; issues: string[] };
 	}> {
-		// If no OpenAI key, return a default score
 		if (!this.openaiApiKey) {
-			return { score: 10, issues: [] };
+			return {
+				specificity: { score: 10, issues: [] },
+				relevance: { score: 10, issues: [] },
+			};
 		}
+
+		const specificityPrompt = formatSpecificityAssessmentPrompt(digestData);
+		const relevancePrompt = formatRelevanceAssessmentPrompt(digestData);
+		const schema = JSON.stringify({
+			type: "object",
+			properties: {
+				specificity: {
+					type: "object",
+					properties: {
+						score: { type: "number" },
+						issues: { type: "array", items: { type: "string" } },
+					},
+					required: ["score", "issues"],
+				},
+				relevance: {
+					type: "object",
+					properties: {
+						score: { type: "number" },
+						issues: { type: "array", items: { type: "string" } },
+					},
+					required: ["score", "issues"],
+				},
+			},
+			required: ["specificity", "relevance"],
+		});
+		const prompt = `Evaluate session digest quality and return ONLY JSON.
+
+Assess two dimensions:
+1) Specificity: are entries concrete and actionable instead of vague.
+2) Relevance: is content focused on campaign/session planning utility.
+
+Specificity rubric and context:
+${specificityPrompt}
+
+Relevance rubric and context:
+${relevancePrompt}
+
+Return:
+{
+  "specificity": { "score": 0-10, "issues": ["..."] },
+  "relevance": { "score": 0-10, "issues": ["..."] }
+}`;
 
 		try {
 			const llmProvider = createLLMProvider({
 				provider: "openai",
 				apiKey: this.openaiApiKey,
-				defaultModel: MODEL_CONFIG.OPENAI.ANALYSIS,
+				defaultModel: MODEL_CONFIG.OPENAI.PIPELINE_ANALYSIS,
 				defaultTemperature: 0.1,
-				defaultMaxTokens: 2000,
+				defaultMaxTokens: 2200,
 			});
-
-			const prompt = formatSpecificityAssessmentPrompt(digestData);
-
 			const result = await llmProvider.generateStructuredOutput<{
-				score: number;
-				issues: string[];
+				specificity?: { score?: number; issues?: string[] };
+				relevance?: { score?: number; issues?: string[] };
 			}>(prompt, {
-				model: MODEL_CONFIG.OPENAI.ANALYSIS,
+				model: MODEL_CONFIG.OPENAI.PIPELINE_ANALYSIS,
 				temperature: 0.1,
-				maxTokens: 2000,
+				maxTokens: 2200,
+				schema,
 			});
 
 			return {
-				score: Math.max(0, Math.min(10, result.score)),
-				issues: result.issues || [],
+				specificity: {
+					score: Math.max(0, Math.min(10, result.specificity?.score ?? 10)),
+					issues: result.specificity?.issues || [],
+				},
+				relevance: {
+					score: Math.max(0, Math.min(10, result.relevance?.score ?? 10)),
+					issues: result.relevance?.issues || [],
+				},
 			};
 		} catch (error) {
 			console.warn(
-				"[DigestQualityService] Failed to check specificity with AI:",
+				"[DigestQualityService] Combined specificity/relevance check failed:",
 				error
 			);
-			// Return default score if AI check fails
-			return { score: 10, issues: [] };
+			return {
+				specificity: { score: 10, issues: [] },
+				relevance: { score: 10, issues: [] },
+			};
 		}
 	}
 
@@ -486,7 +524,7 @@ export class DigestQualityService {
 		const llmProvider = createLLMProvider({
 			provider: "openai",
 			apiKey: this.openaiApiKey,
-			defaultModel: MODEL_CONFIG.OPENAI.ANALYSIS,
+			defaultModel: MODEL_CONFIG.OPENAI.PIPELINE_ANALYSIS,
 			defaultTemperature: 0.1,
 			defaultMaxTokens: 1500,
 		});
@@ -495,7 +533,7 @@ export class DigestQualityService {
 			const result = await llmProvider.generateStructuredOutput<{
 				issues: string[];
 			}>(consistencyPrompt, {
-				model: MODEL_CONFIG.OPENAI.ANALYSIS,
+				model: MODEL_CONFIG.OPENAI.PIPELINE_ANALYSIS,
 				temperature: 0.1,
 				maxTokens: 1500,
 			});
@@ -507,47 +545,6 @@ export class DigestQualityService {
 				error
 			);
 			return [];
-		}
-	}
-
-	/**
-	 * Check relevance - uses LLM to verify content relevance
-	 */
-	private async checkRelevance(digestData: SessionDigestData): Promise<{
-		score: number;
-		issues: string[];
-	}> {
-		if (!this.openaiApiKey) {
-			return { score: 10, issues: [] };
-		}
-
-		try {
-			const llmProvider = createLLMProvider({
-				provider: "openai",
-				apiKey: this.openaiApiKey,
-				defaultModel: MODEL_CONFIG.OPENAI.ANALYSIS,
-				defaultTemperature: 0.1,
-				defaultMaxTokens: 500,
-			});
-
-			const prompt = formatRelevanceAssessmentPrompt(digestData);
-
-			const result = await llmProvider.generateStructuredOutput<{
-				score: number;
-				issues: string[];
-			}>(prompt, {
-				model: MODEL_CONFIG.OPENAI.ANALYSIS,
-				temperature: 0.1,
-				maxTokens: 500,
-			});
-
-			return {
-				score: Math.max(0, Math.min(10, result.score)),
-				issues: result.issues || [],
-			};
-		} catch (error) {
-			console.error("[DigestQualityService] Relevance check error:", error);
-			return { score: 10, issues: [] }; // Default to no issues if check fails
 		}
 	}
 

--- a/tests/services/digest-quality-service.test.ts
+++ b/tests/services/digest-quality-service.test.ts
@@ -67,7 +67,7 @@ describe("DigestQualityService", () => {
 		});
 	});
 
-	describe("checkSpecificity", () => {
+	describe("checkSpecificityAndRelevance", () => {
 		it("should detect vague entries", async () => {
 			const digest: SessionDigestData = {
 				last_session_recap: {
@@ -93,11 +93,14 @@ describe("DigestQualityService", () => {
 				todo_checklist: [],
 			};
 
-			// checkSpecificity is async and requires OpenAI key, returns default score of 10 if no key
-			const result = await (service as any).checkSpecificity(digest);
+			const result = await (service as any).checkSpecificityAndRelevance(
+				digest
+			);
 			// Without OpenAI key, it returns default score of 10
-			expect(result.score).toBeDefined();
-			expect(Array.isArray(result.issues)).toBe(true);
+			expect(result.specificity.score).toBeDefined();
+			expect(Array.isArray(result.specificity.issues)).toBe(true);
+			expect(result.relevance.score).toBeDefined();
+			expect(Array.isArray(result.relevance.issues)).toBe(true);
 		});
 
 		it("should give high score for specific entries", async () => {
@@ -127,10 +130,11 @@ describe("DigestQualityService", () => {
 				todo_checklist: [],
 			};
 
-			// checkSpecificity is async and requires OpenAI key, returns default score of 10 if no key
-			const result = await (service as any).checkSpecificity(digest);
+			const result = await (service as any).checkSpecificityAndRelevance(
+				digest
+			);
 			// Without OpenAI key, it returns default score of 10
-			expect(result.score).toBeDefined();
+			expect(result.specificity.score).toBeDefined();
 		});
 	});
 

--- a/tests/services/openai-provider.test.ts
+++ b/tests/services/openai-provider.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OpenAIProvider } from "@/services/llm/openai-provider";
+
+const generateTextMock = vi.fn();
+const createOpenAIMock = vi.fn();
+const modelFactoryMock = vi.fn();
+
+vi.mock("ai", () => ({
+	APICallError: {
+		isInstance: () => false,
+	},
+	generateText: (...args: unknown[]) => generateTextMock(...args),
+	Output: {
+		json: vi.fn(() => ({ type: "json" })),
+	},
+}));
+
+vi.mock("@ai-sdk/openai", () => ({
+	createOpenAI: (...args: unknown[]) => createOpenAIMock(...args),
+}));
+
+describe("OpenAIProvider.generateStructuredOutput", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		modelFactoryMock.mockImplementation((modelId: string) => ({ modelId }));
+		createOpenAIMock.mockReturnValue({
+			chat: modelFactoryMock,
+		});
+		generateTextMock.mockResolvedValue({
+			output: { ok: true },
+			usage: { totalTokens: 123 },
+		});
+	});
+
+	it("uses json_schema response format when schema is provided", async () => {
+		const provider = new OpenAIProvider("test-key");
+		const schema = JSON.stringify({
+			type: "object",
+			properties: {
+				ok: { type: "boolean" },
+			},
+			required: ["ok"],
+		});
+
+		const result = await provider.generateStructuredOutput<{ ok: boolean }>(
+			"Return a result",
+			{
+				model: "gpt-5-mini",
+				schema,
+			}
+		);
+
+		expect(result).toEqual({ ok: true });
+		expect(generateTextMock).toHaveBeenCalledTimes(1);
+		const callArg = generateTextMock.mock.calls[0][0] as {
+			providerOptions?: {
+				openai?: {
+					responseFormat?: { type?: string };
+					response_format?: { type?: string };
+				};
+			};
+		};
+		expect(callArg.providerOptions?.openai?.responseFormat?.type).toBe(
+			"json_schema"
+		);
+		expect(callArg.providerOptions?.openai?.response_format?.type).toBe(
+			"json_schema"
+		);
+	});
+
+	it("falls back to json_object path when schema is invalid json", async () => {
+		const provider = new OpenAIProvider("test-key");
+		await provider.generateStructuredOutput("Return JSON", {
+			model: "gpt-5-mini",
+			schema: "{not-valid-json",
+		});
+
+		expect(generateTextMock).toHaveBeenCalledTimes(1);
+		const callArg = generateTextMock.mock.calls[0][0] as {
+			providerOptions?: {
+				openai?: {
+					responseFormat?: { type?: string };
+					response_format?: { type?: string };
+				};
+			};
+		};
+		expect(callArg.providerOptions?.openai?.responseFormat?.type).toBe(
+			"json_object"
+		);
+		expect(callArg.providerOptions?.openai?.response_format?.type).toBe(
+			"json_object"
+		);
+	});
+});


### PR DESCRIPTION
Split interactive vs background model tiers, use schema-first JSON output with fallback in the OpenAI provider, and reduce pipeline latency by combining digest quality calls and adding bounded community summary concurrency.

Made-with: Cursor