### PR TITLE
Eliminate trim COUNT query from message inserts. (#405)

### DIFF
--- a/src/dao/message-history-dao.ts
+++ b/src/dao/message-history-dao.ts
@@ -89,21 +89,6 @@ export class MessageHistoryDAO extends BaseDAOClass {
 		sessionId: string,
 		keepCount: number = this.MAX_MESSAGES_PER_SESSION
 	): Promise<void> {
-		// First, get total count before trimming (for logging)
-		const countSql = `
-      SELECT COUNT(*) as count
-      FROM message_history
-      WHERE session_id = ?
-    `;
-		const countResult = await this.queryFirst<{ count: number }>(countSql, [
-			sessionId,
-		]);
-		const totalCount = countResult?.count || 0;
-
-		if (totalCount <= keepCount) {
-			return; // No trimming needed
-		}
-
 		// Delete all messages for this session except the most recent keepCount.
 		// Use a subquery to avoid exceeding D1's 100-parameter limit (session_id + N keep IDs would exceed it).
 		const deleteSql = `
@@ -120,13 +105,6 @@ export class MessageHistoryDAO extends BaseDAOClass {
     `;
 
 		await this.execute(deleteSql, [sessionId, sessionId, keepCount]);
-
-		const deletedCount = totalCount - keepCount;
-		if (deletedCount > 0) {
-			console.log(
-				`[MessageHistoryDAO] Trimmed ${deletedCount} old message(s) for session ${sessionId} (kept ${keepCount} most recent)`
-			);
-		}
 	}
 
 	/**

--- a/tests/dao/message-history-dao.test.ts
+++ b/tests/dao/message-history-dao.test.ts
@@ -1,0 +1,92 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageHistoryDAO } from "../../src/dao/message-history-dao";
+
+const mockDB = {
+	prepare: vi.fn(),
+} as unknown as D1Database;
+
+describe("MessageHistoryDAO", () => {
+	let dao: MessageHistoryDAO;
+	let mockPreparedStatement: {
+		bind: ReturnType<typeof vi.fn>;
+		run: ReturnType<typeof vi.fn>;
+		all: ReturnType<typeof vi.fn>;
+		first: ReturnType<typeof vi.fn>;
+	};
+
+	beforeEach(() => {
+		dao = new MessageHistoryDAO(mockDB);
+		mockPreparedStatement = {
+			bind: vi.fn().mockReturnThis(),
+			run: vi.fn().mockResolvedValue({}),
+			all: vi.fn().mockResolvedValue({ results: [] }),
+			first: vi.fn().mockResolvedValue(null),
+		};
+		vi.clearAllMocks();
+		(mockDB.prepare as any).mockReturnValue(mockPreparedStatement);
+	});
+
+	it("createMessage inserts and trims without a count query", async () => {
+		await dao.createMessage({
+			sessionId: "session-1",
+			username: "alice",
+			campaignId: "campaign-1",
+			role: "user",
+			content: "hello",
+		});
+
+		const preparedSqls = (mockDB.prepare as any).mock.calls.map(
+			([sql]: [string]) => sql
+		);
+
+		expect(
+			preparedSqls.some((sql: string) =>
+				sql.includes("INSERT INTO message_history")
+			)
+		).toBe(true);
+		expect(
+			preparedSqls.some((sql: string) =>
+				sql.includes("DELETE FROM message_history")
+			)
+		).toBe(true);
+		expect(
+			preparedSqls.some((sql: string) => sql.includes("SELECT COUNT(*)"))
+		).toBe(false);
+		expect(mockPreparedStatement.bind).toHaveBeenCalledWith(
+			"session-1",
+			"session-1",
+			100
+		);
+	});
+
+	it("trimSessionMessages uses bounded delete with provided keep count", async () => {
+		await dao.trimSessionMessages("session-2", 25);
+
+		const preparedSqls = (mockDB.prepare as any).mock.calls.map(
+			([sql]: [string]) => sql
+		);
+		expect(
+			preparedSqls.some((sql: string) =>
+				sql.includes("DELETE FROM message_history")
+			)
+		).toBe(true);
+		expect(
+			preparedSqls.some((sql: string) => sql.includes("SELECT COUNT(*)"))
+		).toBe(false);
+		expect(mockPreparedStatement.bind).toHaveBeenCalledWith(
+			"session-2",
+			"session-2",
+			25
+		);
+	});
+
+	it("trimSessionMessages is a no-op when fewer rows exist than keep count", async () => {
+		mockPreparedStatement.run.mockResolvedValue({ meta: { changes: 0 } });
+
+		await expect(
+			dao.trimSessionMessages("session-3", 100)
+		).resolves.toBeUndefined();
+		expect(mockPreparedStatement.run).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Remove the pre-check count in session message trimming and add focused DAO tests to verify insert+trim behavior still works without the extra query.

Made-with: Cursor