### PR TITLE
Optimize entity filtering by moving hot-path predicates into SQL.

### DIFF
--- a/migrations/0006_entities_shard_status_indexing.sql
+++ b/migrations/0006_entities_shard_status_indexing.sql
@@ -1,0 +1,17 @@
+-- Add first-class shard status column for SQL-level filtering.
+ALTER TABLE entities ADD COLUMN shard_status text;
+
+-- Backfill shard status from existing metadata with approved fallback.
+UPDATE entities
+SET shard_status = COALESCE(
+	json_extract(metadata, '$.shardStatus'),
+	'approved'
+)
+WHERE shard_status IS NULL;
+
+-- Add composite indexes for common campaign filtering paths.
+CREATE INDEX IF NOT EXISTS idx_entities_campaign_source
+ON entities(campaign_id, source_id);
+
+CREATE INDEX IF NOT EXISTS idx_entities_campaign_shard_status_updated
+ON entities(campaign_id, shard_status, updated_at DESC);

--- a/src/dao/entity-dao.ts
+++ b/src/dao/entity-dao.ts
@@ -20,6 +20,7 @@ export interface EntityRecord {
 	confidence: number | null;
 	source_type: string | null;
 	source_id: string | null;
+	shard_status?: string | null;
 	embedding_id: string | null;
 	created_at: string;
 	updated_at: string;
@@ -37,6 +38,7 @@ export interface Entity {
 	confidence?: number;
 	sourceType?: string | null;
 	sourceId?: string | null;
+	shardStatus?: string | null;
 	embeddingId?: string | null;
 	createdAt: string;
 	updatedAt: string;
@@ -54,6 +56,7 @@ export interface CreateEntityInput {
 	confidence?: number | null;
 	sourceType?: string | null;
 	sourceId?: string | null;
+	shardStatus?: string | null;
 	embeddingId?: string | null;
 }
 
@@ -66,6 +69,7 @@ export interface UpdateEntityInput {
 	confidence?: number | null;
 	sourceType?: string | null;
 	sourceId?: string | null;
+	shardStatus?: string | null;
 	embeddingId?: string | null;
 	entityType?: string;
 }
@@ -162,6 +166,10 @@ export interface UpdateEntityDeduplicationInput {
 
 export class EntityDAO extends BaseDAOClass {
 	async createEntity(entity: CreateEntityInput): Promise<void> {
+		const metadataShardStatus = this.extractShardStatusFromMetadata(
+			entity.metadata
+		);
+		const shardStatus = entity.shardStatus ?? metadataShardStatus;
 		const sql = `
       INSERT INTO entities (
         id,
@@ -173,11 +181,12 @@ export class EntityDAO extends BaseDAOClass {
         confidence,
         source_type,
         source_id,
+        shard_status,
         embedding_id,
         created_at,
         updated_at
       ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
       )
     `;
 
@@ -191,6 +200,7 @@ export class EntityDAO extends BaseDAOClass {
 			entity.confidence ?? null,
 			entity.sourceType ?? null,
 			entity.sourceId ?? null,
+			shardStatus ?? null,
 			entity.embeddingId ?? null,
 		]);
 	}
@@ -232,6 +242,11 @@ export class EntityDAO extends BaseDAOClass {
 			values.push(updates.sourceId);
 		}
 
+		if (updates.shardStatus !== undefined) {
+			setClauses.push("shard_status = ?");
+			values.push(updates.shardStatus);
+		}
+
 		if (updates.embeddingId !== undefined) {
 			setClauses.push("embedding_id = ?");
 			values.push(updates.embeddingId);
@@ -240,6 +255,16 @@ export class EntityDAO extends BaseDAOClass {
 		if (updates.entityType !== undefined) {
 			setClauses.push("entity_type = ?");
 			values.push(updates.entityType);
+		}
+
+		if (updates.metadata !== undefined && updates.shardStatus === undefined) {
+			const metadataShardStatus = this.extractShardStatusFromMetadata(
+				updates.metadata
+			);
+			if (metadataShardStatus !== undefined) {
+				setClauses.push("shard_status = ?");
+				values.push(metadataShardStatus);
+			}
 		}
 
 		if (setClauses.length === 0) {
@@ -278,6 +303,11 @@ export class EntityDAO extends BaseDAOClass {
 		campaignId: string,
 		options: {
 			entityType?: string;
+			sourceId?: string;
+			resourceId?: string;
+			entityIds?: string[];
+			shardStatus?: string | string[];
+			excludeShardStatuses?: string[];
 			limit?: number;
 			offset?: number;
 			orderBy?: "updated_at" | "name";
@@ -289,6 +319,45 @@ export class EntityDAO extends BaseDAOClass {
 		if (options.entityType) {
 			conditions.push("entity_type = ?");
 			params.push(options.entityType);
+		}
+
+		if (options.sourceId) {
+			conditions.push("source_id = ?");
+			params.push(options.sourceId);
+		}
+
+		if (options.resourceId) {
+			conditions.push("json_extract(metadata, '$.resourceId') = ?");
+			params.push(options.resourceId);
+		}
+
+		if (options.entityIds && options.entityIds.length > 0) {
+			conditions.push("id IN (SELECT value FROM json_each(?))");
+			params.push(JSON.stringify(options.entityIds));
+		}
+
+		if (options.shardStatus) {
+			const statuses = Array.isArray(options.shardStatus)
+				? options.shardStatus
+				: [options.shardStatus];
+			if (statuses.length > 0) {
+				const placeholders = statuses.map(() => "?").join(", ");
+				conditions.push(`shard_status IN (${placeholders})`);
+				params.push(...statuses);
+			}
+		}
+
+		if (
+			options.excludeShardStatuses &&
+			options.excludeShardStatuses.length > 0
+		) {
+			const placeholders = options.excludeShardStatuses
+				.map(() => "?")
+				.join(", ");
+			conditions.push(
+				`(shard_status IS NULL OR shard_status NOT IN (${placeholders}))`
+			);
+			params.push(...options.excludeShardStatuses);
 		}
 
 		const orderBy =
@@ -1001,6 +1070,7 @@ export class EntityDAO extends BaseDAOClass {
 			confidence: record.confidence ?? undefined,
 			sourceType: record.source_type,
 			sourceId: record.source_id,
+			shardStatus: record.shard_status ?? undefined,
 			embeddingId: record.embedding_id,
 			createdAt: record.created_at,
 			updatedAt: record.updated_at,
@@ -1029,6 +1099,16 @@ export class EntityDAO extends BaseDAOClass {
 		} catch (_error) {
 			return undefined;
 		}
+	}
+
+	private extractShardStatusFromMetadata(
+		metadata: unknown
+	): string | undefined {
+		if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+			return undefined;
+		}
+		const candidate = (metadata as Record<string, unknown>).shardStatus;
+		return typeof candidate === "string" ? candidate : undefined;
 	}
 
 	async createDeduplicationEntry(

--- a/src/routes/campaign-graphrag.ts
+++ b/src/routes/campaign-graphrag.ts
@@ -160,21 +160,13 @@ export async function handleGetStagedShards(c: ContextWithAuth) {
 
 		// Get all entities for the campaign with staging status
 		const daoFactory = getDAOFactory(c.env);
-		const allEntities =
-			await daoFactory.entityDAO.listEntitiesByCampaign(campaignId);
-
-		// Filter to only staging entities (include stubs; they appear in approval pane with required fields)
-		const stagedEntities = allEntities.filter((entity) => {
-			const metadata = (entity.metadata as Record<string, unknown>) || {};
-			const shardStatus = metadata.shardStatus;
-			if (shardStatus !== "staging") {
-				return false;
+		const stagedEntities = await daoFactory.entityDAO.listEntitiesByCampaign(
+			campaignId,
+			{
+				shardStatus: "staging",
+				resourceId: resourceId || undefined,
 			}
-			if (resourceId && metadata.resourceId !== resourceId) {
-				return false;
-			}
-			return true;
-		});
+		);
 
 		console.log(
 			`[Server] Found ${stagedEntities.length} staged entities for campaign ${campaignId}`
@@ -301,13 +293,10 @@ export async function handleApproveShards(c: ContextWithAuth) {
 		const openaiApiKey = openaiApiKeyRaw.trim() || undefined;
 		const openaiEmbeddingService = new OpenAIEmbeddingService(openaiApiKey);
 
-		// Diagnostic: List all entities in campaign to help debug relationship target ID mismatches
-		const allCampaignEntities =
-			await daoFactory.entityDAO.listEntitiesByCampaign(campaignId);
-		console.log(
-			`[Server] Campaign has ${allCampaignEntities.length} total entities. Entity IDs:`,
-			allCampaignEntities.map((e) => `${e.id} (${e.name})`).join(", ")
-		);
+		// Diagnostic: report campaign entity count without materializing all rows.
+		const campaignEntityCount =
+			await daoFactory.entityDAO.getEntityCountByCampaign(campaignId);
+		console.log(`[Server] Campaign has ${campaignEntityCount} total entities.`);
 
 		// Validate first: stub shards must have required fields filled; fail entire request if any are insufficient
 		const insufficientStubs: Array<{
@@ -388,6 +377,7 @@ export async function handleApproveShards(c: ContextWithAuth) {
 
 			await daoFactory.entityDAO.updateEntity(entityId, {
 				metadata: updatedMetadata,
+				shardStatus: "approved",
 			});
 			touchedEntityIds.add(entityId);
 
@@ -613,6 +603,7 @@ export async function handleRejectShards(c: ContextWithAuth) {
 
 			await daoFactory.entityDAO.updateEntity(entityId, {
 				metadata: updatedMetadata,
+				shardStatus: "rejected",
 			});
 			touchedEntityIds.add(entityId);
 

--- a/src/routes/graph-visualization.ts
+++ b/src/routes/graph-visualization.ts
@@ -93,7 +93,17 @@ export async function handleGetGraphVisualization(c: ContextWithAuth) {
 		// Load all entities for the campaign to check filters (exclude stubs so they are not rendered)
 		const allEntities = await daoFactory.entityDAO.listEntitiesByCampaign(
 			campaignId,
-			{ limit: 10000 }
+			{
+				limit: 10000,
+				entityType:
+					entityTypes && entityTypes.length === 1 ? entityTypes[0] : undefined,
+				resourceId:
+					resourceIds && resourceIds.length === 1 ? resourceIds[0] : undefined,
+				shardStatus:
+					approvalStatuses && approvalStatuses.length > 0
+						? approvalStatuses
+						: undefined,
+			}
 		);
 		const nonStubEntities = allEntities.filter((e) => !isEntityStub(e));
 
@@ -273,18 +283,15 @@ export async function handleGetCommunityEntityGraph(c: ContextWithAuth) {
 			return c.json({ error: "Community not found" }, 404);
 		}
 
-		// Load entities in the community
-		const entityIdsSet = new Set(community.entityIds);
-		const allEntities = await daoFactory.entityDAO.listEntitiesByCampaign(
-			campaignId,
-			{ limit: 10000 }
-		);
+		// Load entities in the community with coarse SQL-level status filtering.
+		const communityEntitiesRaw =
+			await daoFactory.entityDAO.listEntitiesByCampaign(campaignId, {
+				entityIds: community.entityIds,
+				excludeShardStatuses: ["rejected", "deleted"],
+			});
 
-		// Filter to only entities in this community, not rejected/ignored, and not stubs
-		const communityEntities = allEntities.filter((entity) => {
-			if (!entityIdsSet.has(entity.id)) {
-				return false;
-			}
+		// Preserve ignored/stub filtering behavior in app layer.
+		const communityEntities = communityEntitiesRaw.filter((entity) => {
 			if (isEntityStub(entity)) {
 				return false;
 			}

--- a/src/services/campaign/campaign-context-sync-service.ts
+++ b/src/services/campaign/campaign-context-sync-service.ts
@@ -340,6 +340,7 @@ export class CampaignContextSyncService {
 					entityType: "conversational_context",
 					name: noteTitle, // Individual shard title appears as entity name
 					content: { text: noteContent },
+					shardStatus: "staging",
 					metadata: {
 						shardStatus: "staging",
 						resourceId,

--- a/src/services/campaign/entity-staging-service.ts
+++ b/src/services/campaign/entity-staging-service.ts
@@ -285,6 +285,7 @@ export async function stageEntitiesFromResource(
 					await daoFactory.entityDAO.updateEntity(existingPC.id, {
 						content: characterData,
 						metadata: finalMetadata,
+						shardStatus: "staging",
 						sourceType: "file_upload",
 						sourceId: normalizedResource.id,
 					});
@@ -310,6 +311,7 @@ export async function stageEntitiesFromResource(
 						entityType: "pcs",
 						name: characterName,
 						content: characterData,
+						shardStatus: "staging",
 						metadata: finalMetadata,
 						sourceType: "file_upload",
 						sourceId: normalizedResource.id,
@@ -759,6 +761,10 @@ export async function stageEntitiesFromResource(
 					name: normalizedName,
 					content: mergedContent,
 					metadata: mergedMeta,
+					shardStatus:
+						existingMetadata.shardStatus === "approved"
+							? "approved"
+							: "staging",
 					confidence: (extracted.metadata.confidence as number) ?? null,
 					sourceType: "file_upload",
 					sourceId: normalizedResource.id,
@@ -844,6 +850,10 @@ export async function stageEntitiesFromResource(
 					name: normalizedName,
 					content: mergedContent,
 					metadata: mergedMeta,
+					shardStatus:
+						existingMetadata.shardStatus === "approved"
+							? "approved"
+							: "staging",
 					confidence: (extracted.metadata.confidence as number) ?? null,
 					sourceType: "file_upload",
 					sourceId: normalizedResource.id,
@@ -885,6 +895,7 @@ export async function stageEntitiesFromResource(
 				entityType,
 				name: normalizedName,
 				content: extracted.content,
+				shardStatus: "staging",
 				metadata: newMeta,
 				confidence: (extracted.metadata.confidence as number) ?? null,
 				sourceType: "file_upload",

--- a/src/tools/campaign-context/entity-tools.ts
+++ b/src/tools/campaign-context/entity-tools.ts
@@ -715,14 +715,9 @@ export const updateEntityTypeTool = tool({
 
 			// Also update ALL other entities with the same name in this campaign
 			// This ensures consistency when there are duplicates
-			const allEntitiesWithSameName =
-				await daoFactory.entityDAO.listEntitiesByCampaign(campaignId, {
-					limit: 1000, // Large limit to catch all duplicates
-				});
-
-			const duplicates = allEntitiesWithSameName.filter(
-				(e) => e.name === entity.name && e.id !== entityId
-			);
+			const duplicates = (
+				await daoFactory.entityDAO.findEntitiesByName(campaignId, entity.name)
+			).filter((e) => e.id !== entityId);
 
 			const updatedDuplicates: string[] = [];
 			for (const duplicate of duplicates) {

--- a/src/tools/campaign-context/search-tools.ts
+++ b/src/tools/campaign-context/search-tools.ts
@@ -477,17 +477,15 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 										const fetchLimit = queryIntent.isListAll
 											? effectiveLimit + 1
 											: 100;
-										const allEntities =
+										entities =
 											await daoFactory.entityDAO.listEntitiesByCampaign(
 												campaignId,
 												{
 													limit: fetchLimit,
 													entityType: targetEntityType || undefined,
+													entityIds,
 												}
 											);
-										entities = allEntities.filter((e) =>
-											entityIds.includes(e.id)
-										);
 
 										// For list-all queries, get total count for accurate reporting
 										if (queryIntent.isListAll && totalCount === undefined) {
@@ -586,17 +584,15 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 
 											if (entityIds.length > 0) {
 												// CRITICAL: Always filter by entityType if specified
-												const allEntities =
+												entities =
 													await daoFactory.entityDAO.listEntitiesByCampaign(
 														campaignId,
 														{
 															limit: 100,
 															entityType: targetEntityType || undefined,
+															entityIds,
 														}
 													);
-												entities = allEntities.filter((e) =>
-													entityIds.includes(e.id)
-												);
 												console.log(
 													`[Tool] searchCampaignContext - Found ${entities.length} entities via PlanningContextService fallback`
 												);
@@ -785,14 +781,6 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 						) {
 							try {
 								const communityDAO = daoFactory.communityDAO;
-								const allCampaignEntities =
-									await daoFactory.entityDAO.listEntitiesByCampaign(
-										campaignId,
-										{ limit: 1000 }
-									);
-								const allEntitiesMap = new Map(
-									allCampaignEntities.map((e) => [e.id, e])
-								);
 
 								// Find communities for each found entity
 								const communityIdsSet = new Set<string>();
@@ -820,6 +808,27 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 										await communityDAO.listCommunitiesByCampaign(campaignId);
 									const relevantCommunities = allCommunities.filter((c) =>
 										communityIdsSet.has(c.id)
+									);
+									const candidateEntityIds = Array.from(
+										new Set(
+											relevantCommunities.flatMap(
+												(community) => community.entityIds
+											)
+										)
+									);
+									const candidateEntities =
+										candidateEntityIds.length > 0
+											? await daoFactory.entityDAO.listEntitiesByCampaign(
+													campaignId,
+													{
+														limit: 1000,
+														entityIds: candidateEntityIds,
+														excludeShardStatuses: ["rejected", "deleted"],
+													}
+												)
+											: [];
+									const allEntitiesMap = new Map(
+										candidateEntities.map((e) => [e.id, e])
 									);
 
 									for (const community of relevantCommunities) {
@@ -964,6 +973,7 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 						if (relatedEntityIds.size > 0) {
 							const relatedEntities =
 								await daoFactory.entityDAO.listEntitiesByCampaign(campaignId, {
+									entityIds: Array.from(relatedEntityIds),
 									limit: 1000,
 								});
 							for (const relatedEntity of relatedEntities) {
@@ -1320,14 +1330,12 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 							uniqueTraversedEntityIds.length > 0
 						) {
 							// Fetch full entity details for traversed entities
-							const allCampaignEntities =
+							const traversedEntities =
 								await daoFactory.entityDAO.listEntitiesByCampaign(campaignId, {
+									entityIds: uniqueTraversedEntityIds,
 									limit: 1000,
+									excludeShardStatuses: ["rejected", "deleted"],
 								});
-
-							const traversedEntities = allCampaignEntities.filter((entity) =>
-								uniqueTraversedEntityIds.includes(entity.id)
-							);
 
 							// Filter out rejected/ignored/stub entities
 							const approvedTraversedEntities = traversedEntities.filter(
@@ -1399,7 +1407,10 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 								const allRelatedEntities =
 									await daoFactory.entityDAO.listEntitiesByCampaign(
 										campaignId,
-										{ limit: 1000 }
+										{
+											limit: 1000,
+											entityIds: Array.from(traversedRelatedEntityIds),
+										}
 									);
 								for (const relatedEntity of allRelatedEntities) {
 									if (traversedRelatedEntityIds.has(relatedEntity.id)) {
@@ -1417,7 +1428,10 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 								const allSourceEntities =
 									await daoFactory.entityDAO.listEntitiesByCampaign(
 										campaignId,
-										{ limit: 1000 }
+										{
+											limit: 1000,
+											entityIds: traverseFromEntityIds,
+										}
 									);
 								for (const sourceEntity of allSourceEntities) {
 									if (traverseFromEntityIds.includes(sourceEntity.id)) {

--- a/src/tools/campaign-context/suggestion-tools.ts
+++ b/src/tools/campaign-context/suggestion-tools.ts
@@ -807,7 +807,9 @@ async function performSemanticChecklistAnalysis(
 			const entityDAO = daoFactory.entityDAO;
 			const graphService = new EntityGraphService(entityDAO);
 
-			const allEntities = await entityDAO.listEntitiesByCampaign(campaignId);
+			const allEntities = await entityDAO.listEntitiesByCampaign(campaignId, {
+				excludeShardStatuses: ["rejected", "deleted"],
+			});
 
 			const entityTypeCounts: Record<string, number> = {};
 			for (const entity of allEntities) {

--- a/tests/dao/entity-dao.test.ts
+++ b/tests/dao/entity-dao.test.ts
@@ -45,6 +45,7 @@ describe("EntityDAO", () => {
 			null,
 			null,
 			null,
+			null,
 			null
 		);
 		expect(mockStmt.run).toHaveBeenCalled();
@@ -106,6 +107,51 @@ describe("EntityDAO", () => {
 			expect.stringContaining("entity_type")
 		);
 		expect(mockStmt.bind).toHaveBeenCalledWith("c1", "location");
+	});
+
+	it("listEntitiesByCampaign supports SQL shard status and source filters", async () => {
+		mockStmt.all.mockResolvedValue({ results: [] });
+
+		await dao.listEntitiesByCampaign("c1", {
+			sourceId: "resource-1",
+			shardStatus: ["staging", "approved"],
+			excludeShardStatuses: ["rejected"],
+			limit: 25,
+		});
+
+		expect(mockDB.prepare).toHaveBeenCalledWith(
+			expect.stringContaining("source_id = ?")
+		);
+		expect(mockDB.prepare).toHaveBeenCalledWith(
+			expect.stringContaining("shard_status IN")
+		);
+		expect(mockDB.prepare).toHaveBeenCalledWith(
+			expect.stringContaining("shard_status NOT IN")
+		);
+		expect(mockStmt.bind).toHaveBeenCalledWith(
+			"c1",
+			"resource-1",
+			"staging",
+			"approved",
+			"rejected",
+			25
+		);
+	});
+
+	it("listEntitiesByCampaign supports entityIds through json_each", async () => {
+		mockStmt.all.mockResolvedValue({ results: [] });
+
+		await dao.listEntitiesByCampaign("c1", {
+			entityIds: ["e1", "e2"],
+		});
+
+		expect(mockDB.prepare).toHaveBeenCalledWith(
+			expect.stringContaining("json_each")
+		);
+		expect(mockStmt.bind).toHaveBeenCalledWith(
+			"c1",
+			JSON.stringify(["e1", "e2"])
+		);
 	});
 
 	it("getEntitiesByIds returns empty array for empty input", async () => {


### PR DESCRIPTION
Add shard-status schema/index support and refactor high-traffic entity call sites to avoid full campaign scans while keeping shard lifecycle writes synchronized.

Made-with: Cursor