### PR TITLE
Fix tool result trimming performance with batched importance lookups.

### DIFF
--- a/src/dao/entity-importance-dao.ts
+++ b/src/dao/entity-importance-dao.ts
@@ -126,6 +126,23 @@ export class EntityImportanceDAO extends BaseDAOClass {
 		return record ? this.mapRecord(record) : null;
 	}
 
+	async getImportanceByEntityIds(
+		entityIds: string[]
+	): Promise<EntityImportance[]> {
+		if (entityIds.length === 0) {
+			return [];
+		}
+
+		const placeholders = entityIds.map(() => "?").join(", ");
+		const sql = `
+      SELECT * FROM entity_importance
+      WHERE entity_id IN (${placeholders})
+    `;
+
+		const records = await this.queryAll<EntityImportanceRecord>(sql, entityIds);
+		return records.map((record) => this.mapRecord(record));
+	}
+
 	async getImportanceForCampaign(
 		campaignId: string,
 		options: EntityImportanceQueryOptions = {}

--- a/src/lib/tool-result-trimming.ts
+++ b/src/lib/tool-result-trimming.ts
@@ -32,11 +32,10 @@ function estimateToolResultTokens(result: unknown): number {
  * Get priority score for a result item
  * Higher score = higher priority (keep these)
  */
-async function getItemPriority(
+function getItemPriority(
 	item: TrimmableResult,
-	env: any,
-	campaignId?: string | null
-): Promise<number> {
+	importanceByEntityId: Map<string, number>
+): number {
 	let priority = 0;
 
 	// Use similarity/relevancy score if available (from semantic search)
@@ -48,26 +47,38 @@ async function getItemPriority(
 	}
 
 	// Boost priority for entities with high importance scores
-	if (item.entityId && campaignId && env?.DB) {
-		try {
-			const daoFactory = getDAOFactory(env);
-			const importance = await daoFactory.entityImportanceDAO.getImportance(
-				item.entityId
-			);
-			if (importance) {
-				// Add importance score (0-100) to priority
-				priority += importance.importanceScore;
-			}
-		} catch (error) {
-			// Ignore errors - importance lookup is optional
-			console.warn(
-				`[ToolResultTrimming] Failed to get importance for entity ${item.entityId}:`,
-				error
-			);
-		}
+	if (item.entityId) {
+		priority += importanceByEntityId.get(item.entityId) ?? 0;
 	}
 
 	return priority;
+}
+
+function buildTrimmedPayload(
+	result: ToolResultData,
+	isNested: boolean,
+	arrayKey: "results" | "entities",
+	keptItems: TrimmableResult[]
+): ToolResultData {
+	const trimmedPayload = { ...result };
+
+	if (isNested && result.data && typeof result.data === "object") {
+		const trimmedData = { ...(result.data as ToolResultData) };
+		if (arrayKey === "results") {
+			trimmedData.results = keptItems;
+		} else {
+			trimmedData.entities = keptItems;
+		}
+		trimmedPayload.data = trimmedData;
+		return trimmedPayload;
+	}
+
+	if (arrayKey === "results") {
+		trimmedPayload.results = keptItems;
+	} else {
+		trimmedPayload.entities = keptItems;
+	}
+	return trimmedPayload;
 }
 
 /**
@@ -124,6 +135,9 @@ export async function trimToolResultsByRelevancy(
 	if (!itemsToTrim || itemsToTrim.length === 0) {
 		return toolResult; // Nothing to trim
 	}
+	if (!arrayKey) {
+		return toolResult;
+	}
 
 	// Estimate current token count
 	const currentTokens = estimateToolResultTokens(toolResult);
@@ -132,93 +146,86 @@ export async function trimToolResultsByRelevancy(
 		return toolResult; // Within limit, no trimming needed
 	}
 
-	console.log(
-		`[ToolResultTrimming] Tool result exceeds token limit: ${currentTokens} > ${maxTokens}. Trimming ${itemsToTrim.length} items by relevancy...`
-	);
+	const importanceByEntityId = new Map<string, number>();
+	const shouldFetchImportance = Boolean(campaignId && env?.DB);
+	if (shouldFetchImportance) {
+		try {
+			const uniqueEntityIds = Array.from(
+				new Set(
+					itemsToTrim
+						.map((item) => item.entityId)
+						.filter(
+							(entityId): entityId is string => typeof entityId === "string"
+						)
+				)
+			);
 
-	// Calculate priority scores for all items
-	const itemsWithPriority = await Promise.all(
-		itemsToTrim.map(async (item) => ({
-			item,
-			priority: await getItemPriority(item, env, campaignId),
-		}))
-	);
+			if (uniqueEntityIds.length > 0) {
+				const daoFactory = getDAOFactory(env);
+				const importanceRecords =
+					await daoFactory.entityImportanceDAO.getImportanceByEntityIds(
+						uniqueEntityIds
+					);
+				for (const importance of importanceRecords) {
+					importanceByEntityId.set(
+						importance.entityId,
+						importance.importanceScore
+					);
+				}
+			}
+		} catch (error) {
+			// Ignore errors - importance lookup is optional.
+			console.warn(
+				"[ToolResultTrimming] Failed to load batch entity importance:",
+				error
+			);
+		}
+	}
+
+	// Calculate priority scores for all items.
+	const itemsWithPriority = itemsToTrim.map((item) => ({
+		item,
+		priority: getItemPriority(item, importanceByEntityId),
+	}));
 
 	// Sort by priority (highest first)
 	itemsWithPriority.sort((a, b) => b.priority - a.priority);
 
-	// Binary search to find how many items we can keep
-	let left = 0;
-	let right = itemsWithPriority.length;
-	let bestCount = 0;
+	// Greedy trim: remove lowest-priority items until we fit.
+	const keptItems = itemsWithPriority.map((i) => i.item);
+	while (keptItems.length > 0) {
+		const trimmedPayload = buildTrimmedPayload(
+			result,
+			isNested,
+			arrayKey,
+			keptItems
+		);
+		const candidateResult = inner
+			? {
+					...raw,
+					result: {
+						...inner,
+						data: trimmedPayload,
+					},
+				}
+			: trimmedPayload;
 
-	while (left <= right) {
-		const mid = Math.floor((left + right) / 2);
-		const keptItems = itemsWithPriority.slice(0, mid).map((i) => i.item);
+		if (estimateToolResultTokens(candidateResult) <= maxTokens) {
+			return candidateResult;
+		}
 
-		// Reconstruct result with trimmed items
-		const trimmedResult = { ...result };
-		if (isNested && result.data && typeof result.data === "object") {
-			const trimmedData = { ...(result.data as ToolResultData) };
-			if (arrayKey === "results") {
-				trimmedData.results = keptItems;
-			} else if (arrayKey === "entities") {
-				trimmedData.entities = keptItems;
+		keptItems.pop();
+	}
+
+	// Nothing fit within budget; return same shape with an empty result list.
+	const emptyPayload = buildTrimmedPayload(result, isNested, arrayKey, []);
+	return inner
+		? {
+				...raw,
+				result: {
+					...inner,
+					data: emptyPayload,
+				},
 			}
-			trimmedResult.data = trimmedData;
-		} else {
-			if (arrayKey === "results") {
-				trimmedResult.results = keptItems;
-			} else if (arrayKey === "entities") {
-				trimmedResult.entities = keptItems;
-			}
-		}
-
-		const trimmedTokens = estimateToolResultTokens(trimmedResult);
-
-		if (trimmedTokens <= maxTokens) {
-			bestCount = mid;
-			left = mid + 1;
-		} else {
-			right = mid - 1;
-		}
-	}
-
-	// Keep top N items by priority
-	const keptItems = itemsWithPriority.slice(0, bestCount).map((i) => i.item);
-
-	const trimmedCount = itemsToTrim.length - keptItems.length;
-	console.log(
-		`[ToolResultTrimming] Trimmed ${trimmedCount} items (kept ${keptItems.length} highest priority items)`
-	);
-
-	// Reconstruct result with trimmed items
-	const trimmedPayload = { ...result };
-	if (isNested && result.data && typeof result.data === "object") {
-		const trimmedData = { ...(result.data as ToolResultData) };
-		if (arrayKey === "results") {
-			trimmedData.results = keptItems;
-		} else if (arrayKey === "entities") {
-			trimmedData.entities = keptItems;
-		}
-		trimmedPayload.data = trimmedData;
-	} else {
-		if (arrayKey === "results") {
-			trimmedPayload.results = keptItems;
-		} else if (arrayKey === "entities") {
-			trimmedPayload.entities = keptItems;
-		}
-	}
-
-	// If we unwrapped envelope format, rewrap so the agent gets the same shape
-	if (inner) {
-		return {
-			...raw,
-			result: {
-				...inner,
-				data: trimmedPayload,
-			},
-		};
-	}
-	return trimmedPayload;
+		: emptyPayload;
 }

--- a/tests/dao/entity-importance-dao.test.ts
+++ b/tests/dao/entity-importance-dao.test.ts
@@ -89,6 +89,75 @@ describe("EntityImportanceDAO", () => {
 		expect(importance).toBeNull();
 	});
 
+	it("gets importance for multiple entity IDs in a single query", async () => {
+		const records = [
+			{
+				entity_id: "entity-1",
+				campaign_id: "campaign-123",
+				pagerank: 0.8,
+				betweenness_centrality: 0.6,
+				hierarchy_level: 90,
+				importance_score: 80.0,
+				computed_at: "2025-01-01T00:00:00Z",
+			},
+			{
+				entity_id: "entity-2",
+				campaign_id: "campaign-123",
+				pagerank: 0.5,
+				betweenness_centrality: 0.3,
+				hierarchy_level: 75,
+				importance_score: 65.0,
+				computed_at: "2025-01-01T00:00:00Z",
+			},
+		];
+		mockStatement.all.mockResolvedValue({ results: records });
+
+		const importanceList = await dao.getImportanceByEntityIds([
+			"entity-1",
+			"entity-2",
+		]);
+
+		expect(mockDB.prepare).toHaveBeenCalledWith(
+			expect.stringContaining("WHERE entity_id IN (?, ?)")
+		);
+		expect(mockStatement.bind).toHaveBeenCalledWith("entity-1", "entity-2");
+		expect(importanceList).toHaveLength(2);
+		expect(importanceList.map((item) => item.entityId)).toEqual([
+			"entity-1",
+			"entity-2",
+		]);
+	});
+
+	it("returns empty array when no entity IDs are provided", async () => {
+		const importanceList = await dao.getImportanceByEntityIds([]);
+
+		expect(importanceList).toEqual([]);
+		expect(mockDB.prepare).not.toHaveBeenCalled();
+	});
+
+	it("returns only matching records for mixed existing and missing IDs", async () => {
+		const records = [
+			{
+				entity_id: "entity-1",
+				campaign_id: "campaign-123",
+				pagerank: 0.8,
+				betweenness_centrality: 0.6,
+				hierarchy_level: 90,
+				importance_score: 80.0,
+				computed_at: "2025-01-01T00:00:00Z",
+			},
+		];
+		mockStatement.all.mockResolvedValue({ results: records });
+
+		const importanceList = await dao.getImportanceByEntityIds([
+			"entity-1",
+			"entity-missing",
+		]);
+
+		expect(importanceList).toHaveLength(1);
+		expect(importanceList[0].entityId).toBe("entity-1");
+	});
+
 	it("gets importance for campaign with options", async () => {
 		const records = [
 			{

--- a/tests/lib/tool-result-trimming.test.ts
+++ b/tests/lib/tool-result-trimming.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { estimateTokenCount } from "@/lib/token-utils";
+import { trimToolResultsByRelevancy } from "@/lib/tool-result-trimming";
+
+const mockGetImportanceByEntityIds = vi.fn();
+
+vi.mock("@/dao/dao-factory", () => ({
+	getDAOFactory: vi.fn(() => ({
+		entityImportanceDAO: {
+			getImportanceByEntityIds: mockGetImportanceByEntityIds,
+		},
+	})),
+}));
+
+describe("trimToolResultsByRelevancy", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetImportanceByEntityIds.mockResolvedValue([]);
+	});
+
+	it("uses one batch importance lookup and keeps higher-priority items", async () => {
+		mockGetImportanceByEntityIds.mockResolvedValue([
+			{
+				entityId: "entity-1",
+				campaignId: "campaign-1",
+				pagerank: 0.9,
+				betweennessCentrality: 0.9,
+				hierarchyLevel: 90,
+				importanceScore: 100,
+				computedAt: "2026-01-01T00:00:00Z",
+			},
+		]);
+
+		const toolResult = {
+			results: [
+				{ entityId: "entity-1", score: 0.1, content: "a".repeat(320) },
+				{ entityId: "entity-2", score: 0.9, content: "b".repeat(320) },
+			],
+		};
+
+		const trimmed = (await trimToolResultsByRelevancy(
+			toolResult,
+			120,
+			{ DB: {} },
+			"campaign-1"
+		)) as { results: Array<{ entityId: string }> };
+
+		expect(mockGetImportanceByEntityIds).toHaveBeenCalledTimes(1);
+		expect(mockGetImportanceByEntityIds).toHaveBeenCalledWith([
+			"entity-1",
+			"entity-2",
+		]);
+		expect(trimmed.results).toHaveLength(1);
+		expect(trimmed.results[0].entityId).toBe("entity-1");
+		expect(estimateTokenCount(JSON.stringify(trimmed))).toBeLessThanOrEqual(
+			120
+		);
+	});
+
+	it("preserves envelope shape when trimming nested result data", async () => {
+		const toolResult = {
+			toolCallId: "call-1",
+			result: {
+				success: true,
+				data: {
+					results: [
+						{ entityId: "entity-1", score: 0.5, content: "x".repeat(280) },
+						{ entityId: "entity-2", score: 0.4, content: "y".repeat(280) },
+					],
+				},
+			},
+		};
+
+		const trimmed = (await trimToolResultsByRelevancy(
+			toolResult,
+			100,
+			{ DB: {} },
+			"campaign-1"
+		)) as {
+			toolCallId: string;
+			result: {
+				success: boolean;
+				data: { results: Array<{ entityId: string }> };
+			};
+		};
+
+		expect(trimmed.toolCallId).toBe("call-1");
+		expect(trimmed.result.success).toBe(true);
+		expect(Array.isArray(trimmed.result.data.results)).toBe(true);
+		expect(trimmed.result.data.results.length).toBeLessThan(2);
+		expect(estimateTokenCount(JSON.stringify(trimmed))).toBeLessThanOrEqual(
+			100
+		);
+	});
+
+	it("returns original result and skips DAO lookup when already within budget", async () => {
+		const toolResult = {
+			results: [{ entityId: "entity-1", score: 0.8, content: "short" }],
+		};
+
+		const trimmed = await trimToolResultsByRelevancy(
+			toolResult,
+			1000,
+			{ DB: {} },
+			"campaign-1"
+		);
+
+		expect(trimmed).toEqual(toolResult);
+		expect(mockGetImportanceByEntityIds).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Replace per-item entity importance queries with a single batched DAO call and switch trimming to a greedy low-priority removal loop to reduce serialization overhead while preserving output shape.

Made-with: Cursor