### PR TITLE
Centralize graph and importance service access through DAOFactory.

### DIFF
--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -1,5 +1,9 @@
 import type { D1Database } from "@cloudflare/workers-types";
 import { DAOFactoryError } from "@/lib/errors";
+import { CommunitySummaryService } from "@/services/graph/community-summary-service";
+import { EntityGraphService } from "@/services/graph/entity-graph-service";
+import { EntityImportanceService } from "@/services/graph/entity-importance-service";
+import { RebuildTriggerService } from "@/services/graph/rebuild-trigger-service";
 import { AuthUserDAO } from "./auth-user-dao";
 import { CampaignDAO } from "./campaign-dao";
 import { CampaignResourceProposalDAO } from "./campaign-resource-proposal-dao";
@@ -53,6 +57,10 @@ export interface DAOFactory {
 	playerCharacterClaimDAO: PlayerCharacterClaimDAO;
 	campaignShareLinkDAO: CampaignShareLinkDAO;
 	campaignResourceProposalDAO: CampaignResourceProposalDAO;
+	entityGraphService: EntityGraphService;
+	entityImportanceService: EntityImportanceService;
+	rebuildTriggerService: RebuildTriggerService;
+	communitySummaryService: CommunitySummaryService;
 
 	getStorageUsage(username: string): Promise<UserStorageUsage>;
 }
@@ -79,6 +87,10 @@ export class DAOFactoryImpl implements DAOFactory {
 	public readonly playerCharacterClaimDAO: PlayerCharacterClaimDAO;
 	public readonly campaignShareLinkDAO: CampaignShareLinkDAO;
 	public readonly campaignResourceProposalDAO: CampaignResourceProposalDAO;
+	private _entityGraphService: EntityGraphService | null = null;
+	private _entityImportanceService: EntityImportanceService | null = null;
+	private _rebuildTriggerService: RebuildTriggerService | null = null;
+	private _communitySummaryService: CommunitySummaryService | null = null;
 
 	constructor(db: D1Database) {
 		this.authUserDAO = new AuthUserDAO(db);
@@ -108,9 +120,56 @@ export class DAOFactoryImpl implements DAOFactory {
 		return this.userDAO.getStorageUsage(username);
 	}
 
-	getDAO<T extends keyof Omit<DAOFactory, "getStorageUsage">>(
-		name: T
-	): DAOFactory[T] {
+	get entityGraphService(): EntityGraphService {
+		if (!this._entityGraphService) {
+			this._entityGraphService = new EntityGraphService(this.entityDAO);
+		}
+		return this._entityGraphService;
+	}
+
+	get entityImportanceService(): EntityImportanceService {
+		if (!this._entityImportanceService) {
+			this._entityImportanceService = new EntityImportanceService(
+				this.entityDAO,
+				this.communityDAO,
+				this.entityImportanceDAO
+			);
+		}
+		return this._entityImportanceService;
+	}
+
+	get rebuildTriggerService(): RebuildTriggerService {
+		if (!this._rebuildTriggerService) {
+			this._rebuildTriggerService = new RebuildTriggerService(
+				this.campaignDAO,
+				this.entityDAO,
+				this.rebuildStatusDAO,
+				this.graphRebuildDirtyDAO
+			);
+		}
+		return this._rebuildTriggerService;
+	}
+
+	get communitySummaryService(): CommunitySummaryService {
+		if (!this._communitySummaryService) {
+			this._communitySummaryService = new CommunitySummaryService(
+				this.entityDAO,
+				this.communitySummaryDAO
+			);
+		}
+		return this._communitySummaryService;
+	}
+
+	getDAO<
+		T extends keyof Omit<
+			DAOFactory,
+			| "getStorageUsage"
+			| "entityGraphService"
+			| "entityImportanceService"
+			| "rebuildTriggerService"
+			| "communitySummaryService"
+		>,
+	>(name: T): DAOFactory[T] {
 		return this[name];
 	}
 

--- a/src/routes/campaign-graphrag.ts
+++ b/src/routes/campaign-graphrag.ts
@@ -8,9 +8,7 @@ import { getEnvVar } from "@/lib/env-utils";
 import { notifyCampaignMembers } from "@/lib/notifications";
 import { type ContextWithAuth, verifyCampaignAccess } from "@/lib/route-utils";
 import { OpenAIEmbeddingService } from "@/services/embedding/openai-embedding-service";
-import { EntityGraphService } from "@/services/graph/entity-graph-service";
 import { getGraphServices } from "@/services/graph/graph-service-factory";
-import { RebuildTriggerService } from "@/services/graph/rebuild-trigger-service";
 import { createLLMProvider } from "@/services/llm/llm-provider-factory";
 import { getLLMRateLimitService } from "@/services/llm/llm-rate-limit-service";
 import { EntityEmbeddingService } from "@/services/vectorize/entity-embedding-service";
@@ -48,12 +46,7 @@ async function checkAndRunCommunityDetection(
 	relationshipKeys: DirtyRelationshipRef[] = [],
 	username?: string
 ): Promise<void> {
-	const rebuildTriggerService = new RebuildTriggerService(
-		daoFactory.campaignDAO,
-		daoFactory.entityDAO,
-		daoFactory.rebuildStatusDAO,
-		daoFactory.graphRebuildDirtyDAO
-	);
+	const rebuildTriggerService = daoFactory.rebuildTriggerService;
 	if (!daoFactory.graphRebuildDirtyDAO) {
 		console.warn(
 			`[Server] graphRebuildDirtyDAO unavailable, skipping async rebuild trigger for campaign ${campaignId}`
@@ -285,7 +278,7 @@ export async function handleApproveShards(c: ContextWithAuth) {
 		}
 
 		const daoFactory = getDAOFactory(c.env);
-		const graphService = new EntityGraphService(daoFactory.entityDAO);
+		const graphService = daoFactory.entityGraphService;
 		const embeddingService = new EntityEmbeddingService(c.env.VECTORIZE);
 		const openaiApiKeyRaw = await getEnvVar(c.env, "OPENAI_API_KEY", false);
 		const openaiApiKey = openaiApiKeyRaw.trim() || undefined;
@@ -566,7 +559,7 @@ export async function handleRejectShards(c: ContextWithAuth) {
 		}
 
 		const daoFactory = getDAOFactory(c.env);
-		const graphService = new EntityGraphService(daoFactory.entityDAO);
+		const graphService = daoFactory.entityGraphService;
 
 		let rejectedCount = 0;
 		const relationshipCount = 0;

--- a/src/routes/entities.ts
+++ b/src/routes/entities.ts
@@ -17,8 +17,8 @@ import {
 } from "@/lib/text-chunking-utils";
 import { DirectFileContentExtractionProvider } from "@/services/campaign/impl/direct-file-content-extraction-provider";
 import type { AuthPayload } from "@/services/core/auth-service";
-import { EntityGraphService } from "@/services/graph/entity-graph-service";
-import { EntityImportanceService } from "@/services/graph/entity-importance-service";
+import type { EntityGraphService } from "@/services/graph/entity-graph-service";
+import type { EntityImportanceService } from "@/services/graph/entity-importance-service";
 import { WorldStateChangelogService } from "@/services/graph/world-state-changelog-service";
 import { EntityDeduplicationService } from "@/services/rag/entity-deduplication-service";
 import { EntityExtractionPipeline } from "@/services/rag/entity-extraction-pipeline";
@@ -43,14 +43,14 @@ interface CampaignHandlerContext {
 
 function buildEntityServiceAccessor(
 	c: ContextWithAuth,
-	entityDAO: EntityDAO
+	entityDAO: EntityDAO,
+	graphService: EntityGraphService
 ): () => EntityServiceBundle {
 	let bundle: EntityServiceBundle | null = null;
 	return () => {
 		if (!bundle) {
 			const embeddingService = new EntityEmbeddingService(c.env.VECTORIZE);
 			const extractionService = new EntityExtractionService(null);
-			const graphService = new EntityGraphService(entityDAO);
 			bundle = {
 				embeddingService,
 				extractionService,
@@ -106,7 +106,11 @@ async function withCampaignContext(
 
 		const daoFactory = getDAOFactory(c.env);
 		const entityDAO = daoFactory.entityDAO;
-		const getServices = buildEntityServiceAccessor(c, entityDAO);
+		const getServices = buildEntityServiceAccessor(
+			c,
+			entityDAO,
+			daoFactory.entityGraphService
+		);
 
 		return await executor({
 			c,
@@ -194,11 +198,7 @@ export async function handleUpdateEntityImportance(c: ContextWithAuth) {
 			}
 
 			const daoFactory = getDAOFactory(ctx.env);
-			const importanceService = new EntityImportanceService(
-				entityDAO,
-				daoFactory.communityDAO,
-				daoFactory.entityImportanceDAO
-			);
+			const importanceService = daoFactory.entityImportanceService;
 
 			const currentCalculated =
 				await importanceService.calculateCombinedImportance(

--- a/src/routes/graph-visualization.ts
+++ b/src/routes/graph-visualization.ts
@@ -21,7 +21,6 @@ import {
 import type { Env } from "@/middleware/auth";
 import type { AuthPayload } from "@/services/core/auth-service";
 import { OpenAIEmbeddingService } from "@/services/embedding/openai-embedding-service";
-import { EntityGraphService } from "@/services/graph/entity-graph-service";
 import { getLLMRateLimitService } from "@/services/llm/llm-rate-limit-service";
 import { EntitySemanticSearchService } from "@/services/vectorize/entity-semantic-search-service";
 import type {
@@ -442,7 +441,7 @@ export async function handleSearchEntityInGraph(c: ContextWithAuth) {
 			);
 		}
 
-		const graphService = new EntityGraphService(daoFactory.entityDAO);
+		const graphService = daoFactory.entityGraphService;
 		const primaryEntities: Entity[] = [];
 		const associatedEntityIds = new Set<string>();
 

--- a/src/tools/campaign-context/entity-tools.ts
+++ b/src/tools/campaign-context/entity-tools.ts
@@ -5,7 +5,6 @@ import { getDAOFactory } from "@/dao/dao-factory";
 import { STRUCTURED_ENTITY_TYPES } from "@/lib/entity-types";
 import { RELATIONSHIP_TYPES } from "@/lib/relationship-types";
 import { authenticatedFetch, handleAuthError } from "@/lib/tool-auth";
-import { EntityGraphService } from "@/services/graph/entity-graph-service";
 import { EntityExtractionPipeline } from "@/services/rag/entity-extraction-pipeline";
 import { EntityExtractionService } from "@/services/rag/entity-extraction-service";
 import { EntityEmbeddingService } from "@/services/vectorize/entity-embedding-service";
@@ -170,7 +169,7 @@ export const extractEntitiesFromContentTool = tool({
 					| import("@cloudflare/workers-types").VectorizeIndex
 					| undefined
 			);
-			const graphService = new EntityGraphService(daoFactory.entityDAO);
+			const graphService = daoFactory.entityGraphService;
 			const pipeline = new EntityExtractionPipeline(
 				daoFactory.entityDAO,
 				extractionService,
@@ -360,7 +359,7 @@ export const createEntityRelationshipTool = tool({
 			if (gmError) return gmError;
 
 			// Initialize graph service
-			const graphService = new EntityGraphService(daoFactory.entityDAO);
+			const graphService = daoFactory.entityGraphService;
 
 			// Check entities exist
 			const fromEntity = await daoFactory.entityDAO.getEntityById(fromEntityId);

--- a/src/tools/campaign-context/search-tools.ts
+++ b/src/tools/campaign-context/search-tools.ts
@@ -7,7 +7,6 @@ import { sanitizeEntityContentForPlayer } from "@/lib/entity-content-sanitizer";
 import { AUTH_CODES, type ToolResult } from "../../app-constants";
 import { getDAOFactory } from "../../dao/dao-factory";
 import { STRUCTURED_ENTITY_TYPES } from "../../lib/entity-types";
-import { EntityGraphService } from "../../services/graph/entity-graph-service";
 import { WorldStateChangelogService } from "../../services/graph/world-state-changelog-service";
 import type { PlanningContextService } from "../../services/rag/planning-context-service";
 import { getPlanningServices } from "../../services/rag/rag-service-factory";
@@ -919,7 +918,7 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 
 						// Fetch relationships for entities to help AI understand actual connections
 						// Relationships are stored separately from entities, so we need to fetch them explicitly
-						const graphService = new EntityGraphService(daoFactory.entityDAO);
+						const graphService = daoFactory.entityGraphService;
 
 						// Collect all relationship data first, then batch-fetch related entity names
 						const entityRelationshipsMap = new Map<
@@ -1246,7 +1245,7 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 						);
 
 						const daoFactory = getDAOFactory(env);
-						const graphService = new EntityGraphService(daoFactory.entityDAO);
+						const graphService = daoFactory.entityGraphService;
 
 						// Normalize relationship types if provided
 						const normalizedRelationshipTypes = traverseRelationshipTypes?.map(

--- a/src/tools/campaign-context/suggestion-tools.ts
+++ b/src/tools/campaign-context/suggestion-tools.ts
@@ -20,7 +20,6 @@ import { getAssessmentService } from "../../lib/service-factory";
 import { authenticatedFetch, handleAuthError } from "../../lib/tool-auth";
 import type { Env } from "../../middleware/auth";
 import { CharacterEntitySyncService } from "../../services/campaign/character-entity-sync-service";
-import { EntityGraphService } from "../../services/graph/entity-graph-service";
 import { createLLMProvider } from "../../services/llm/llm-provider-factory";
 import { getPlanningServices } from "../../services/rag/rag-service-factory";
 import {
@@ -801,7 +800,7 @@ async function performSemanticChecklistAnalysis(
 		try {
 			const daoFactory = getDAOFactory(env);
 			const entityDAO = daoFactory.entityDAO;
-			const graphService = new EntityGraphService(entityDAO);
+			const graphService = daoFactory.entityGraphService;
 
 			const allEntities = await entityDAO.listEntitiesByCampaign(campaignId, {
 				excludeShardStatuses: ["rejected", "deleted"],

--- a/src/tools/campaign/check-planning-readiness-tool.ts
+++ b/src/tools/campaign/check-planning-readiness-tool.ts
@@ -7,8 +7,6 @@ import {
 	ENTITY_TYPE_NPCS,
 	ENTITY_TYPE_PCS,
 } from "@/lib/entity-type-constants";
-import { EntityGraphService } from "@/services/graph/entity-graph-service";
-import { EntityImportanceService } from "@/services/graph/entity-importance-service";
 import {
 	commonSchemas,
 	createToolError,
@@ -156,12 +154,8 @@ export const checkPlanningReadiness = tool({
 						"Adding character backstories and goals as entities can help create more personalized session moments and connect characters to the campaign's entity graph.",
 				});
 			} else {
-				const entityGraphService = new EntityGraphService(daoFactory.entityDAO);
-				const importanceService = new EntityImportanceService(
-					daoFactory.entityDAO,
-					daoFactory.communityDAO,
-					daoFactory.entityImportanceDAO
-				);
+				const entityGraphService = daoFactory.entityGraphService;
+				const importanceService = daoFactory.entityImportanceService;
 				for (const character of playerCharacters) {
 					const characterGaps = await analyzePlayerCharacterCompleteness(
 						character,

--- a/src/tools/campaign/plan-session-tool.ts
+++ b/src/tools/campaign/plan-session-tool.ts
@@ -7,7 +7,6 @@ import { getEntitiesWithRelationships } from "@/lib/graph/entity-utils";
 import type { SessionScriptContext } from "@/lib/prompts/session-script-prompts";
 import { SESSION_SCRIPT_PROMPTS } from "@/lib/prompts/session-script-prompts";
 import { authenticatedFetch, handleAuthError } from "@/lib/tool-auth";
-import { EntityGraphService } from "@/services/graph/entity-graph-service";
 import { createLLMProvider } from "@/services/llm/llm-provider-factory";
 import { getPlanningServices } from "@/services/rag/rag-service-factory";
 import {
@@ -233,7 +232,7 @@ export const planSession = tool({
 				entityIds.add(pc.id);
 			});
 
-			const entityGraphService = new EntityGraphService(daoFactory.entityDAO);
+			const entityGraphService = daoFactory.entityGraphService;
 			const filteredEntities = await getEntitiesWithRelationships(
 				Array.from(entityIds).slice(0, 30),
 				campaignId,


### PR DESCRIPTION
Replace direct service instantiation at call sites with DAOFactory-vended singletons to reduce boilerplate and keep graph service wiring consistent.

Made-with: Cursor