### PR TITLE
Replace DAOFactory DB key monkey-patching with WeakMap caching.

### DIFF
--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -28,12 +28,7 @@ import type { UserStorageUsage } from "./user-dao";
 import { UserDAO } from "./user-dao";
 
 // Cache for DAO factory instances
-const daoFactoryCache = new Map<string, DAOFactory>();
-
-// Wrapper to add a stable key to D1Database objects
-interface DatabaseWithKey extends D1Database {
-	_daoKey?: string;
-}
+const daoFactoryCache = new WeakMap<D1Database, DAOFactory>();
 
 export interface DAOFactory {
 	authUserDAO: AuthUserDAO;
@@ -183,46 +178,27 @@ export class DAOFactoryImpl implements DAOFactory {
 	}
 }
 
-// Generate a stable key for a D1Database instance
-export function getDatabaseKey(db: D1Database | undefined): string {
-	if (!db) {
-		// For undefined/null databases, generate a unique key
-		return `db-undefined-${Math.random().toString(36).substr(2, 9)}`;
-	}
-
-	const dbWithKey = db as DatabaseWithKey;
-
-	// If the database already has a key, use it
-	if (dbWithKey._daoKey) {
-		return dbWithKey._daoKey;
-	}
-
-	// Generate a new key and store it on the database object
-	// Use a more stable approach - just use a random string without timestamp
-	const key = `db-${Math.random().toString(36).substr(2, 9)}`;
-	dbWithKey._daoKey = key;
-	return key;
-}
-
 export function createDAOFactory(db: D1Database | undefined): DAOFactory {
 	if (!db) {
 		throw new DAOFactoryError();
 	}
 
 	const factory = new DAOFactoryImpl(db);
-	const key = getDatabaseKey(db);
-	daoFactoryCache.set(key, factory);
+	daoFactoryCache.set(db, factory);
 	return factory;
 }
 
 export function getDAOFactory(env: unknown): DAOFactory {
 	const e = env as { DB?: D1Database };
 	const db = e?.DB;
-	const key = getDatabaseKey(db);
-
-	if (!daoFactoryCache.has(key)) {
-		return createDAOFactory(db!);
+	if (!db) {
+		throw new DAOFactoryError();
 	}
 
-	return daoFactoryCache.get(key)!;
+	const existingFactory = daoFactoryCache.get(db);
+	if (existingFactory) {
+		return existingFactory;
+	}
+
+	return createDAOFactory(db);
 }

--- a/src/lib/service-factory.ts
+++ b/src/lib/service-factory.ts
@@ -1,7 +1,6 @@
 // Service Factory - Provides cached service instances to reduce memory usage and initialization overhead
 // Uses per-request caching to reuse services within the same request context
 
-import { getDatabaseKey } from "@/dao/dao-factory";
 import type { Env } from "@/middleware/auth";
 import { CampaignService } from "@/services/campaign/campaign-service";
 import { AssessmentService } from "@/services/core/assessment-service";
@@ -18,11 +17,36 @@ import { ModelManager } from "./model-manager";
 export class ServiceFactory {
 	private static services = new Map<string, any>();
 	private static authServicesByEnv = new WeakMap<object, AuthService>();
+	private static dbKeyByDb = new WeakMap<object, string>();
+	private static dbKeyCounter = 0;
 
 	// Clear services (called between requests to prevent memory leaks)
 	static clearCache(): void {
 		ServiceFactory.services.clear();
 		ServiceFactory.authServicesByEnv = new WeakMap();
+		ServiceFactory.dbKeyByDb = new WeakMap();
+		ServiceFactory.dbKeyCounter = 0;
+	}
+
+	private static getOrCreateDbKey(db: unknown): string {
+		if (db === null || db === undefined) {
+			return "db-missing";
+		}
+
+		if (typeof db !== "object") {
+			return `db-primitive-${String(db)}`;
+		}
+
+		const dbObject = db as object;
+		const existingKey = ServiceFactory.dbKeyByDb.get(dbObject);
+		if (existingKey) {
+			return existingKey;
+		}
+
+		ServiceFactory.dbKeyCounter += 1;
+		const newKey = `db-${ServiceFactory.dbKeyCounter}`;
+		ServiceFactory.dbKeyByDb.set(dbObject, newKey);
+		return newKey;
 	}
 
 	// Get or create AssessmentService
@@ -88,7 +112,7 @@ export class ServiceFactory {
 	// Get or create CampaignService
 	static getCampaignService(env: Env): CampaignService {
 		// Create a more unique key based on environment content and database identity
-		const dbKey = getDatabaseKey(env.DB);
+		const dbKey = ServiceFactory.getOrCreateDbKey(env.DB);
 		const envHash = JSON.stringify({
 			hasDb: !!env.DB,
 			hasJwtSecret: !!env.JWT_SECRET,
@@ -122,7 +146,7 @@ export class ServiceFactory {
 	 */
 	static getAgentRegistryService(env: Env): AgentRegistryService {
 		// Create a more unique key based on database identity
-		const dbKey = getDatabaseKey(env.DB);
+		const dbKey = ServiceFactory.getOrCreateDbKey(env.DB);
 		const key = `agent-registry-${dbKey}`;
 		if (!ServiceFactory.services.has(key)) {
 			ServiceFactory.services.set(key, new AgentRegistryService());


### PR DESCRIPTION
Decouple ServiceFactory from dao-factory key generation by using local WeakMap-based DB identity keys.

Made-with: Cursor