### PR TITLE
Add subscription-based retry limits (per-file daily/monthly)

### DIFF
--- a/migrations/0008_file_retry_usage.sql
+++ b/migrations/0008_file_retry_usage.sql
@@ -1,0 +1,12 @@
+-- Per-file retry usage for indexation/entity extraction retry limits
+-- retry_date format: YYYY-MM-DD for daily rollups; monthly = sum across dates in month
+CREATE TABLE IF NOT EXISTS file_retry_usage (
+  username text not null,
+  file_key text not null,
+  retry_date text not null,
+  retry_count integer not null default 0,
+  updated_at datetime default current_timestamp,
+  primary key (username, file_key, retry_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_file_retry_usage_lookup ON file_retry_usage(username, file_key);

--- a/src/app-constants.ts
+++ b/src/app-constants.ts
@@ -282,6 +282,10 @@ export interface TierLimits {
 	qpd: number;
 	/** Monthly token cap for free tier only; undefined for paid tiers */
 	monthlyTokens?: number;
+	/** Per-file retries per day for indexation/entity extraction retry */
+	retriesPerFilePerDay: number;
+	/** Per-file retries per month for indexation/entity extraction retry */
+	retriesPerFilePerMonth: number;
 }
 
 export const SUBSCRIPTION_TIERS: Record<SubscriptionTier, TierLimits> = {
@@ -294,6 +298,8 @@ export const SUBSCRIPTION_TIERS: Record<SubscriptionTier, TierLimits> = {
 		tpd: 10_000,
 		qpd: 50,
 		monthlyTokens: 10_000,
+		retriesPerFilePerDay: 1,
+		retriesPerFilePerMonth: 3,
 	},
 	basic: {
 		maxCampaigns: 5,
@@ -303,6 +309,8 @@ export const SUBSCRIPTION_TIERS: Record<SubscriptionTier, TierLimits> = {
 		qpm: 10,
 		tpd: 500_000,
 		qpd: 500,
+		retriesPerFilePerDay: 3,
+		retriesPerFilePerMonth: 15,
 	},
 	pro: {
 		maxCampaigns: 999_999, // effectively unlimited
@@ -312,6 +320,8 @@ export const SUBSCRIPTION_TIERS: Record<SubscriptionTier, TierLimits> = {
 		qpm: 20,
 		tpd: 1_000_000,
 		qpd: 1_000,
+		retriesPerFilePerDay: 5,
+		retriesPerFilePerMonth: 50,
 	},
 } as const;
 

--- a/src/components/resource-side-panel/CampaignDetailsModal.tsx
+++ b/src/components/resource-side-panel/CampaignDetailsModal.tsx
@@ -14,6 +14,7 @@ import { STANDARD_MODAL_SIZE_OBJECT } from "@/constants/modal-sizes";
 import { useAuthenticatedRequest } from "@/hooks/useAuthenticatedRequest";
 import { useBaseAsync } from "@/hooks/useBaseAsync";
 import { useResourceFiles } from "@/hooks/useResourceFiles";
+import { useRetryLimitStatus } from "@/hooks/useRetryLimitStatus";
 import { useSessionDigests } from "@/hooks/useSessionDigests";
 import { APP_EVENT_TYPE } from "@/lib/app-events";
 import { getDisplayName } from "@/lib/display-name-utils";
@@ -212,6 +213,11 @@ export function CampaignDetailsModal({
 		// After queuing, mark as processing and start polling
 		setProcessingResources((prev) => new Set(prev).add(resourceId));
 	};
+
+	// Fetch retry limit status for all resources (to disable retry button when limit reached)
+	const limitKeys =
+		resources.length > 0 ? resources.map((r) => r.file_key ?? r.id) : null;
+	const { status: retryLimitStatus } = useRetryLimitStatus(limitKeys);
 
 	const removeResourceFromCampaign = useBaseAsync(
 		useMemo(
@@ -678,6 +684,7 @@ export function CampaignDetailsModal({
 									retryingResourceId={retryingResourceId}
 									onRetry={handleRetryEntityExtraction}
 									canRetryEntityExtraction={isOwner}
+									retryLimitStatus={retryLimitStatus}
 									onAddResource={() => setIsAddResourceModalOpen(true)}
 									canAddResource={canShare}
 									onRemoveResource={handleRemoveResource}

--- a/src/components/resource-side-panel/CampaignResourcesTab.tsx
+++ b/src/components/resource-side-panel/CampaignResourcesTab.tsx
@@ -20,6 +20,7 @@ interface CampaignResourcesTabProps {
 	retryingResourceId: string | null;
 	onRetry: (resourceId: string) => void;
 	canRetryEntityExtraction?: boolean;
+	retryLimitStatus?: Record<string, { canRetry: boolean; reason?: string }>;
 	onAddResource: () => void;
 	canAddResource?: boolean;
 	onRemoveResource?: (resourceId: string) => void;
@@ -39,6 +40,7 @@ export function CampaignResourcesTab({
 	retryingResourceId,
 	onRetry,
 	canRetryEntityExtraction = true,
+	retryLimitStatus = {},
 	onAddResource,
 	canAddResource = true,
 	onRemoveResource,
@@ -221,38 +223,60 @@ export function CampaignResourcesTab({
 														</span>
 													</Tooltip>
 												) : (
-													<button
-														type="button"
-														onClick={(e) => {
-															e.stopPropagation();
-															onRetry(resource.id);
-														}}
-														disabled={
-															retryingResourceId === resource.id ||
-															processingResources.has(resource.id)
-														}
-														className="w-full px-3 py-2 text-sm font-medium rounded-md border transition-colors text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
-													>
-														{processingResources.has(resource.id) ? (
-															<span className="flex items-center justify-center gap-2">
-																<ArrowClockwise
-																	size={16}
-																	className="animate-spin"
-																/>
-																Processing...
-															</span>
-														) : retryingResourceId === resource.id ? (
-															<span className="flex items-center justify-center gap-2">
-																<ArrowClockwise
-																	size={16}
-																	className="animate-spin"
-																/>
-																Retrying...
-															</span>
+													(() => {
+														const limitKey = resource.file_key ?? resource.id;
+														const limitInfo = retryLimitStatus[limitKey];
+														const limitReached =
+															limitInfo && !limitInfo.canRetry;
+														const tooltipContent = limitReached
+															? (limitInfo?.reason ?? "Retry limit reached")
+															: undefined;
+														const button = (
+															<button
+																type="button"
+																onClick={(e) => {
+																	if (!limitReached) {
+																		e.stopPropagation();
+																		onRetry(resource.id);
+																	}
+																}}
+																disabled={
+																	limitReached ||
+																	retryingResourceId === resource.id ||
+																	processingResources.has(resource.id)
+																}
+																title={tooltipContent}
+																className="w-full px-3 py-2 text-sm font-medium rounded-md border transition-colors text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+															>
+																{processingResources.has(resource.id) ? (
+																	<span className="flex items-center justify-center gap-2">
+																		<ArrowClockwise
+																			size={16}
+																			className="animate-spin"
+																		/>
+																		Processing...
+																	</span>
+																) : retryingResourceId === resource.id ? (
+																	<span className="flex items-center justify-center gap-2">
+																		<ArrowClockwise
+																			size={16}
+																			className="animate-spin"
+																		/>
+																		Retrying...
+																	</span>
+																) : (
+																	"Retry entity extraction"
+																)}
+															</button>
+														);
+														return tooltipContent ? (
+															<Tooltip content={tooltipContent}>
+																<span className="block w-full">{button}</span>
+															</Tooltip>
 														) : (
-															"Retry entity extraction"
-														)}
-													</button>
+															<span className="block w-full">{button}</span>
+														);
+													})()
 												)}
 												{onRemoveResource && (
 													<button

--- a/src/components/upload/FileStatusIndicator.tsx
+++ b/src/components/upload/FileStatusIndicator.tsx
@@ -5,6 +5,7 @@ import {
 	XCircle,
 } from "@phosphor-icons/react";
 import { useCallback } from "react";
+import { Tooltip } from "@/components/tooltip/Tooltip";
 import { FileDAO } from "@/dao";
 import {
 	estimateProcessingTime,
@@ -22,6 +23,10 @@ interface FileStatusIndicatorProps {
 	fileSize?: number;
 	processingError?: string; // JSON string containing error code and metadata
 	onRetry?: (fileKey: string, fileName: string) => void;
+	/** When true, retry button is disabled (e.g. limit reached) */
+	retryLimitDisabled?: boolean;
+	/** Tooltip text when retry is disabled due to limit */
+	retryLimitTooltip?: string;
 }
 
 export function FileStatusIndicator({
@@ -35,6 +40,8 @@ export function FileStatusIndicator({
 	fileSize,
 	processingError,
 	onRetry,
+	retryLimitDisabled = false,
+	retryLimitTooltip,
 }: FileStatusIndicatorProps) {
 	// No local error timeout; rely on SSE-driven updates and server state
 
@@ -194,16 +201,31 @@ export function FileStatusIndicator({
 				fileKey &&
 				fileName &&
 				onRetry &&
-				!isMemoryLimitError && (
-					<button
-						type="button"
-						onClick={handleRetry}
-						className="ml-1 p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
-						title="Retry processing"
-					>
-						<ArrowClockwise size={12} />
-					</button>
-				)}
+				!isMemoryLimitError &&
+				(() => {
+					const button = (
+						<button
+							type="button"
+							onClick={retryLimitDisabled ? undefined : handleRetry}
+							disabled={retryLimitDisabled}
+							className={`ml-1 p-1 transition-colors ${
+								retryLimitDisabled
+									? "text-gray-400 dark:text-gray-500 cursor-not-allowed opacity-60"
+									: "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+							}`}
+							title={!retryLimitTooltip ? "Retry processing" : undefined}
+						>
+							<ArrowClockwise size={12} />
+						</button>
+					);
+					return retryLimitTooltip ? (
+						<Tooltip content={retryLimitTooltip}>
+							<span className="inline-flex">{button}</span>
+						</Tooltip>
+					) : (
+						button
+					);
+				})()}
 		</div>
 	);
 }

--- a/src/components/upload/ResourceFileDetails.tsx
+++ b/src/components/upload/ResourceFileDetails.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/button/Button";
+import { Tooltip } from "@/components/tooltip/Tooltip";
 import { FileDAO } from "@/dao";
 import type { ResourceFileWithCampaigns } from "@/hooks/useResourceFiles";
 import type { Campaign } from "@/types/campaign";
@@ -10,6 +11,8 @@ interface ResourceFileDetailsProps {
 	onRetryIndexing: (fileKey: string) => Promise<void>;
 	fetchResources: () => Promise<void>;
 	campaigns?: Campaign[];
+	retryLimitDisabled?: boolean;
+	retryLimitTooltip?: string;
 }
 
 /**
@@ -22,6 +25,8 @@ export function ResourceFileDetails({
 	onRetryIndexing,
 	fetchResources,
 	campaigns = [],
+	retryLimitDisabled = false,
+	retryLimitTooltip,
 }: ResourceFileDetailsProps) {
 	const handleRetryIndexing = async () => {
 		await onRetryIndexing(file.file_key);
@@ -145,18 +150,30 @@ export function ResourceFileDetails({
 						file.status === "failed" ||
 						file.status === "error";
 
+					const retryButton = (
+						<Button
+							onClick={retryLimitDisabled ? undefined : handleRetryIndexing}
+							disabled={retryLimitDisabled}
+							variant="secondary"
+							size="sm"
+							className="w-full !text-orange-600 dark:!text-orange-400 hover:!text-orange-700 dark:hover:!text-orange-300 border-orange-200 dark:border-orange-700 hover:border-orange-300 dark:hover:border-orange-600 disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Retry Indexing
+						</Button>
+					);
+					const tooltipContent = retryLimitDisabled
+						? (retryLimitTooltip ?? "Retry limit reached")
+						: null;
 					return (
 						isFailedStatus &&
-						!isMemoryLimitError && (
-							<Button
-								onClick={handleRetryIndexing}
-								variant="secondary"
-								size="sm"
-								className="w-full !text-orange-600 dark:!text-orange-400 hover:!text-orange-700 dark:hover:!text-orange-300 border-orange-200 dark:border-orange-700 hover:border-orange-300 dark:hover:border-orange-600"
-							>
-								Retry Indexing
-							</Button>
-						)
+						!isMemoryLimitError &&
+						(tooltipContent ? (
+							<Tooltip content={tooltipContent}>
+								<span className="block w-full">{retryButton}</span>
+							</Tooltip>
+						) : (
+							<span className="block w-full">{retryButton}</span>
+						))
 					);
 				})()}
 				{file.processing_error &&

--- a/src/components/upload/ResourceFileItem.tsx
+++ b/src/components/upload/ResourceFileItem.tsx
@@ -19,6 +19,7 @@ interface ResourceFileItemProps {
 	onRetryIndexing: (fileKey: string) => Promise<void>;
 	fetchResources: () => Promise<void>;
 	campaigns?: Campaign[];
+	retryLimitStatus?: { canRetry: boolean; reason?: string };
 }
 
 /**
@@ -36,6 +37,7 @@ export function ResourceFileItem({
 	onRetryIndexing,
 	fetchResources,
 	campaigns = [],
+	retryLimitStatus,
 }: ResourceFileItemProps) {
 	const progressPercentage = (() => {
 		// Check for campaign addition progress first
@@ -122,6 +124,10 @@ export function ResourceFileItem({
 								fileSize={file.file_size}
 								processingError={file.processing_error}
 								onRetry={onRetryFile}
+								retryLimitDisabled={
+									retryLimitStatus && !retryLimitStatus.canRetry
+								}
+								retryLimitTooltip={retryLimitStatus?.reason}
 								className="flex-shrink-0"
 							/>
 						)}
@@ -156,6 +162,8 @@ export function ResourceFileItem({
 						onRetryIndexing={onRetryIndexing}
 						fetchResources={fetchResources}
 						campaigns={campaigns}
+						retryLimitDisabled={retryLimitStatus && !retryLimitStatus.canRetry}
+						retryLimitTooltip={retryLimitStatus?.reason}
 					/>
 				)}
 			</div>

--- a/src/components/upload/ResourceList.tsx
+++ b/src/components/upload/ResourceList.tsx
@@ -4,6 +4,7 @@ import { FileDAO } from "@/dao";
 import { useAuthReady } from "@/hooks/useAuthReady";
 import { useResourceFileEvents } from "@/hooks/useResourceFileEvents";
 import type { ResourceFileWithCampaigns } from "@/hooks/useResourceFiles";
+import { useRetryLimitStatus } from "@/hooks/useRetryLimitStatus";
 import { APP_EVENT_TYPE } from "@/lib/app-events";
 import { logger } from "@/lib/logger";
 import {
@@ -59,6 +60,26 @@ export function ResourceList({
 		setProgressByFileKey,
 		fetchResources,
 	});
+
+	// Fetch retry limit status for files that can show retry (error/failed/unindexed, not memory limit)
+	const retryEligibleFileKeys = files
+		.filter((f) => {
+			const isFailed =
+				f.status === FileDAO.STATUS.ERROR ||
+				f.status === "failed" ||
+				f.status === FileDAO.STATUS.UNINDEXED;
+			if (!isFailed) return false;
+			try {
+				const err = f.processing_error ? JSON.parse(f.processing_error) : null;
+				return err?.code !== "MEMORY_LIMIT_EXCEEDED";
+			} catch {
+				return true;
+			}
+		})
+		.map((f) => f.file_key);
+	const { status: retryLimitStatus } = useRetryLimitStatus(
+		retryEligibleFileKeys.length > 0 ? retryEligibleFileKeys : null
+	);
 
 	const handleRetryFile = useCallback(
 		async (fileKey: string, fileName: string) => {
@@ -302,6 +323,7 @@ export function ResourceList({
 						onRetryIndexing={handleRetryIndexing}
 						fetchResources={fetchResources}
 						campaigns={campaigns}
+						retryLimitStatus={retryLimitStatus[file.file_key]}
 					/>
 				))}
 			</div>

--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -19,6 +19,7 @@ import { CommunitySummaryDAO } from "./community-summary-dao";
 import { EntityDAO } from "./entity-dao";
 import { EntityImportanceDAO } from "./entity-importance-dao";
 import { FileDAO } from "./file/file-dao";
+import { FileRetryUsageDAO } from "./file-retry-usage-dao";
 import { GraphRebuildDirtyDAO } from "./graph-rebuild-dirty-dao";
 import { LLMUsageDAO } from "./llm-usage-dao";
 import { MessageHistoryDAO } from "./message-history-dao";
@@ -60,6 +61,7 @@ export interface DAOFactory {
 	campaignResourceProposalDAO: CampaignResourceProposalDAO;
 	subscriptionDAO: SubscriptionDAO;
 	userMonthlyUsageDAO: UserMonthlyUsageDAO;
+	fileRetryUsageDAO: FileRetryUsageDAO;
 	entityGraphService: EntityGraphService;
 	entityImportanceService: EntityImportanceService;
 	rebuildTriggerService: RebuildTriggerService;
@@ -95,6 +97,7 @@ export class DAOFactoryImpl implements DAOFactory {
 	public readonly campaignResourceProposalDAO: CampaignResourceProposalDAO;
 	public readonly subscriptionDAO: SubscriptionDAO;
 	public readonly userMonthlyUsageDAO: UserMonthlyUsageDAO;
+	public readonly fileRetryUsageDAO: FileRetryUsageDAO;
 	private _entityGraphService: EntityGraphService | null = null;
 	private _entityImportanceService: EntityImportanceService | null = null;
 	private _rebuildTriggerService: RebuildTriggerService | null = null;
@@ -125,6 +128,7 @@ export class DAOFactoryImpl implements DAOFactory {
 		this.campaignResourceProposalDAO = new CampaignResourceProposalDAO(db);
 		this.subscriptionDAO = new SubscriptionDAO(db);
 		this.userMonthlyUsageDAO = new UserMonthlyUsageDAO(db);
+		this.fileRetryUsageDAO = new FileRetryUsageDAO(db);
 	}
 
 	async getStorageUsage(username: string): Promise<UserStorageUsage> {

--- a/src/dao/file-retry-usage-dao.ts
+++ b/src/dao/file-retry-usage-dao.ts
@@ -1,0 +1,63 @@
+import { BaseDAOClass } from "./base-dao";
+
+function getToday(): string {
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = String(now.getMonth() + 1).padStart(2, "0");
+	const day = String(now.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+export class FileRetryUsageDAO extends BaseDAOClass {
+	async incrementRetry(username: string, fileKey: string): Promise<void> {
+		const retryDate = getToday();
+		const now = new Date().toISOString();
+
+		const sql = `
+      INSERT INTO file_retry_usage (username, file_key, retry_date, retry_count, updated_at)
+      VALUES (?, ?, ?, 1, ?)
+      ON CONFLICT(username, file_key, retry_date) DO UPDATE SET
+        retry_count = retry_count + 1,
+        updated_at = ?
+    `;
+		await this.execute(sql, [username, fileKey, retryDate, now, now]);
+	}
+
+	async getRetriesForFileToday(
+		username: string,
+		fileKey: string
+	): Promise<number> {
+		const retryDate = getToday();
+		const sql = `
+      SELECT COALESCE(retry_count, 0) as retry_count
+      FROM file_retry_usage
+      WHERE username = ? AND file_key = ? AND retry_date = ?
+    `;
+		const row = await this.queryFirst<{ retry_count: number }>(sql, [
+			username,
+			fileKey,
+			retryDate,
+		]);
+		return row?.retry_count ?? 0;
+	}
+
+	async getRetriesForFileThisMonth(
+		username: string,
+		fileKey: string
+	): Promise<number> {
+		const now = new Date();
+		const yearMonthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+
+		const sql = `
+      SELECT COALESCE(SUM(retry_count), 0) as total
+      FROM file_retry_usage
+      WHERE username = ? AND file_key = ? AND retry_date LIKE ?
+    `;
+		const row = await this.queryFirst<{ total: number }>(sql, [
+			username,
+			fileKey,
+			`${yearMonthPrefix}%`,
+		]);
+		return row?.total ?? 0;
+	}
+}

--- a/src/hooks/useRetryLimitStatus.ts
+++ b/src/hooks/useRetryLimitStatus.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { JWT_STORAGE_KEY } from "@/app-constants";
+import { API_CONFIG } from "@/shared-config";
+
+export interface RetryLimitStatusEntry {
+	canRetry: boolean;
+	reason?: string;
+}
+
+export function useRetryLimitStatus(fileKeys: string[] | null): {
+	status: Record<string, RetryLimitStatusEntry>;
+	loading: boolean;
+} {
+	const [status, setStatus] = useState<Record<string, RetryLimitStatusEntry>>(
+		{}
+	);
+	const [loading, setLoading] = useState(false);
+
+	useEffect(() => {
+		if (!fileKeys || fileKeys.length === 0) {
+			setStatus({});
+			setLoading(false);
+			return;
+		}
+
+		let cancelled = false;
+		setLoading(true);
+
+		async function fetchStatus() {
+			const jwt = localStorage.getItem(JWT_STORAGE_KEY);
+			if (!jwt) {
+				setLoading(false);
+				return;
+			}
+
+			try {
+				const uniqueKeys = [...new Set(fileKeys)].filter(Boolean);
+				const query = new URLSearchParams({
+					fileKeys: uniqueKeys.join(","),
+				});
+				const url = `${API_CONFIG.buildUrl(API_CONFIG.ENDPOINTS.BILLING.RETRY_LIMIT_STATUS)}?${query}`;
+				const res = await fetch(url, {
+					headers: { Authorization: `Bearer ${jwt}` },
+				});
+				if (cancelled) return;
+				if (!res.ok) {
+					setStatus({});
+					return;
+				}
+				const json = (await res.json()) as {
+					status: Record<string, { canRetry: boolean; reason?: string }>;
+				};
+				setStatus(json.status ?? {});
+			} catch {
+				if (!cancelled) setStatus({});
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		}
+
+		fetchStatus();
+		return () => {
+			cancelled = true;
+		};
+	}, [fileKeys?.join(",") ?? ""]);
+
+	return { status, loading };
+}

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -5,6 +5,7 @@ import type { SubscriptionStatus } from "@/dao/subscription-dao";
 import { getEnvVar } from "@/lib/env-utils";
 import type { Env } from "@/routes/register-routes";
 import { getSubscriptionService } from "@/services/billing/subscription-service";
+import { RetryLimitService } from "@/services/retry-limit-service";
 import { DEFAULT_APP_ORIGIN } from "@/shared-config";
 
 async function getStripe(env: Env): Promise<Stripe> {
@@ -167,6 +168,50 @@ export async function handleBillingStatus(c: ContextWithAuth) {
 			monthlyTokens: limits.monthlyTokens,
 		},
 	});
+}
+
+/**
+ * GET /billing/retry-limit-status?fileKeys=key1,key2,key3
+ * Returns per-file retry limit status (read-only, does not increment).
+ * Used by UI to disable retry buttons with tooltip when limit is reached.
+ */
+export async function handleRetryLimitStatus(c: ContextWithAuth) {
+	const auth = getUserAuth(c);
+	if (!auth?.username) {
+		return c.json({ error: "Unauthorized" }, 401);
+	}
+
+	const url = new URL(c.req.url);
+	const fileKeysParam = url.searchParams.get("fileKeys");
+	const fileKeys = fileKeysParam
+		? fileKeysParam
+				.split(",")
+				.map((k) => k.trim())
+				.filter(Boolean)
+		: [];
+
+	if (fileKeys.length === 0) {
+		return c.json({ status: {} });
+	}
+
+	// Limit to avoid abuse (e.g. 50 keys max)
+	const keysToCheck = fileKeys.slice(0, 50);
+
+	const status: Record<string, { canRetry: boolean; reason?: string }> = {};
+	for (const fileKey of keysToCheck) {
+		const result = await RetryLimitService.checkRetryLimit(
+			auth.username,
+			fileKey,
+			auth.isAdmin ?? false,
+			c.env
+		);
+		status[fileKey] = {
+			canRetry: result.allowed,
+			reason: result.reason,
+		};
+	}
+
+	return c.json({ status });
 }
 
 export async function handleBillingCheckout(c: ContextWithAuth) {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -42,6 +42,7 @@ import { ChecklistStatusService } from "@/services/campaign/checklist-status-ser
 import { EntityExtractionQueueService } from "@/services/campaign/entity-extraction-queue-service";
 import type { AuthPayload } from "@/services/core/auth-service";
 import { SyncQueueService } from "@/services/file/sync-queue-service";
+import { RetryLimitService } from "@/services/retry-limit-service";
 
 // Extend the context to include userAuth
 type ContextWithAuth = Context<{ Bindings: Env }> & {
@@ -779,6 +780,47 @@ export async function handleRetryEntityExtraction(c: ContextWithAuth) {
 		}
 
 		console.log("[Server] Found resource for retry:", resource);
+
+		// In-progress check: block retry until current extraction completes
+		const queueDAO = new EntityExtractionQueueDAO(c.env.DB);
+		const queueItem = await queueDAO.getQueueItemByResource(
+			campaignId,
+			resourceId
+		);
+		const activeStatuses = ["pending", "processing", "rate_limited"];
+		if (
+			queueItem &&
+			activeStatuses.includes(queueItem.status?.toLowerCase() ?? "")
+		) {
+			return c.json(
+				{
+					success: false,
+					message:
+						"Please wait for the current extraction to complete before retrying.",
+					error: "EXTRACTION_IN_PROGRESS",
+				},
+				409
+			);
+		}
+
+		// Limit check: per-file daily and monthly retry limits
+		const limitKey = resource.file_key ?? resourceId;
+		const retryLimit = await RetryLimitService.checkAndIncrementRetry(
+			userAuth.username,
+			limitKey,
+			userAuth.isAdmin ?? false,
+			c.env
+		);
+		if (!retryLimit.allowed) {
+			return c.json(
+				{
+					success: false,
+					message: retryLimit.reason,
+					error: "RETRY_LIMIT_EXCEEDED",
+				},
+				429
+			);
+		}
 
 		// Queue entity extraction retry (asynchronous)
 		try {

--- a/src/routes/rag.ts
+++ b/src/routes/rag.ts
@@ -16,6 +16,7 @@ import type { AuthPayload } from "@/services/core/auth-service";
 import { completeProgress } from "@/services/core/progress-service";
 import { SyncQueueService } from "@/services/file/sync-queue-service";
 import { LibraryRAGService } from "@/services/rag/rag-service";
+import { RetryLimitService } from "@/services/retry-limit-service";
 
 // Extend the context to include userAuth
 type ContextWithAuth = Context<{ Bindings: Env }> & {
@@ -235,8 +236,43 @@ export async function handleTriggerIndexing(c: ContextWithAuth) {
 			);
 		}
 
+		// In-progress check: block retry until current indexing completes
+		const inProgressStatuses = [
+			FileDAO.STATUS.PROCESSING,
+			FileDAO.STATUS.SYNCING,
+			FileDAO.STATUS.INDEXING,
+		];
+		if (inProgressStatuses.includes(file.status)) {
+			return c.json(
+				{
+					success: false,
+					message:
+						"Please wait for the current indexing to complete before retrying.",
+					error: "INDEXING_IN_PROGRESS",
+				},
+				409
+			);
+		}
+
 		// Reset status from ERROR to UPLOADED before retrying
 		if (file.status === FileDAO.STATUS.ERROR || file.status === "failed") {
+			// Limit check: per-file daily and monthly retry limits
+			const retryLimit = await RetryLimitService.checkAndIncrementRetry(
+				userAuth.username,
+				fileKey,
+				userAuth.isAdmin ?? false,
+				c.env
+			);
+			if (!retryLimit.allowed) {
+				return c.json(
+					{
+						success: false,
+						message: retryLimit.reason,
+						error: "RETRY_LIMIT_EXCEEDED",
+					},
+					429
+				);
+			}
 			console.log(
 				`[handleTriggerIndexing] Resetting file status from ${file.status} to UPLOADED for retry: ${file.file_name}`
 			);

--- a/src/routes/register-routes.ts
+++ b/src/routes/register-routes.ts
@@ -25,6 +25,7 @@ import {
 	handleBillingPortal,
 	handleBillingStatus,
 	handleBillingWebhook,
+	handleRetryLimitStatus,
 } from "@/routes/billing";
 import {
 	handleApproveShards,
@@ -250,6 +251,11 @@ export function registerRoutes(app: Hono<{ Bindings: Env }>) {
 		toApiRoutePath(API_CONFIG.ENDPOINTS.BILLING.STATUS),
 		requireUserJwt,
 		handleBillingStatus
+	);
+	app.get(
+		toApiRoutePath(API_CONFIG.ENDPOINTS.BILLING.RETRY_LIMIT_STATUS),
+		requireUserJwt,
+		handleRetryLimitStatus
 	);
 	app.post(
 		toApiRoutePath(API_CONFIG.ENDPOINTS.BILLING.CHECKOUT),

--- a/src/services/retry-limit-service.ts
+++ b/src/services/retry-limit-service.ts
@@ -1,0 +1,103 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { getDAOFactory } from "@/dao/dao-factory";
+import { getSubscriptionService } from "@/services/billing/subscription-service";
+
+export interface RetryLimitResult {
+	allowed: boolean;
+	reason?: string;
+}
+
+export class RetryLimitService {
+	/**
+	 * Check if user can retry (read-only, does not increment).
+	 * Used by UI to disable retry button with tooltip when limit is reached.
+	 */
+	static async checkRetryLimit(
+		username: string,
+		fileKey: string,
+		isAdmin: boolean,
+		env: { DB: D1Database }
+	): Promise<RetryLimitResult> {
+		if (isAdmin) {
+			return { allowed: true };
+		}
+
+		const subService = getSubscriptionService(env as any);
+		const tier = await subService.getTier(username, isAdmin);
+		const limits = subService.getTierLimits(tier);
+
+		const dailyLimit = limits.retriesPerFilePerDay;
+		const monthlyLimit = limits.retriesPerFilePerMonth;
+
+		const fileRetryDAO = getDAOFactory(env).fileRetryUsageDAO;
+		const dailyRetries = await fileRetryDAO.getRetriesForFileToday(
+			username,
+			fileKey
+		);
+		const monthlyRetries = await fileRetryDAO.getRetriesForFileThisMonth(
+			username,
+			fileKey
+		);
+
+		if (dailyRetries >= dailyLimit) {
+			return {
+				allowed: false,
+				reason: `Daily retry limit (${dailyLimit} per file) reached. Try again tomorrow.`,
+			};
+		}
+
+		if (monthlyRetries >= monthlyLimit) {
+			return {
+				allowed: false,
+				reason: `Monthly retry limit (${monthlyLimit} per file) reached. Upgrade for more retries.`,
+			};
+		}
+
+		return { allowed: true };
+	}
+
+	static async checkAndIncrementRetry(
+		username: string,
+		fileKey: string,
+		isAdmin: boolean,
+		env: { DB: D1Database }
+	): Promise<RetryLimitResult> {
+		if (isAdmin) {
+			return { allowed: true };
+		}
+
+		const subService = getSubscriptionService(env as any);
+		const tier = await subService.getTier(username, isAdmin);
+		const limits = subService.getTierLimits(tier);
+
+		const dailyLimit = limits.retriesPerFilePerDay;
+		const monthlyLimit = limits.retriesPerFilePerMonth;
+
+		const fileRetryDAO = getDAOFactory(env).fileRetryUsageDAO;
+		const dailyRetries = await fileRetryDAO.getRetriesForFileToday(
+			username,
+			fileKey
+		);
+		const monthlyRetries = await fileRetryDAO.getRetriesForFileThisMonth(
+			username,
+			fileKey
+		);
+
+		if (dailyRetries >= dailyLimit) {
+			return {
+				allowed: false,
+				reason: `Daily retry limit (${dailyLimit} per file) reached. Try again tomorrow.`,
+			};
+		}
+
+		if (monthlyRetries >= monthlyLimit) {
+			return {
+				allowed: false,
+				reason: `Monthly retry limit (${monthlyLimit} per file) reached. Upgrade for more retries.`,
+			};
+		}
+
+		await fileRetryDAO.incrementRetry(username, fileKey);
+		return { allowed: true };
+	}
+}

--- a/src/shared-config.ts
+++ b/src/shared-config.ts
@@ -317,6 +317,7 @@ export const API_CONFIG = {
 			PORTAL: "/billing/portal",
 			WEBHOOK: "/billing/webhook",
 			STATUS: "/billing/status",
+			RETRY_LIMIT_STATUS: "/billing/retry-limit-status",
 		},
 		AUTH: {
 			LOGOUT: "/auth/logout",


### PR DESCRIPTION
- Add retriesPerFilePerDay and retriesPerFilePerMonth to TierLimits
- Create file_retry_usage table and FileRetryUsageDAO
- Add RetryLimitService with checkAndIncrementRetry and checkRetryLimit
- Enforce in-progress guard (no retry until last attempt completes)
- Enforce limits in handleRetryEntityExtraction and handleTriggerIndexing
- Add GET /billing/retry-limit-status API for UI
- Add useRetryLimitStatus hook
- Disable retry buttons with tooltip when limit reached (CampaignResourcesTab, FileStatusIndicator, ResourceFileDetails)

Made-with: Cursor