### PR TITLE
Shard approval/rejection performance improvements

### DIFF
--- a/src/dao/entity-dao.ts
+++ b/src/dao/entity-dao.ts
@@ -293,6 +293,30 @@ export class EntityDAO extends BaseDAOClass {
 		await this.execute(sql, values);
 	}
 
+	/**
+	 * Batch update entities (metadata and shardStatus). Each entity can have different metadata.
+	 */
+	async updateEntitiesBatch(
+		updates: Array<{
+			entityId: string;
+			metadata: Record<string, unknown>;
+			shardStatus: string;
+		}>
+	): Promise<void> {
+		if (updates.length === 0) return;
+
+		const sql = `
+      UPDATE entities
+      SET metadata = ?, shard_status = ?, updated_at = CURRENT_TIMESTAMP
+      WHERE id = ?
+    `;
+		const stmt = this.db.prepare(sql);
+		const batch = updates.map((u) =>
+			stmt.bind(JSON.stringify(u.metadata), u.shardStatus, u.entityId)
+		);
+		await this.db.batch(batch);
+	}
+
 	async getEntityById(entityId: string): Promise<Entity | null> {
 		// Entity IDs are campaign-scoped with format: ${campaignId}_${baseId}
 		// So we only need to check by ID - the campaign is already encoded in the ID
@@ -716,6 +740,49 @@ export class EntityDAO extends BaseDAOClass {
 		}
 
 		return this.mapRelationshipRecord(record);
+	}
+
+	/**
+	 * Batch upsert relationships. Does not return the created records.
+	 */
+	async upsertRelationshipsBatch(
+		relationships: CreateEntityRelationshipInput[]
+	): Promise<void> {
+		if (relationships.length === 0) return;
+
+		const sql = `
+      INSERT INTO entity_relationships (
+        id,
+        campaign_id,
+        from_entity_id,
+        to_entity_id,
+        relationship_type,
+        strength,
+        metadata,
+        created_at,
+        updated_at
+      ) VALUES (
+        ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      )
+      ON CONFLICT(from_entity_id, to_entity_id, relationship_type)
+      DO UPDATE SET
+        strength = excluded.strength,
+        metadata = excluded.metadata,
+        updated_at = CURRENT_TIMESTAMP
+    `;
+		const stmt = this.db.prepare(sql);
+		const batch = relationships.map((r) =>
+			stmt.bind(
+				r.id ?? crypto.randomUUID(),
+				r.campaignId,
+				r.fromEntityId,
+				r.toEntityId,
+				r.relationshipType,
+				r.strength ?? null,
+				r.metadata ? JSON.stringify(r.metadata) : null
+			)
+		);
+		await this.db.batch(batch);
 	}
 
 	async deleteRelationship(relationshipId: string): Promise<void> {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -16,6 +16,7 @@ export interface Env extends AuthEnv, EnvWithSecrets {
 	FILE_PROCESSING_QUEUE: Queue;
 	FILE_PROCESSING_DLQ: Queue;
 	GRAPH_REBUILD_QUEUE: Queue;
+	SHARD_EMBEDDING_QUEUE?: Queue;
 }
 
 // Set user authentication data in context

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -17,7 +17,9 @@ import { CommunitySummaryService } from "./services/graph/community-summary-serv
 import { RebuildQueueProcessor } from "./services/graph/rebuild-queue-processor";
 import { RebuildQueueService } from "./services/graph/rebuild-queue-service";
 import { RebuildTriggerService } from "./services/graph/rebuild-trigger-service";
+import { ShardEmbeddingQueueProcessor } from "./services/graph/shard-embedding-queue-processor";
 import type { RebuildQueueMessage } from "./types/rebuild-queue";
+import type { ShardEmbeddingQueueMessage } from "./types/shard-embedding-queue";
 
 export interface ProcessingMessage {
 	bucket: string;
@@ -263,21 +265,40 @@ function isRebuildQueueMessage(message: any): message is RebuildQueueMessage {
 	);
 }
 
+// Type guard to check if message is a shard embedding queue message
+function isShardEmbeddingQueueMessage(
+	message: any
+): message is ShardEmbeddingQueueMessage {
+	return (
+		message &&
+		typeof message === "object" &&
+		message.type === "shard_embedding" &&
+		Array.isArray(message.entityIds) &&
+		typeof message.campaignId === "string" &&
+		typeof message.username === "string"
+	);
+}
+
 // Export the queue handler function for Wrangler
 export async function queue(
-	batch: MessageBatch<ProcessingMessage | RebuildQueueMessage>,
+	batch: MessageBatch<
+		ProcessingMessage | RebuildQueueMessage | ShardEmbeddingQueueMessage
+	>,
 	env: Env
 ): Promise<void> {
 	console.log(`[Queue] Processing ${batch.messages.length} messages`);
 
 	const fileProcessor = new FileProcessingQueue(env);
 	const rebuildProcessor = new RebuildQueueProcessor(env);
+	const shardEmbeddingProcessor = new ShardEmbeddingQueueProcessor(env);
 
 	for (const message of batch.messages) {
 		try {
 			// Route to appropriate processor based on message type
 			if (isRebuildQueueMessage(message.body)) {
 				await rebuildProcessor.handleMessage(message.body);
+			} else if (isShardEmbeddingQueueMessage(message.body)) {
+				await shardEmbeddingProcessor.handleMessage(message.body);
 			} else {
 				await fileProcessor.handleMessage(message.body as ProcessingMessage);
 			}

--- a/src/routes/campaign-graphrag.ts
+++ b/src/routes/campaign-graphrag.ts
@@ -7,32 +7,14 @@ import {
 import { getEnvVar } from "@/lib/env-utils";
 import { notifyCampaignMembers } from "@/lib/notifications";
 import { type ContextWithAuth, verifyCampaignAccess } from "@/lib/route-utils";
-import { OpenAIEmbeddingService } from "@/services/embedding/openai-embedding-service";
 import { getGraphServices } from "@/services/graph/graph-service-factory";
 import { createLLMProvider } from "@/services/llm/llm-provider-factory";
 import { getLLMRateLimitService } from "@/services/llm/llm-rate-limit-service";
-import { EntityEmbeddingService } from "@/services/vectorize/entity-embedding-service";
-
-interface PendingRelation {
-	relationshipType: string;
-	targetId: string;
-	strength?: number | null;
-	metadata?: Record<string, unknown>;
-}
 
 interface DirtyRelationshipRef {
 	fromEntityId: string;
 	toEntityId: string;
 	relationshipType: string;
-}
-
-/**
- * Extract pendingRelations from entity metadata
- */
-function extractPendingRelations(
-	metadata: Record<string, unknown>
-): PendingRelation[] {
-	return (metadata.pendingRelations as Array<PendingRelation>) || [];
 }
 
 /**
@@ -95,36 +77,6 @@ async function checkAndRunCommunityDetection(
 			`[Server] Rebuild not enqueued for campaign ${campaignId}: ${result.reason}`
 		);
 	}
-}
-
-/**
- * Validate entity exists and is in staging status
- */
-async function validateStagingEntity(
-	daoFactory: ReturnType<typeof getDAOFactory>,
-	entityId: string,
-	campaignId: string
-): Promise<{ entity: any; pendingRelations: PendingRelation[] } | null> {
-	const entity = await daoFactory.entityDAO.getEntityById(entityId);
-
-	if (!entity || entity.campaignId !== campaignId) {
-		console.warn(
-			`[Server] Entity ${entityId} not found or wrong campaign, skipping`
-		);
-		return null;
-	}
-
-	const metadata = (entity.metadata as Record<string, unknown>) || {};
-	if (metadata.shardStatus !== "staging") {
-		console.log(
-			`[Server] Entity ${entityId} is not in staging (status: ${metadata.shardStatus}), skipping`
-		);
-		return null;
-	}
-
-	const pendingRelations = extractPendingRelations(metadata);
-
-	return { entity, pendingRelations };
 }
 
 // Get staged entities for a campaign (UI refers to them as "shards")
@@ -279,30 +231,26 @@ export async function handleApproveShards(c: ContextWithAuth) {
 
 		const daoFactory = getDAOFactory(c.env);
 		const graphService = daoFactory.entityGraphService;
-		const embeddingService = new EntityEmbeddingService(c.env.VECTORIZE);
-		const openaiApiKeyRaw = await getEnvVar(c.env, "OPENAI_API_KEY", false);
-		const openaiApiKey = openaiApiKeyRaw.trim() || undefined;
-		const openaiEmbeddingService = new OpenAIEmbeddingService(openaiApiKey);
+		const graphServices = getGraphServices(c.env as any);
 
 		// Diagnostic: report campaign entity count without materializing all rows.
 		const campaignEntityCount =
 			await daoFactory.entityDAO.getEntityCountByCampaign(campaignId);
 		console.log(`[Server] Campaign has ${campaignEntityCount} total entities.`);
 
-		// Validate first: stub shards must have required fields filled; fail entire request if any are insufficient
+		// Fetch only entities that exist, belong to this campaign, and are in staging (filter in SQL)
+		const validEntities = await daoFactory.entityDAO.listEntitiesByCampaign(
+			campaignId,
+			{ entityIds: shardIds, shardStatus: "staging" }
+		);
+
+		// Stub shards must have required fields filled; fail entire request if any are insufficient
 		const insufficientStubs: Array<{
 			entityId: string;
 			name: string;
 			missingFields: string[];
 		}> = [];
-		for (const entityId of shardIds) {
-			const validationResult = await validateStagingEntity(
-				daoFactory,
-				entityId,
-				campaignId
-			);
-			if (!validationResult) continue;
-			const { entity } = validationResult;
+		for (const entity of validEntities) {
 			const meta = (entity.metadata as Record<string, unknown>) || {};
 			if (
 				meta.isStub === true &&
@@ -337,27 +285,9 @@ export async function handleApproveShards(c: ContextWithAuth) {
 			);
 		}
 
-		let approvedCount = 0;
-		const relationshipCount = 0;
-		const touchedEntityIds = new Set<string>();
-		const touchedRelationships: DirtyRelationshipRef[] = [];
-
-		// Approve each entity (shardIds from UI are entity IDs) and create its relationships
-		for (const entityId of shardIds) {
-			const validationResult = await validateStagingEntity(
-				daoFactory,
-				entityId,
-				campaignId
-			);
-
-			if (!validationResult) {
-				continue;
-			}
-
-			const { entity } = validationResult;
+		// Batch entity updates
+		const entityUpdates = validEntities.map((entity) => {
 			const metadata = (entity.metadata as Record<string, unknown>) || {};
-
-			// Update entity status to approved (remove pendingRelations from metadata)
 			const { pendingRelations: _, ...metadataWithoutPending } = metadata;
 			const updatedMetadata = {
 				...metadataWithoutPending,
@@ -365,108 +295,50 @@ export async function handleApproveShards(c: ContextWithAuth) {
 				staged: false,
 				approvedAt: new Date().toISOString(),
 			};
-
-			await daoFactory.entityDAO.updateEntity(entityId, {
+			return {
+				entityId: entity.id,
 				metadata: updatedMetadata,
-				shardStatus: "approved",
-			});
-			touchedEntityIds.add(entityId);
+				shardStatus: "approved" as string,
+			};
+		});
+		if (entityUpdates.length > 0) {
+			await daoFactory.entityDAO.updateEntitiesBatch(entityUpdates);
+		}
 
-			// Ensure entity embedding is indexed in Vectorize for searchability
-			try {
-				// Check if embedding already exists in Vectorize by trying to find similar entities
-				// This will return empty if the embedding doesn't exist
-				let hasEmbedding = false;
-				if (c.env.VECTORIZE) {
-					const existingVectors = await c.env.VECTORIZE.getByIds([entityId]);
-					hasEmbedding = existingVectors && existingVectors.length > 0;
-				}
+		const approvedCount = validEntities.length;
+		const approvedEntityIds = validEntities.map((e) => e.id);
+		const touchedEntityIds = new Set<string>(approvedEntityIds);
+		const touchedRelationships: DirtyRelationshipRef[] = [];
 
-				if (!hasEmbedding) {
-					// Generate and index embedding for this entity
-					// Use the same text generation logic as EntityExtractionPipeline
-					const contentText =
-						typeof entity.content === "string"
-							? entity.content
-							: JSON.stringify(entity.content || {});
-					const entityText = contentText;
-
-					console.log(
-						`[Server] Creating embedding for approved entity: ${entityId} (${entity.name})`
-					);
-
-					const rateLimitService = getLLMRateLimitService(c.env);
-					const embedding = await openaiEmbeddingService.generateEmbedding(
-						entityText,
-						{
-							username: userAuth.username,
-							onUsage: async (usage) => {
-								await rateLimitService.recordUsage(
-									userAuth.username,
-									usage.tokens,
-									usage.queryCount
-								);
-							},
-						}
-					);
-					await embeddingService.upsertEmbedding({
-						entityId: entity.id,
-						campaignId: entity.campaignId,
-						entityType: entity.entityType,
-						embedding,
-						metadata: updatedMetadata,
-					});
-
-					console.log(
-						`[Server] Successfully indexed embedding for entity: ${entityId}`
-					);
-				} else {
-					// Update existing embedding metadata to reflect approval status
-					if (c.env.VECTORIZE) {
-						const existingVectors = await c.env.VECTORIZE.getByIds([entityId]);
-						const existingEmbedding = existingVectors?.[0];
-						if (existingEmbedding?.values) {
-							await embeddingService.upsertEmbedding({
-								entityId: entity.id,
-								campaignId: entity.campaignId,
-								entityType: entity.entityType,
-								embedding: Array.from(existingEmbedding.values),
-								metadata: updatedMetadata,
-							});
-							console.log(
-								`[Server] Updated embedding metadata for entity: ${entityId}`
-							);
-						}
-					}
-				}
-			} catch (error) {
-				console.warn(
-					`[Server] Failed to index embedding for entity ${entityId}:`,
-					error
-				);
-				// Continue with approval even if embedding fails
-			}
-
-			approvedCount++;
-
-			// Update relationship status from staging to approved
-			const relationships = await graphService.getRelationshipsForEntity(
-				campaignId,
-				entityId
-			);
-			for (const rel of relationships) {
+		// Batch load relationships and update staging → approved
+		const relationshipsMap = await graphService.getRelationshipsForEntities(
+			campaignId,
+			approvedEntityIds
+		);
+		const seenEdgeKeys = new Set<string>();
+		const edgesToApprove: Array<{
+			campaignId: string;
+			fromEntityId: string;
+			toEntityId: string;
+			relationshipType: string;
+			strength?: number | null;
+			metadata?: unknown;
+			allowSelfRelation?: boolean;
+		}> = [];
+		for (const rels of relationshipsMap.values()) {
+			for (const rel of rels) {
 				const relMetadata = (rel.metadata as Record<string, unknown>) || {};
 				if (relMetadata.status === "staging") {
-					await graphService.upsertEdge({
+					const key = `${rel.fromEntityId}|${rel.toEntityId}|${rel.relationshipType}`;
+					if (seenEdgeKeys.has(key)) continue;
+					seenEdgeKeys.add(key);
+					edgesToApprove.push({
 						campaignId,
 						fromEntityId: rel.fromEntityId,
 						toEntityId: rel.toEntityId,
 						relationshipType: rel.relationshipType,
 						strength: rel.strength,
-						metadata: {
-							...relMetadata,
-							status: "approved",
-						},
+						metadata: { ...relMetadata, status: "approved" },
 						allowSelfRelation: false,
 					});
 					touchedEntityIds.add(rel.fromEntityId);
@@ -479,18 +351,43 @@ export async function handleApproveShards(c: ContextWithAuth) {
 				}
 			}
 		}
+		if (edgesToApprove.length > 0) {
+			await graphService.upsertEdgesBatch(edgesToApprove);
+		}
+		const relationshipCount = edgesToApprove.length;
 
 		console.log(
 			`[Server] Approved ${approvedCount} entities and created ${relationshipCount} relationships for campaign: ${campaignId}`
 		);
 
-		const approvedEntityIds = Array.from(touchedEntityIds);
-		if (approvedEntityIds.length > 0) {
+		// Defer embedding generation to background queue for faster UI response
+		if (
+			approvedEntityIds.length > 0 &&
+			graphServices.shardEmbeddingQueue &&
+			c.env.VECTORIZE
+		) {
+			try {
+				await graphServices.shardEmbeddingQueue.enqueueShardEmbedding({
+					type: "shard_embedding",
+					entityIds: approvedEntityIds,
+					campaignId,
+					username: userAuth.username,
+				});
+			} catch (error) {
+				console.warn(
+					"[Server] Failed to enqueue shard embedding, embeddings will not be indexed:",
+					error
+				);
+			}
+		}
+
+		const approvedEntityIdsForRebuild = Array.from(touchedEntityIds);
+		if (approvedEntityIdsForRebuild.length > 0) {
 			await checkAndRunCommunityDetection(
 				daoFactory,
 				campaignId,
 				c.env as any,
-				approvedEntityIds,
+				approvedEntityIdsForRebuild,
 				touchedRelationships,
 				userAuth.username
 			);
@@ -561,54 +458,62 @@ export async function handleRejectShards(c: ContextWithAuth) {
 		const daoFactory = getDAOFactory(c.env);
 		const graphService = daoFactory.entityGraphService;
 
-		let rejectedCount = 0;
-		const relationshipCount = 0;
-		const touchedEntityIds = new Set<string>();
-		const touchedRelationships: DirtyRelationshipRef[] = [];
+		// Fetch only entities that exist, belong to this campaign, and are in staging (filter in SQL)
+		const validEntities = await daoFactory.entityDAO.listEntitiesByCampaign(
+			campaignId,
+			{ entityIds: shardIds, shardStatus: "staging" }
+		);
 
-		// Reject each entity (shardIds from UI are entity IDs) - mark as rejected but keep in graph with ignore flag
-		for (const entityId of shardIds) {
-			const validationResult = await validateStagingEntity(
-				daoFactory,
-				entityId,
-				campaignId
-			);
-
-			if (!validationResult) {
-				continue;
-			}
-
-			const { entity } = validationResult;
-
-			// Update entity status to rejected with ignore flag (remove pendingRelations from metadata)
+		// Batch entity updates
+		const entityUpdates = validEntities.map((entity) => {
 			const metadata = (entity.metadata as Record<string, unknown>) || {};
 			const { pendingRelations: _, ...metadataWithoutPending } = metadata;
 			const updatedMetadata = {
 				...metadataWithoutPending,
 				shardStatus: "rejected" as const,
 				rejected: true,
-				ignored: true, // Flag to ignore this entity in graph operations
+				ignored: true,
 				rejectionReason: reason,
 				rejectedAt: new Date().toISOString(),
 			};
-
-			await daoFactory.entityDAO.updateEntity(entityId, {
+			return {
+				entityId: entity.id,
 				metadata: updatedMetadata,
-				shardStatus: "rejected",
-			});
-			touchedEntityIds.add(entityId);
+				shardStatus: "rejected" as string,
+			};
+		});
+		if (entityUpdates.length > 0) {
+			await daoFactory.entityDAO.updateEntitiesBatch(entityUpdates);
+		}
 
-			rejectedCount++;
+		const rejectedCount = validEntities.length;
+		const rejectedEntityIds = validEntities.map((e) => e.id);
+		const touchedEntityIds = new Set<string>(rejectedEntityIds);
+		const touchedRelationships: DirtyRelationshipRef[] = [];
 
-			// Update relationship status from staging to rejected
-			const relationships = await graphService.getRelationshipsForEntity(
-				campaignId,
-				entityId
-			);
-			for (const rel of relationships) {
+		// Batch load relationships and update staging → rejected
+		const relationshipsMap = await graphService.getRelationshipsForEntities(
+			campaignId,
+			rejectedEntityIds
+		);
+		const seenEdgeKeys = new Set<string>();
+		const edgesToReject: Array<{
+			campaignId: string;
+			fromEntityId: string;
+			toEntityId: string;
+			relationshipType: string;
+			strength?: number | null;
+			metadata?: unknown;
+			allowSelfRelation?: boolean;
+		}> = [];
+		for (const rels of relationshipsMap.values()) {
+			for (const rel of rels) {
 				const relMetadata = (rel.metadata as Record<string, unknown>) || {};
 				if (relMetadata.status === "staging") {
-					await graphService.upsertEdge({
+					const key = `${rel.fromEntityId}|${rel.toEntityId}|${rel.relationshipType}`;
+					if (seenEdgeKeys.has(key)) continue;
+					seenEdgeKeys.add(key);
+					edgesToReject.push({
 						campaignId,
 						fromEntityId: rel.fromEntityId,
 						toEntityId: rel.toEntityId,
@@ -633,18 +538,22 @@ export async function handleRejectShards(c: ContextWithAuth) {
 				}
 			}
 		}
+		if (edgesToReject.length > 0) {
+			await graphService.upsertEdgesBatch(edgesToReject);
+		}
+		const relationshipCount = edgesToReject.length;
 
 		console.log(
 			`[Server] Rejected ${rejectedCount} entities and created ${relationshipCount} relationships (marked as ignored) for campaign: ${campaignId}`
 		);
 
-		const rejectedEntityIds = Array.from(touchedEntityIds);
-		if (rejectedEntityIds.length > 0) {
+		const rejectedEntityIdsForRebuild = Array.from(touchedEntityIds);
+		if (rejectedEntityIdsForRebuild.length > 0) {
 			await checkAndRunCommunityDetection(
 				daoFactory,
 				campaignId,
 				c.env as any,
-				rejectedEntityIds,
+				rejectedEntityIdsForRebuild,
 				touchedRelationships,
 				userAuth.username
 			);

--- a/src/routes/register-routes.ts
+++ b/src/routes/register-routes.ts
@@ -221,6 +221,7 @@ export interface Env extends AuthEnv, EnvWithSecrets {
 	FILE_PROCESSING_QUEUE: Queue;
 	FILE_PROCESSING_DLQ: Queue;
 	GRAPH_REBUILD_QUEUE: Queue;
+	SHARD_EMBEDDING_QUEUE?: Queue;
 }
 
 const toApiRoutePath = (path: string) => API_CONFIG.apiRoute(path);

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import {
 import { type Env, registerRoutes } from "@/routes/register-routes";
 import { API_CONFIG } from "@/shared-config";
 import type { RebuildQueueMessage } from "@/types/rebuild-queue";
+import type { ShardEmbeddingQueueMessage } from "@/types/shard-embedding-queue";
 
 export { Chat } from "@/durable-objects/chat";
 export { NotificationHub } from "./durable-objects";
@@ -89,7 +90,9 @@ export default {
 		return app.fetch(request, env, ctx);
 	},
 	queue: (
-		batch: MessageBatch<ProcessingMessage | RebuildQueueMessage>,
+		batch: MessageBatch<
+			ProcessingMessage | RebuildQueueMessage | ShardEmbeddingQueueMessage
+		>,
 		env: Env,
 		_ctx: ExecutionContext
 	) => {

--- a/src/services/graph/entity-graph-service.ts
+++ b/src/services/graph/entity-graph-service.ts
@@ -97,6 +97,56 @@ export class EntityGraphService {
 		return created;
 	}
 
+	/**
+	 * Batch upsert edges. More efficient than calling upsertEdge repeatedly.
+	 */
+	async upsertEdgesBatch(inputs: UpsertGraphEdgeInput[]): Promise<void> {
+		if (inputs.length === 0) return;
+
+		const entityIds = new Set<string>();
+		const payloads: CreateEntityRelationshipInput[] = [];
+
+		for (const input of inputs) {
+			const normalizedType = normalizeRelationshipType(input.relationshipType);
+			const normalizedStrength = normalizeRelationshipStrength(input.strength);
+
+			if (!input.allowSelfRelation && input.fromEntityId === input.toEntityId) {
+				throw new SelfReferentialRelationshipError();
+			}
+
+			entityIds.add(input.fromEntityId);
+			entityIds.add(input.toEntityId);
+
+			payloads.push({
+				campaignId: input.campaignId,
+				fromEntityId: input.fromEntityId,
+				toEntityId: input.toEntityId,
+				relationshipType: normalizedType,
+				strength: normalizedStrength,
+				metadata: input.metadata,
+			});
+
+			if (isBidirectionalRelationship(normalizedType)) {
+				const reciprocalType = getReciprocalRelationshipType(normalizedType);
+				if (reciprocalType) {
+					payloads.push({
+						campaignId: input.campaignId,
+						fromEntityId: input.toEntityId,
+						toEntityId: input.fromEntityId,
+						relationshipType: reciprocalType,
+						strength: normalizedStrength,
+						metadata: input.metadata,
+					});
+				}
+			}
+		}
+
+		const campaignId = inputs[0].campaignId;
+		await this.ensureEntitiesInCampaign(campaignId, Array.from(entityIds));
+		await this.entityDAO.upsertRelationshipsBatch(payloads);
+		ContextAssemblyService.invalidateEntityCaches(Array.from(entityIds));
+	}
+
 	async removeEdgeById(relationshipId: string): Promise<void> {
 		// Note: Cache invalidation skipped here since we don't have entity IDs
 		// Cache will expire naturally or be invalidated on next relationship update

--- a/src/services/graph/graph-service-factory.ts
+++ b/src/services/graph/graph-service-factory.ts
@@ -5,6 +5,7 @@ import { getEnvVar } from "@/lib/env-utils";
 import type { Env } from "@/middleware/auth";
 import { RebuildPipelineService } from "./rebuild-pipeline-service";
 import { RebuildQueueService } from "./rebuild-queue-service";
+import { ShardEmbeddingQueueService } from "./shard-embedding-queue-service";
 import { WorldStateChangelogService } from "./world-state-changelog-service";
 
 function normalizeApiKey(value: string): string | undefined {
@@ -15,6 +16,7 @@ function normalizeApiKey(value: string): string | undefined {
 export function getGraphServices(env: Env): {
 	rebuildQueue: RebuildQueueService;
 	worldStateChangelog: WorldStateChangelogService;
+	shardEmbeddingQueue: ShardEmbeddingQueueService | null;
 } {
 	if (!env.GRAPH_REBUILD_QUEUE) {
 		throw new Error("GRAPH_REBUILD_QUEUE binding not configured");
@@ -26,6 +28,9 @@ export function getGraphServices(env: Env): {
 	return {
 		rebuildQueue: new RebuildQueueService(env.GRAPH_REBUILD_QUEUE),
 		worldStateChangelog: new WorldStateChangelogService({ db: env.DB }),
+		shardEmbeddingQueue: env.SHARD_EMBEDDING_QUEUE
+			? new ShardEmbeddingQueueService(env.SHARD_EMBEDDING_QUEUE)
+			: null,
 	};
 }
 

--- a/src/services/graph/shard-embedding-queue-processor.ts
+++ b/src/services/graph/shard-embedding-queue-processor.ts
@@ -1,0 +1,143 @@
+import { getDAOFactory } from "@/dao/dao-factory";
+import { getEnvVar } from "@/lib/env-utils";
+import type { Env } from "@/middleware/auth";
+import { OpenAIEmbeddingService } from "@/services/embedding/openai-embedding-service";
+import { getLLMRateLimitService } from "@/services/llm/llm-rate-limit-service";
+import { EntityEmbeddingService } from "@/services/vectorize/entity-embedding-service";
+import type { ShardEmbeddingQueueMessage } from "@/types/shard-embedding-queue";
+
+const EMBEDDING_BATCH_SIZE = 25;
+
+export class ShardEmbeddingQueueProcessor {
+	constructor(private env: Env) {}
+
+	async handleMessage(message: ShardEmbeddingQueueMessage): Promise<void> {
+		const { entityIds, campaignId, username } = message;
+
+		if (!entityIds.length) {
+			return;
+		}
+
+		const daoFactory = getDAOFactory(this.env);
+		const entityDAO = daoFactory.entityDAO;
+		const vectorize = this.env.VECTORIZE;
+		const openaiApiKeyRaw = await getEnvVar(this.env, "OPENAI_API_KEY", false);
+		const openaiApiKey = openaiApiKeyRaw?.trim() || undefined;
+
+		if (!vectorize) {
+			console.warn(
+				"[ShardEmbeddingQueue] VECTORIZE not configured, skipping embedding"
+			);
+			return;
+		}
+
+		if (!openaiApiKey) {
+			console.warn(
+				"[ShardEmbeddingQueue] OPENAI_API_KEY not configured, skipping embedding"
+			);
+			return;
+		}
+
+		const embeddingService = new EntityEmbeddingService(vectorize);
+		const openaiEmbeddingService = new OpenAIEmbeddingService(openaiApiKey);
+		const rateLimitService = getLLMRateLimitService(this.env);
+
+		const entities = await entityDAO.getEntitiesByIds(entityIds);
+		const campaignEntities = entities.filter(
+			(e) => e.campaignId === campaignId
+		);
+
+		if (campaignEntities.length === 0) {
+			return;
+		}
+
+		const existingVectors =
+			(await vectorize.getByIds(campaignEntities.map((e) => e.id))) ?? [];
+		const hasEmbeddingById = new Set(
+			existingVectors
+				.filter((v) => v?.values?.length)
+				.map((v) => v.id as string)
+		);
+
+		const toEmbed = campaignEntities.filter((e) => !hasEmbeddingById.has(e.id));
+
+		if (toEmbed.length > 0) {
+			for (let i = 0; i < toEmbed.length; i += EMBEDDING_BATCH_SIZE) {
+				const chunk = toEmbed.slice(i, i + EMBEDDING_BATCH_SIZE);
+				const texts = chunk.map((entity) => {
+					const contentText =
+						typeof entity.content === "string"
+							? entity.content
+							: JSON.stringify(entity.content || {});
+					return contentText;
+				});
+
+				const embeddings = await openaiEmbeddingService.generateEmbeddings(
+					texts,
+					{
+						username,
+						onUsage: async (usage) => {
+							await rateLimitService.recordUsage(
+								username,
+								usage.tokens,
+								usage.queryCount
+							);
+						},
+					}
+				);
+
+				await embeddingService.upsertEmbeddings(
+					chunk.map((entity, idx) => ({
+						entityId: entity.id,
+						campaignId: entity.campaignId,
+						entityType: entity.entityType,
+						embedding: embeddings[idx],
+						metadata: (entity.metadata as Record<string, unknown>) || {},
+					}))
+				);
+
+				console.log(
+					`[ShardEmbeddingQueue] Indexed embeddings for ${chunk.length} entities (batch ${Math.floor(i / EMBEDDING_BATCH_SIZE) + 1})`
+				);
+			}
+		}
+
+		const toUpdateMetadata = campaignEntities.filter((e) =>
+			hasEmbeddingById.has(e.id)
+		);
+		if (toUpdateMetadata.length > 0) {
+			const vectors = await vectorize.getByIds(
+				toUpdateMetadata.map((e) => e.id)
+			);
+			const vectorById = new Map<string, { values: number[] }>();
+			if (vectors) {
+				for (const v of vectors) {
+					if (v?.id && v?.values?.length) {
+						vectorById.set(v.id as string, {
+							values: Array.from(v.values),
+						});
+					}
+				}
+			}
+			const toUpsert = toUpdateMetadata
+				.map((entity) => {
+					const vec = vectorById.get(entity.id);
+					if (!vec) return null;
+					return {
+						entityId: entity.id,
+						campaignId: entity.campaignId,
+						entityType: entity.entityType,
+						embedding: vec.values,
+						metadata: (entity.metadata as Record<string, unknown>) || {},
+					};
+				})
+				.filter((x): x is NonNullable<typeof x> => x !== null);
+			if (toUpsert.length > 0) {
+				await embeddingService.upsertEmbeddings(toUpsert);
+				console.log(
+					`[ShardEmbeddingQueue] Updated metadata for ${toUpsert.length} existing embeddings`
+				);
+			}
+		}
+	}
+}

--- a/src/services/graph/shard-embedding-queue-service.ts
+++ b/src/services/graph/shard-embedding-queue-service.ts
@@ -1,0 +1,23 @@
+import type { Queue } from "@cloudflare/workers-types";
+import type { ShardEmbeddingQueueMessage } from "@/types/shard-embedding-queue";
+
+export class ShardEmbeddingQueueService {
+	constructor(private readonly queue: Queue<ShardEmbeddingQueueMessage>) {}
+
+	async enqueueShardEmbedding(
+		message: ShardEmbeddingQueueMessage
+	): Promise<void> {
+		try {
+			await this.queue.send(message);
+			console.log(
+				`[ShardEmbeddingQueueService] Enqueued embedding for ${message.entityIds.length} entities in campaign ${message.campaignId}`
+			);
+		} catch (error) {
+			console.error(
+				`[ShardEmbeddingQueueService] Failed to enqueue shard embedding:`,
+				error
+			);
+			throw error;
+		}
+	}
+}

--- a/src/services/vectorize/entity-embedding-service.ts
+++ b/src/services/vectorize/entity-embedding-service.ts
@@ -43,6 +43,22 @@ export class EntityEmbeddingService {
 		]);
 	}
 
+	async upsertEmbeddings(items: UpsertEntityEmbeddingOptions[]): Promise<void> {
+		if (items.length === 0) return;
+
+		const index = this.ensureIndex();
+		const vectors = items.map((options) => ({
+			id: options.entityId,
+			values: options.embedding,
+			metadata: {
+				campaignId: options.campaignId,
+				entityType: options.entityType,
+				...(options.metadata ?? {}),
+			},
+		}));
+		await index.upsert(vectors);
+	}
+
 	async deleteEmbedding(entityId: string): Promise<void> {
 		const index = this.ensureIndex();
 		await index.deleteByIds([entityId]);

--- a/src/types/shard-embedding-queue.ts
+++ b/src/types/shard-embedding-queue.ts
@@ -1,0 +1,6 @@
+export interface ShardEmbeddingQueueMessage {
+	type: "shard_embedding";
+	entityIds: string[];
+	campaignId: string;
+	username: string;
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -77,6 +77,10 @@
 			{
 				"queue": "graph-rebuild-queue",
 				"binding": "GRAPH_REBUILD_QUEUE"
+			},
+			{
+				"queue": "shard-embedding-queue",
+				"binding": "SHARD_EMBEDDING_QUEUE"
 			}
 		],
 		"consumers": [
@@ -88,6 +92,11 @@
 			{
 				"queue": "graph-rebuild-queue",
 				"max_batch_size": 1,
+				"max_retries": 3
+			},
+			{
+				"queue": "shard-embedding-queue",
+				"max_batch_size": 10,
 				"max_retries": 3
 			}
 		]


### PR DESCRIPTION
- Defer embedding to SHARD_EMBEDDING_QUEUE for faster UI response
- Batch validation using listEntitiesByCampaign (SQL filter, no param limit)
- Batch entity updates via updateEntitiesBatch
- Batch relationship load via getRelationshipsForEntities
- Batch edge updates via upsertEdgesBatch
- Queue consumer batches embeddings (25/API call) and upserts to Vectorize

Made-with: Cursor