### PR TITLE
Fix left pane scrolling: pane and sections both scrollable

### DIFF
--- a/src/components/resource-side-panel/CampaignsSection.tsx
+++ b/src/components/resource-side-panel/CampaignsSection.tsx
@@ -66,7 +66,7 @@ export function CampaignsSection({
 							</p>
 						</div>
 					) : (
-						<div className="border-t border-neutral-200 dark:border-neutral-700">
+						<div className="border-t border-neutral-200 dark:border-neutral-700 max-h-48 overflow-y-auto">
 							{campaigns.map((campaign) => (
 								<CampaignItem
 									key={campaign.campaignId}

--- a/src/components/resource-side-panel/LibrarySection.tsx
+++ b/src/components/resource-side-panel/LibrarySection.tsx
@@ -151,7 +151,7 @@ export function LibrarySection({
 	}, [files, uploadQueue?.queue]);
 
 	return (
-		<Card className="tour-library-section p-0 border-t border-neutral-200 dark:border-neutral-700 flex flex-col min-h-0 overflow-hidden flex-1">
+		<Card className="tour-library-section p-0 border-t border-neutral-200 dark:border-neutral-700 flex flex-col">
 			<button
 				type="button"
 				onClick={onToggle}
@@ -173,7 +173,7 @@ export function LibrarySection({
 			</button>
 
 			{isOpen && (
-				<div className="border-t border-neutral-200 dark:border-neutral-700 flex flex-col min-h-0 flex-1 overflow-hidden">
+				<div className="border-t border-neutral-200 dark:border-neutral-700 flex flex-col">
 					<div className="flex-shrink-0 p-2">
 						<button
 							type="button"
@@ -184,8 +184,8 @@ export function LibrarySection({
 							Add to library
 						</button>
 					</div>
-					<div className="border-t border-neutral-200 dark:border-neutral-700 flex flex-col min-h-0 flex-1 overflow-hidden">
-						<div className="min-h-0 flex-1 overflow-y-auto">
+					<div className="border-t border-neutral-200 dark:border-neutral-700 flex flex-col">
+						<div className="max-h-64 overflow-y-auto">
 							<ResourceList
 								files={displayFiles}
 								setFiles={setFiles}

--- a/src/components/resource-side-panel/ResourceSidePanel.tsx
+++ b/src/components/resource-side-panel/ResourceSidePanel.tsx
@@ -87,35 +87,37 @@ export function ResourceSidePanel({
 		<div
 			className={`tour-sidebar w-full md:w-80 h-full bg-neutral-50/80 dark:bg-neutral-900/80 border-r border-neutral-200 dark:border-neutral-700 flex flex-col backdrop-blur-sm ${className}`}
 		>
-			{/* Content - flex column so library can have internal scroll */}
-			<div className="flex-1 flex flex-col gap-3 p-4 min-h-0 overflow-hidden">
-				{/* Campaigns Section */}
-				<div className="flex-shrink-0">
-					<CampaignsSection
-						campaigns={managedCampaigns}
-						campaignsLoading={campaignsLoading}
-						campaignsError={campaignsError}
-						onToggle={() => setIsCampaignsOpen(!isCampaignsOpen)}
-						isOpen={isCampaignsOpen}
-						onCreateCampaign={onCreateCampaign || (() => {})}
-						onCampaignClick={onCampaignClick || (() => {})}
-					/>
-				</div>
+			{/* Content - scrollable pane so both sections are reachable */}
+			<div className="flex-1 min-h-0 flex flex-col overflow-y-auto">
+				<div className="flex flex-col gap-3 p-4">
+					{/* Campaigns Section */}
+					<div className="flex-shrink-0">
+						<CampaignsSection
+							campaigns={managedCampaigns}
+							campaignsLoading={campaignsLoading}
+							campaignsError={campaignsError}
+							onToggle={() => setIsCampaignsOpen(!isCampaignsOpen)}
+							isOpen={isCampaignsOpen}
+							onCreateCampaign={onCreateCampaign || (() => {})}
+							onCampaignClick={onCampaignClick || (() => {})}
+						/>
+					</div>
 
-				{/* Library Section - flex-1 to take remaining space, min-h-0 for flex shrink */}
-				<div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-					<LibrarySection
-						isOpen={isLibraryOpen}
-						onToggle={() => setIsLibraryOpen(!isLibraryOpen)}
-						onAddToLibrary={onAddResource || (() => {})}
-						onAddToCampaign={onAddToCampaign || (() => {})}
-						onEditFile={onEditFile || (() => {})}
-						campaigns={campaigns}
-						campaignAdditionProgress={campaignAdditionProgress}
-						isAddingToCampaigns={isAddingToCampaigns}
-						addLocalNotification={addLocalNotification}
-						onShowUsageLimits={onShowUsageLimits}
-					/>
+					{/* Library Section */}
+					<div className="flex-shrink-0">
+						<LibrarySection
+							isOpen={isLibraryOpen}
+							onToggle={() => setIsLibraryOpen(!isLibraryOpen)}
+							onAddToLibrary={onAddResource || (() => {})}
+							onAddToCampaign={onAddToCampaign || (() => {})}
+							onEditFile={onEditFile || (() => {})}
+							campaigns={campaigns}
+							campaignAdditionProgress={campaignAdditionProgress}
+							isAddingToCampaigns={isAddingToCampaigns}
+							addLocalNotification={addLocalNotification}
+							onShowUsageLimits={onShowUsageLimits}
+						/>
+					</div>
 				</div>
 			</div>
 


### PR DESCRIPTION
- Make pane content overflow-y-auto so both campaigns and library are reachable
- Add max-height + overflow to campaign list and library list for internal scroll
- Remove flex-1/overflow-hidden that trapped scroll within one section

Made-with: Cursor