### PR TITLE
feat: add test data factory utilities (#496)

### DIFF
--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -16,6 +16,27 @@ npm test tests/lib/leiden-algorithm.test.ts
 npm test -- --coverage
 ```
 
+## Test data factories
+
+The `tests/factories/` directory provides type-checked factory functions for creating test data with sensible defaults. Use these instead of inline mock objects to reduce boilerplate and keep tests consistent when types evolve.
+
+```ts
+import { makeCampaign, makeEntity, makeAuthPayload } from "./factories";
+
+const campaign = makeCampaign({ name: "Custom Name" });
+const entity = makeEntity({ entityType: "npc", name: "Test NPC" });
+```
+
+### Available factories
+
+- **makeCampaign**, **makeCampaignResource** – Campaign and resource data
+- **makeEntity** – Entity (campaign context entities)
+- **makeAuthPayload** – User auth payload for route tests
+- **makeSessionDigest**, **makeSessionDigestData** – Session digest records
+- **makeCommunity** – Community (graph communities)
+
+Campaign tests also support legacy aliases: `createMockCampaign` and `createMockResource` from `tests/campaign/testUtils.ts` (re-exports from factories).
+
 ## Priority areas for coverage
 
 When adding or extending tests, these areas are high priority:
@@ -35,10 +56,10 @@ The following describes campaign-specific tests. The tests cover campaign manage
 
 ### `testUtils.ts`
 
-Contains shared test utilities and mock functions:
+Contains campaign-specific utilities (Durable Object stubs, env helpers). For mock data, prefer `tests/factories/`:
 
-- `createMockCampaign()` - Creates mock campaign data for testing
-- `createMockResource()` - Creates mock resource data for testing
+- `makeCampaign()`, `makeCampaignResource()` - Use from `../factories` (or deprecated aliases below)
+- `createMockCampaign()`, `createMockResource()` - Deprecated aliases for factories
 - `createCampaignManagerStub()` - Creates mock Durable Object stubs
 - `createCampaignsKVStub()` - Creates mock KV storage stubs
 - `createTestEnv()` - Creates test environment with mocked dependencies

--- a/tests/campaign/durable-objects.test.ts
+++ b/tests/campaign/durable-objects.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CampaignData } from "../../src/types/campaign";
-import { createMockCampaign, createMockResource } from "./testUtils";
+import { makeCampaign, makeCampaignResource } from "../factories";
 
 // Mock the CampaignManager Durable Object
 vi.mock("../../src/durable-objects/CampaignManager", () => ({
@@ -22,7 +22,7 @@ describe("Campaign Durable Objects", () => {
 				list: vi.fn(),
 			};
 
-			const mockCampaign = createMockCampaign({
+			const mockCampaign = makeCampaign({
 				campaignId: "test-campaign",
 				name: "Test Campaign",
 			});
@@ -50,7 +50,7 @@ describe("Campaign Durable Objects", () => {
 				list: vi.fn(),
 			};
 
-			const mockCampaign = createMockCampaign({
+			const mockCampaign = makeCampaign({
 				campaignId: "test-campaign",
 				name: "Test Campaign",
 			});
@@ -100,8 +100,8 @@ describe("Campaign Durable Objects", () => {
 			};
 
 			const mockCampaigns = [
-				createMockCampaign({ campaignId: "campaign-1", name: "Campaign 1" }),
-				createMockCampaign({ campaignId: "campaign-2", name: "Campaign 2" }),
+				makeCampaign({ campaignId: "campaign-1", name: "Campaign 1" }),
+				makeCampaign({ campaignId: "campaign-2", name: "Campaign 2" }),
 			];
 
 			// Mock KV list operation
@@ -158,13 +158,13 @@ describe("Campaign Durable Objects", () => {
 				list: vi.fn(),
 			};
 
-			const existingCampaign = createMockCampaign({
+			const existingCampaign = makeCampaign({
 				campaignId: "test-campaign",
 				name: "Test Campaign",
 				resources: [],
 			});
 
-			const newResource = createMockResource({
+			const newResource = makeCampaignResource({
 				id: "new-resource",
 				name: "New Resource",
 				type: "pdf",
@@ -204,12 +204,12 @@ describe("Campaign Durable Objects", () => {
 				list: vi.fn(),
 			};
 
-			const existingCampaign = createMockCampaign({
+			const existingCampaign = makeCampaign({
 				campaignId: "test-campaign",
 				name: "Test Campaign",
 				resources: [
-					createMockResource({ id: "resource-1", name: "Resource 1" }),
-					createMockResource({ id: "resource-2", name: "Resource 2" }),
+					makeCampaignResource({ id: "resource-1", name: "Resource 1" }),
+					makeCampaignResource({ id: "resource-2", name: "Resource 2" }),
 				],
 			});
 
@@ -250,11 +250,11 @@ describe("Campaign Durable Objects", () => {
 				list: vi.fn(),
 			};
 
-			const existingCampaign = createMockCampaign({
+			const existingCampaign = makeCampaign({
 				campaignId: "test-campaign",
 				name: "Test Campaign",
 				resources: [
-					createMockResource({ id: "resource-1", name: "Resource 1" }),
+					makeCampaignResource({ id: "resource-1", name: "Resource 1" }),
 				],
 			});
 
@@ -279,16 +279,16 @@ describe("Campaign Durable Objects", () => {
 
 	describe("Campaign Indexing", () => {
 		it("should trigger indexing for campaign with resources", async () => {
-			const mockCampaign = createMockCampaign({
+			const mockCampaign = makeCampaign({
 				campaignId: "test-campaign",
 				name: "Test Campaign",
 				resources: [
-					createMockResource({
+					makeCampaignResource({
 						id: "pdf-1",
 						name: "Document.pdf",
 						type: "pdf",
 					}),
-					createMockResource({
+					makeCampaignResource({
 						id: "pdf-2",
 						name: "Adventure.pdf",
 						type: "pdf",
@@ -312,7 +312,7 @@ describe("Campaign Durable Objects", () => {
 		});
 
 		it("should handle indexing for campaign without resources", async () => {
-			const mockCampaign = createMockCampaign({
+			const mockCampaign = makeCampaign({
 				campaignId: "empty-campaign",
 				name: "Empty Campaign",
 				resources: [],
@@ -346,7 +346,7 @@ describe("Campaign Durable Objects", () => {
 
 	describe("Data Validation", () => {
 		it("should validate campaign data structure", () => {
-			const mockCampaign = createMockCampaign({
+			const mockCampaign = makeCampaign({
 				campaignId: "test-id",
 				name: "Test Campaign",
 				resources: [],
@@ -366,7 +366,7 @@ describe("Campaign Durable Objects", () => {
 		});
 
 		it("should validate resource data structure", () => {
-			const mockResource = createMockResource({
+			const mockResource = makeCampaignResource({
 				id: "test-resource",
 				name: "Test Resource",
 				type: "pdf",

--- a/tests/campaign/hooks.test.ts
+++ b/tests/campaign/hooks.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockCampaign, createMockResource } from "./testUtils";
+import { makeCampaign, makeCampaignResource } from "../factories";
 
 // Mock fetch
 global.fetch = vi.fn();
@@ -12,8 +12,8 @@ describe("Campaign Hooks", () => {
 	describe("useCampaigns", () => {
 		it("should fetch campaigns successfully", async () => {
 			const mockCampaigns = [
-				createMockCampaign({ campaignId: "1", name: "Campaign 1" }),
-				createMockCampaign({ campaignId: "2", name: "Campaign 2" }),
+				makeCampaign({ campaignId: "1", name: "Campaign 1" }),
+				makeCampaign({ campaignId: "2", name: "Campaign 2" }),
 			];
 
 			(global.fetch as any).mockResolvedValueOnce({
@@ -58,10 +58,12 @@ describe("Campaign Hooks", () => {
 
 	describe("useCampaignDetail", () => {
 		it("should fetch campaign details successfully", async () => {
-			const mockCampaign = createMockCampaign({
+			const mockCampaign = makeCampaign({
 				campaignId: "1",
 				name: "Test Campaign",
-				resources: [createMockResource({ id: "pdf-1", name: "Document.pdf" })],
+				resources: [
+					makeCampaignResource({ id: "pdf-1", name: "Document.pdf" }),
+				],
 			});
 
 			(global.fetch as any).mockResolvedValueOnce({
@@ -94,7 +96,7 @@ describe("Campaign Hooks", () => {
 
 	describe("useCampaignActions", () => {
 		it("should create campaign successfully", async () => {
-			const mockCampaign = createMockCampaign({
+			const mockCampaign = makeCampaign({
 				campaignId: "new-campaign",
 				name: "New Campaign",
 			});
@@ -117,7 +119,7 @@ describe("Campaign Hooks", () => {
 
 		it("should add resource to campaign successfully", async () => {
 			const mockResources = [
-				createMockResource({ id: "new-resource", name: "New Resource" }),
+				makeCampaignResource({ id: "new-resource", name: "New Resource" }),
 			];
 
 			(global.fetch as any).mockResolvedValueOnce({

--- a/tests/campaign/testUtils.ts
+++ b/tests/campaign/testUtils.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
-import type { CampaignData, CampaignResource } from "../../src/types/campaign";
+import type { CampaignData } from "../../src/types/campaign";
+import { makeCampaign, makeCampaignResource } from "../factories";
 
 // Define proper types for the environment and stubs
 type CampaignManagerStub = {
@@ -60,13 +61,7 @@ export function createCampaignManagerStub(
 					status: 200,
 					json: async () => ({
 						success: true,
-						campaign: campaign || {
-							campaignId: "test-campaign-id",
-							name: "Test Campaign",
-							createdAt: new Date().toISOString(),
-							updatedAt: new Date().toISOString(),
-							resources: [],
-						},
+						campaign: campaign ?? makeCampaign(),
 					}),
 				};
 			}
@@ -155,35 +150,11 @@ export function createCampaignManagerStub(
 	};
 }
 
-/**
- * Create a mock campaign for testing
- */
-export function createMockCampaign(
-	overrides: Partial<CampaignData> = {}
-): CampaignData {
-	return {
-		campaignId: "test-campaign-id",
-		name: "Test Campaign",
-		createdAt: new Date().toISOString(),
-		updatedAt: new Date().toISOString(),
-		resources: [],
-		...overrides,
-	};
-}
+/** @deprecated Use makeCampaign from tests/factories instead */
+export const createMockCampaign = makeCampaign;
 
-/**
- * Create a mock campaign resource for testing
- */
-export function createMockResource(
-	overrides: Partial<CampaignResource> = {}
-): CampaignResource {
-	return {
-		type: "pdf",
-		id: "test-resource-id",
-		name: "Test Resource",
-		...overrides,
-	};
-}
+/** @deprecated Use makeCampaignResource from tests/factories instead */
+export const createMockResource = makeCampaignResource;
 
 /**
  * Create a mock KV namespace stub for campaigns

--- a/tests/campaign/tools.test.ts
+++ b/tests/campaign/tools.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createMockCampaign, createMockResource } from "./testUtils";
+import { makeCampaign, makeCampaignResource } from "../factories";
 
 // Mock the tools module
 vi.mock("../../src/tools", () => ({
@@ -168,7 +168,7 @@ describe("Campaign Tools", () => {
 					success: true,
 					message: "Successfully created campaign",
 					data: {
-						campaign: createMockCampaign({ name: "Test Campaign" }),
+						campaign: makeCampaign({ name: "Test Campaign" }),
 					},
 				},
 			});
@@ -187,8 +187,8 @@ describe("Campaign Tools", () => {
 			const mockListResources = (executions as any).listCampaignResources;
 
 			const mockResources = [
-				createMockResource({ id: "pdf-1", name: "Document.pdf" }),
-				createMockResource({
+				makeCampaignResource({ id: "pdf-1", name: "Document.pdf" }),
+				makeCampaignResource({
 					id: "char-1",
 					name: "Character Sheet",
 					type: "character",
@@ -220,7 +220,7 @@ describe("Campaign Tools", () => {
 			const { executions } = await import("../../src/tools");
 			const mockAddResource = (executions as any).addResourceToCampaign;
 
-			const newResource = createMockResource({
+			const newResource = makeCampaignResource({
 				id: "new-resource",
 				name: "New Resource",
 				type: "pdf",
@@ -257,10 +257,12 @@ describe("Campaign Tools", () => {
 			const { executions } = await import("../../src/tools");
 			const mockShowDetails = (executions as any).showCampaignDetails;
 
-			const mockCampaign = createMockCampaign({
+			const mockCampaign = makeCampaign({
 				campaignId: "test-campaign",
 				name: "Test Campaign",
-				resources: [createMockResource({ id: "pdf-1", name: "Document.pdf" })],
+				resources: [
+					makeCampaignResource({ id: "pdf-1", name: "Document.pdf" }),
+				],
 			});
 
 			mockShowDetails.mockResolvedValueOnce({
@@ -306,7 +308,7 @@ describe("Campaign Tools", () => {
 		});
 
 		it("should validate campaign data structure", () => {
-			const mockCampaign = createMockCampaign({
+			const mockCampaign = makeCampaign({
 				campaignId: "test-id",
 				name: "Test Campaign",
 				resources: [],
@@ -321,7 +323,7 @@ describe("Campaign Tools", () => {
 		});
 
 		it("should validate resource data structure", () => {
-			const mockResource = createMockResource({
+			const mockResource = makeCampaignResource({
 				id: "test-resource",
 				name: "Test Resource",
 				type: "pdf",

--- a/tests/components/ResourceSidePanel.test.tsx
+++ b/tests/components/ResourceSidePanel.test.tsx
@@ -2,7 +2,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ResourceSidePanel } from "@/components/resource-side-panel/ResourceSidePanel";
-import type { Campaign } from "@/types/campaign";
+import { makeCampaign } from "../factories";
 
 // Mock the hooks and services
 vi.mock("@/hooks/useCampaignManagement", () => ({
@@ -35,15 +35,12 @@ describe("ResourceSidePanel", () => {
 	const mockOnAddResource = vi.fn();
 	const mockSetShowUserMenu = vi.fn();
 
-	const mockCampaigns: Campaign[] = [
-		{
+	const mockCampaigns = [
+		makeCampaign({
 			campaignId: "camp-1",
 			name: "Test Campaign",
 			description: "A test campaign",
-			createdAt: new Date().toISOString(),
-			updatedAt: new Date().toISOString(),
-			resources: [],
-		},
+		}),
 	];
 
 	beforeEach(() => {

--- a/tests/entity-services.test.ts
+++ b/tests/entity-services.test.ts
@@ -4,6 +4,7 @@ import { EntityGraphService } from "@/services/graph/entity-graph-service";
 import { EntityDeduplicationService } from "@/services/rag/entity-deduplication-service";
 import { EntityExtractionService } from "@/services/rag/entity-extraction-service";
 import type { EntityEmbeddingService } from "@/services/vectorize/entity-embedding-service";
+import { makeEntity } from "./factories";
 
 // Mock LLM provider factory
 vi.mock("@/services/llm/llm-provider-factory", () => ({
@@ -116,16 +117,15 @@ describe("EntityExtractionService", () => {
 
 describe("EntityDeduplicationService", () => {
 	it("identifies high-confidence duplicates and queues medium-confidence entries", async () => {
-		const mockEntity = (id: string): Entity => ({
-			id,
-			campaignId: "campaign-123",
-			entityType: "npcs",
-			name: `Entity ${id}`,
-			content: { id },
-			metadata: {},
-			createdAt: new Date().toISOString(),
-			updatedAt: new Date().toISOString(),
-		});
+		const mockEntity = (id: string): Entity =>
+			makeEntity({
+				id,
+				campaignId: "campaign-123",
+				entityType: "npcs",
+				name: `Entity ${id}`,
+				content: { id },
+				metadata: {},
+			});
 
 		const entityDAO = {
 			getEntityById: vi

--- a/tests/factories/auth.ts
+++ b/tests/factories/auth.ts
@@ -1,0 +1,16 @@
+import type { AuthPayload } from "../../src/services/core/auth-service";
+
+/**
+ * Create a type-checked auth payload (user) for testing with sensible defaults.
+ * @param overrides - Partial overrides merged onto defaults
+ */
+export function makeAuthPayload(
+	overrides: Partial<AuthPayload> = {}
+): AuthPayload {
+	return {
+		type: "user-auth",
+		username: "test-user",
+		isAdmin: false,
+		...overrides,
+	};
+}

--- a/tests/factories/campaign.ts
+++ b/tests/factories/campaign.ts
@@ -1,0 +1,41 @@
+import type { CampaignData, CampaignResource } from "../../src/types/campaign";
+
+const ISO_NOW = "2024-01-01T00:00:00.000Z";
+
+/**
+ * Create a type-checked campaign for testing with sensible defaults.
+ * @param overrides - Partial overrides merged onto defaults
+ */
+export function makeCampaign(
+	overrides: Partial<CampaignData> = {}
+): CampaignData {
+	return {
+		campaignId: "campaign-test-id",
+		name: "Test Campaign",
+		createdAt: ISO_NOW,
+		updatedAt: ISO_NOW,
+		resources: [],
+		...overrides,
+	};
+}
+
+/**
+ * Create a type-checked campaign resource for testing with sensible defaults.
+ * @param overrides - Partial overrides merged onto defaults
+ */
+export function makeCampaignResource(
+	overrides: Partial<CampaignResource> = {}
+): CampaignResource {
+	return {
+		type: "file",
+		id: "resource-test-id",
+		name: "Test Resource",
+		campaign_id: "campaign-test-id",
+		file_key: "file/test-key",
+		file_name: "test.pdf",
+		status: "active",
+		created_at: ISO_NOW,
+		updated_at: ISO_NOW,
+		...overrides,
+	};
+}

--- a/tests/factories/community.ts
+++ b/tests/factories/community.ts
@@ -1,0 +1,19 @@
+import type { Community } from "../../src/dao/community-dao";
+
+const ISO_NOW = "2024-01-01T00:00:00.000Z";
+
+/**
+ * Create a type-checked community for testing with sensible defaults.
+ * @param overrides - Partial overrides merged onto defaults
+ */
+export function makeCommunity(overrides: Partial<Community> = {}): Community {
+	return {
+		id: "community-test-id",
+		campaignId: "campaign-test-id",
+		level: 0,
+		parentCommunityId: null,
+		entityIds: [],
+		createdAt: ISO_NOW,
+		...overrides,
+	};
+}

--- a/tests/factories/entity.ts
+++ b/tests/factories/entity.ts
@@ -1,0 +1,19 @@
+import type { Entity } from "../../src/dao/entity-dao";
+
+const ISO_NOW = "2024-01-01T00:00:00.000Z";
+
+/**
+ * Create a type-checked entity for testing with sensible defaults.
+ * @param overrides - Partial overrides merged onto defaults
+ */
+export function makeEntity(overrides: Partial<Entity> = {}): Entity {
+	return {
+		id: "entity-test-id",
+		campaignId: "campaign-test-id",
+		entityType: "character",
+		name: "Test Entity",
+		createdAt: ISO_NOW,
+		updatedAt: ISO_NOW,
+		...overrides,
+	};
+}

--- a/tests/factories/index.ts
+++ b/tests/factories/index.ts
@@ -1,0 +1,8 @@
+export { makeAuthPayload } from "./auth";
+export { makeCampaign, makeCampaignResource } from "./campaign";
+export { makeCommunity } from "./community";
+export { makeEntity } from "./entity";
+export {
+	makeSessionDigest,
+	makeSessionDigestData,
+} from "./session";

--- a/tests/factories/session.ts
+++ b/tests/factories/session.ts
@@ -1,0 +1,74 @@
+import type {
+	SessionDigest,
+	SessionDigestData,
+	SessionDigestSourceType,
+	SessionDigestStatus,
+} from "../../src/types/session-digest";
+
+const ISO_NOW = "2024-01-01T00:00:00.000Z";
+
+const DEFAULT_DIGEST_DATA: SessionDigestData = {
+	last_session_recap: {
+		key_events: [],
+		state_changes: { factions: [], locations: [], npcs: [] },
+		open_threads: [],
+	},
+	next_session_plan: {
+		objectives_dm: [],
+		probable_player_goals: [],
+		beats: [],
+		if_then_branches: [],
+	},
+	npcs_to_run: [],
+	locations_in_focus: [],
+	encounter_seeds: [],
+	clues_and_revelations: [],
+	treasure_and_rewards: [],
+	todo_checklist: [],
+};
+
+/**
+ * Create a type-checked session digest for testing with sensible defaults.
+ * @param overrides - Partial overrides merged onto defaults
+ */
+export function makeSessionDigest(
+	overrides: Partial<SessionDigest> = {}
+): SessionDigest {
+	const { digest_data: digestOverride, ...rest } = overrides;
+	const digest_data =
+		digestOverride !== undefined
+			? typeof digestOverride === "string"
+				? digestOverride
+				: JSON.stringify(digestOverride)
+			: JSON.stringify(DEFAULT_DIGEST_DATA);
+
+	return {
+		id: "session-test-id",
+		campaign_id: "campaign-test-id",
+		session_number: 1,
+		session_date: null,
+		status: "draft" as SessionDigestStatus,
+		quality_score: null,
+		review_notes: null,
+		generated_by_ai: false,
+		template_id: null,
+		source_type: "manual" as SessionDigestSourceType,
+		created_at: ISO_NOW,
+		updated_at: ISO_NOW,
+		...rest,
+		digest_data,
+	};
+}
+
+/**
+ * Create a type-checked session digest data structure for testing.
+ * @param overrides - Partial overrides merged onto defaults
+ */
+export function makeSessionDigestData(
+	overrides: Partial<SessionDigestData> = {}
+): SessionDigestData {
+	return {
+		...DEFAULT_DIGEST_DATA,
+		...overrides,
+	};
+}

--- a/tests/services/assessment-service.test.ts
+++ b/tests/services/assessment-service.test.ts
@@ -3,7 +3,8 @@ import { AssessmentDAO } from "../../src/dao/assessment-dao";
 import type { Env } from "../../src/middleware/auth";
 import { AssessmentService } from "../../src/services/core/assessment-service";
 import type { ActivityType } from "../../src/types/assessment";
-import type { Campaign, CampaignResource } from "../../src/types/campaign";
+import type { CampaignResource } from "../../src/types/campaign";
+import { makeCampaign, makeCampaignResource } from "../factories";
 
 // Mock the AssessmentDAO
 vi.mock("../../src/dao/assessment-dao");
@@ -126,14 +127,11 @@ describe("AssessmentService", () => {
 	});
 
 	describe("getCampaignReadiness", () => {
-		const mockCampaign: Campaign = {
+		const mockCampaign = makeCampaign({
 			campaignId: "test-campaign",
 			name: "Test Campaign",
 			description: "A test campaign",
-			resources: [],
-			createdAt: "2024-01-01T00:00:00Z",
-			updatedAt: "2024-01-01T00:00:00Z",
-		};
+		});
 
 		it("should return Taking Root state for new campaign", async () => {
 			const campaignId = "test-campaign";
@@ -169,19 +167,14 @@ describe("AssessmentService", () => {
 		it("should return Legendary state for developing campaign", async () => {
 			const campaignId = "test-campaign";
 			const mockResources: CampaignResource[] = [
-				{
-					type: "file",
+				makeCampaignResource({
 					id: "1",
 					name: "Resource 1",
 					campaign_id: campaignId,
 					file_key: "key1",
 					file_name: "file1.pdf",
 					description: "Test",
-					tags: "",
-					status: "active",
-					created_at: "2024-01-01T00:00:00Z",
-					updated_at: "2024-01-01T00:00:00Z",
-				},
+				}),
 			];
 
 			mockDAO.getCampaignContext.mockResolvedValue([
@@ -208,21 +201,18 @@ describe("AssessmentService", () => {
 
 		it("should return Legendary state for well-developed campaign", async () => {
 			const campaignId = "test-campaign";
-			const mockResources: CampaignResource[] = Array(10)
-				.fill(null)
-				.map((_, i) => ({
-					type: "file" as const,
-					id: `${i}`,
-					name: `Resource ${i}`,
-					campaign_id: campaignId,
-					file_key: `key${i}`,
-					file_name: `file${i}.pdf`,
-					description: "Test",
-					tags: "",
-					status: "active" as const,
-					created_at: "2024-01-01T00:00:00Z",
-					updated_at: "2024-01-01T00:00:00Z",
-				}));
+			const mockResources: CampaignResource[] = Array.from(
+				{ length: 10 },
+				(_, i) =>
+					makeCampaignResource({
+						id: `${i}`,
+						name: `Resource ${i}`,
+						campaign_id: campaignId,
+						file_key: `key${i}`,
+						file_name: `file${i}.pdf`,
+						description: "Test",
+					})
+			);
 
 			mockDAO.getCampaignContext.mockResolvedValue(
 				Array(5)
@@ -368,14 +358,11 @@ describe("AssessmentService", () => {
 	describe("campaign state boundaries", () => {
 		it("should correctly map all campaign state boundaries", async () => {
 			const campaignId = "test-campaign";
-			const mockCampaign: Campaign = {
+			const mockCampaign = makeCampaign({
 				campaignId,
 				name: "Test Campaign",
 				description: "A test campaign",
-				resources: [],
-				createdAt: "2024-01-01T00:00:00Z",
-				updatedAt: "2024-01-01T00:00:00Z",
-			};
+			});
 
 			// Test Taking Root (30) - empty campaign gets 10+10+10=30
 			mockDAO.getCampaignContext.mockResolvedValue([]);
@@ -388,21 +375,18 @@ describe("AssessmentService", () => {
 			expect(result.campaignState).toBe("Taking Root"); // Score 30 = Taking Root
 
 			// Test Legendary (90) - 1-2 items in each category gives 30+30+30=90
-			const someResources: CampaignResource[] = Array(2)
-				.fill(null)
-				.map((_, i) => ({
-					type: "file" as const,
-					id: `${i}`,
-					name: `Resource ${i}`,
-					campaign_id: campaignId,
-					file_key: `key${i}`,
-					file_name: `file${i}.pdf`,
-					description: "Test",
-					tags: "",
-					status: "active" as const,
-					created_at: "2024-01-01T00:00:00Z",
-					updated_at: "2024-01-01T00:00:00Z",
-				}));
+			const someResources: CampaignResource[] = Array.from(
+				{ length: 2 },
+				(_, i) =>
+					makeCampaignResource({
+						id: `${i}`,
+						name: `Resource ${i}`,
+						campaign_id: campaignId,
+						file_key: `key${i}`,
+						file_name: `file${i}.pdf`,
+						description: "Test",
+					})
+			);
 
 			mockDAO.getCampaignContext.mockResolvedValue([
 				{ id: "1", title: "Context 1", content: "Test" },

--- a/tests/services/community-summary-service.test.ts
+++ b/tests/services/community-summary-service.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Community } from "@/dao/community-dao";
 import type { CommunitySummaryDAO } from "@/dao/community-summary-dao";
-import type { Entity, EntityDAO } from "@/dao/entity-dao";
+import type { EntityDAO } from "@/dao/entity-dao";
 import { LLMProviderAPIKeyError } from "@/lib/errors";
 import { CommunitySummaryService } from "@/services/graph/community-summary-service";
 import { createLLMProvider } from "@/services/llm/llm-provider-factory";
+import { makeCommunity, makeEntity } from "../factories";
 
 vi.mock("@/services/llm/llm-provider-factory", () => ({
 	createLLMProvider: vi.fn(),
@@ -46,14 +46,13 @@ describe("CommunitySummaryService", () => {
 
 	describe("generateOrGetSummary", () => {
 		it("should return existing summary if found and forceRegenerate is false", async () => {
-			const community: Community = {
+			const community = makeCommunity({
 				id: "community-1",
 				campaignId: "campaign-1",
 				level: 0,
 				parentCommunityId: null,
 				entityIds: ["entity-1", "entity-2"],
-				createdAt: new Date().toISOString(),
-			};
+			});
 
 			const existingSummary = {
 				id: "summary-1",
@@ -87,14 +86,13 @@ describe("CommunitySummaryService", () => {
 				mockSummaryDAO as CommunitySummaryDAO
 			);
 
-			const community: Community = {
+			const community = makeCommunity({
 				id: "community-1",
 				campaignId: "campaign-1",
 				level: 0,
 				parentCommunityId: null,
 				entityIds: ["entity-1", "entity-2"],
-				createdAt: new Date().toISOString(),
-			};
+			});
 
 			(mockSummaryDAO.getSummaryByCommunityId as any).mockResolvedValue(null);
 
@@ -108,34 +106,29 @@ describe("CommunitySummaryService", () => {
 
 	describe("generateSummary", () => {
 		it("should generate summary for a community with entities and relationships", async () => {
-			const community: Community = {
+			const community = makeCommunity({
 				id: "community-1",
 				campaignId: "campaign-1",
 				level: 0,
 				parentCommunityId: null,
 				entityIds: ["entity-1", "entity-2"],
-				createdAt: new Date().toISOString(),
-			};
+			});
 
-			const mockEntity1: Entity = {
+			const mockEntity1 = makeEntity({
 				id: "entity-1",
 				campaignId: "campaign-1",
 				entityType: "location",
 				name: "Test Location",
 				content: { description: "A test location" },
-				createdAt: new Date().toISOString(),
-				updatedAt: new Date().toISOString(),
-			};
+			});
 
-			const mockEntity2: Entity = {
+			const mockEntity2 = makeEntity({
 				id: "entity-2",
 				campaignId: "campaign-1",
 				entityType: "character",
 				name: "Test Character",
 				content: { description: "A test character" },
-				createdAt: new Date().toISOString(),
-				updatedAt: new Date().toISOString(),
-			};
+			});
 
 			(mockEntityDAO.getEntityById as any)
 				.mockResolvedValueOnce(mockEntity1)
@@ -187,26 +180,25 @@ describe("CommunitySummaryService", () => {
 
 	describe("updateSummaryForCommunity", () => {
 		it("should delete existing summary and generate new one", async () => {
-			const community: Community = {
+			const community = makeCommunity({
 				id: "community-1",
 				campaignId: "campaign-1",
 				level: 0,
 				parentCommunityId: null,
 				entityIds: ["entity-1"],
-				createdAt: new Date().toISOString(),
-			};
+			});
 
 			(mockSummaryDAO.deleteSummariesByCommunity as any).mockResolvedValue(
 				undefined
 			);
-			(mockEntityDAO.getEntityById as any).mockResolvedValue({
-				id: "entity-1",
-				campaignId: "campaign-1",
-				entityType: "location",
-				name: "Test Location",
-				createdAt: new Date().toISOString(),
-				updatedAt: new Date().toISOString(),
-			});
+			(mockEntityDAO.getEntityById as any).mockResolvedValue(
+				makeEntity({
+					id: "entity-1",
+					campaignId: "campaign-1",
+					entityType: "location",
+					name: "Test Location",
+				})
+			);
 			(mockEntityDAO.getRelationshipsForEntity as any).mockResolvedValue([]);
 			(mockSummaryDAO.createSummary as any).mockResolvedValue(undefined);
 			const updatedName = "Updated Community";
@@ -243,34 +235,32 @@ describe("CommunitySummaryService", () => {
 
 	describe("generateSummariesForCommunities", () => {
 		it("should generate summaries for multiple communities", async () => {
-			const communities: Community[] = [
-				{
+			const communities = [
+				makeCommunity({
 					id: "community-1",
 					campaignId: "campaign-1",
 					level: 0,
 					parentCommunityId: null,
 					entityIds: ["entity-1"],
-					createdAt: new Date().toISOString(),
-				},
-				{
+				}),
+				makeCommunity({
 					id: "community-2",
 					campaignId: "campaign-1",
 					level: 0,
 					parentCommunityId: null,
 					entityIds: ["entity-2"],
-					createdAt: new Date().toISOString(),
-				},
+				}),
 			];
 
 			(mockSummaryDAO.getSummaryByCommunityId as any).mockResolvedValue(null);
-			(mockEntityDAO.getEntityById as any).mockResolvedValue({
-				id: "entity-1",
-				campaignId: "campaign-1",
-				entityType: "location",
-				name: "Test Location",
-				createdAt: new Date().toISOString(),
-				updatedAt: new Date().toISOString(),
-			});
+			(mockEntityDAO.getEntityById as any).mockResolvedValue(
+				makeEntity({
+					id: "entity-1",
+					campaignId: "campaign-1",
+					entityType: "location",
+					name: "Test Location",
+				})
+			);
 			(mockEntityDAO.getRelationshipsForEntity as any).mockResolvedValue([]);
 			(mockSummaryDAO.createSummary as any).mockResolvedValue(undefined);
 			let callCount = 0;
@@ -308,23 +298,21 @@ describe("CommunitySummaryService", () => {
 		});
 
 		it("should continue with other communities if one fails", async () => {
-			const communities: Community[] = [
-				{
+			const communities = [
+				makeCommunity({
 					id: "community-1",
 					campaignId: "campaign-1",
 					level: 0,
 					parentCommunityId: null,
 					entityIds: ["entity-1"],
-					createdAt: new Date().toISOString(),
-				},
-				{
+				}),
+				makeCommunity({
 					id: "community-2",
 					campaignId: "campaign-1",
 					level: 0,
 					parentCommunityId: null,
 					entityIds: ["entity-2"],
-					createdAt: new Date().toISOString(),
-				},
+				}),
 			];
 
 			(mockSummaryDAO.getSummaryByCommunityId as any)
@@ -335,14 +323,14 @@ describe("CommunitySummaryService", () => {
 				if (id === "entity-1") {
 					throw new Error("Entity not found");
 				}
-				return Promise.resolve({
-					id: "entity-2",
-					campaignId: "campaign-1",
-					entityType: "location",
-					name: "Test Location",
-					createdAt: new Date().toISOString(),
-					updatedAt: new Date().toISOString(),
-				});
+				return Promise.resolve(
+					makeEntity({
+						id: "entity-2",
+						campaignId: "campaign-1",
+						entityType: "location",
+						name: "Test Location",
+					})
+				);
 			});
 			(mockEntityDAO.getRelationshipsForEntity as any).mockResolvedValue([]);
 			(mockSummaryDAO.createSummary as any).mockResolvedValue(undefined);

--- a/tests/services/entity-importance-service.test.ts
+++ b/tests/services/entity-importance-service.test.ts
@@ -3,6 +3,7 @@ import type { CommunityDAO } from "@/dao/community-dao";
 import type { EntityDAO } from "@/dao/entity-dao";
 import type { EntityImportanceDAO } from "@/dao/entity-importance-dao";
 import { EntityImportanceService } from "@/services/graph/entity-importance-service";
+import { makeEntity } from "../factories";
 
 describe("EntityImportanceService", () => {
 	let mockEntityDAO: Partial<EntityDAO>;
@@ -37,15 +38,13 @@ describe("EntityImportanceService", () => {
 
 	describe("getEntityImportance", () => {
 		it("reads from table when available", async () => {
-			const entity = {
+			const entity = makeEntity({
 				id: "entity-1",
 				campaignId: "campaign-123",
 				entityType: "npc",
 				name: "Test Entity",
-				createdAt: "2025-01-01T00:00:00Z",
-				updatedAt: "2025-01-01T00:00:00Z",
 				metadata: {},
-			};
+			});
 
 			const importance = {
 				entityId: "entity-1",
@@ -71,17 +70,13 @@ describe("EntityImportanceService", () => {
 		});
 
 		it("falls back to metadata when table entry not found", async () => {
-			const entity = {
+			const entity = makeEntity({
 				id: "entity-1",
 				campaignId: "campaign-123",
 				entityType: "npc",
 				name: "Test Entity",
-				createdAt: "2025-01-01T00:00:00Z",
-				updatedAt: "2025-01-01T00:00:00Z",
-				metadata: {
-					importanceScore: 70.0,
-				},
-			};
+				metadata: { importanceScore: 70.0 },
+			});
 
 			(mockEntityDAO.getEntityById as any).mockResolvedValue(entity);
 			(mockImportanceDAO.getImportance as any).mockResolvedValue(null);
@@ -96,15 +91,13 @@ describe("EntityImportanceService", () => {
 		});
 
 		it("calculates and stores in table when neither table nor metadata available", async () => {
-			const entity = {
+			const entity = makeEntity({
 				id: "entity-1",
 				campaignId: "campaign-123",
 				entityType: "npc",
 				name: "Test Entity",
-				createdAt: "2025-01-01T00:00:00Z",
-				updatedAt: "2025-01-01T00:00:00Z",
 				metadata: {},
-			};
+			});
 
 			(mockEntityDAO.getEntityById as any).mockResolvedValue(entity);
 			(mockImportanceDAO.getImportance as any).mockResolvedValue(null);
@@ -124,24 +117,20 @@ describe("EntityImportanceService", () => {
 	describe("recalculateImportanceForCampaign", () => {
 		it("writes to table when importanceDAO is available", async () => {
 			const entities = [
-				{
+				makeEntity({
 					id: "entity-1",
 					campaignId: "campaign-123",
 					entityType: "npc",
 					name: "Entity 1",
-					createdAt: "2025-01-01T00:00:00Z",
-					updatedAt: "2025-01-01T00:00:00Z",
 					metadata: {},
-				},
-				{
+				}),
+				makeEntity({
 					id: "entity-2",
 					campaignId: "campaign-123",
 					entityType: "npc",
 					name: "Entity 2",
-					createdAt: "2025-01-01T00:00:00Z",
-					updatedAt: "2025-01-01T00:00:00Z",
 					metadata: {},
-				},
+				}),
 			];
 
 			(mockEntityDAO.listEntitiesByCampaign as any).mockResolvedValue(entities);
@@ -169,17 +158,13 @@ describe("EntityImportanceService", () => {
 				mockCommunityDAO as CommunityDAO
 			);
 
-			const entity = {
+			const entity = makeEntity({
 				id: "entity-1",
 				campaignId: "campaign-123",
 				entityType: "npc",
 				name: "Test Entity",
-				createdAt: "2025-01-01T00:00:00Z",
-				updatedAt: "2025-01-01T00:00:00Z",
-				metadata: {
-					importanceScore: 70.0,
-				},
-			};
+				metadata: { importanceScore: 70.0 },
+			});
 
 			(mockEntityDAO.getEntityById as any).mockResolvedValue(entity);
 
@@ -199,15 +184,13 @@ describe("EntityImportanceService", () => {
 			);
 
 			const entities = [
-				{
+				makeEntity({
 					id: "entity-1",
 					campaignId: "campaign-123",
 					entityType: "npc",
 					name: "Entity 1",
-					createdAt: "2025-01-01T00:00:00Z",
-					updatedAt: "2025-01-01T00:00:00Z",
 					metadata: {},
-				},
+				}),
 			];
 
 			(mockEntityDAO.listEntitiesByCampaign as any).mockResolvedValue(entities);

--- a/tests/tools/player-handout-tools.test.ts
+++ b/tests/tools/player-handout-tools.test.ts
@@ -30,6 +30,7 @@ import {
 	exportHandoutTool,
 	generateHandoutTool,
 } from "@/tools/campaign-context/player-handout-tools";
+import { makeEntity } from "../factories";
 
 function createJwt(username: string): string {
 	const payload = Buffer.from(JSON.stringify({ username }), "utf8")
@@ -74,19 +75,19 @@ describe("player handout tools", () => {
 
 	it("generates handout prompt without GM-only fields", async () => {
 		mockCampaignDAO.getCampaignRole.mockResolvedValue("editor_gm");
-		mockEntityDAO.getEntityById.mockResolvedValue({
-			id: "entity-1",
-			campaignId: "campaign-1",
-			entityType: "npc",
-			name: "Thornwall steward",
-			content: {
-				summary: "A weary steward managing the keep.",
-				secrets: "Serves the hidden villain in the crypt below.",
-			},
-			metadata: {},
-			createdAt: "2026-01-01T00:00:00.000Z",
-			updatedAt: "2026-01-01T00:00:00.000Z",
-		});
+		mockEntityDAO.getEntityById.mockResolvedValue(
+			makeEntity({
+				id: "entity-1",
+				campaignId: "campaign-1",
+				entityType: "npc",
+				name: "Thornwall steward",
+				content: {
+					summary: "A weary steward managing the keep.",
+					secrets: "Serves the hidden villain in the crypt below.",
+				},
+				metadata: {},
+			})
+		);
 		mockGenerateStructuredOutput.mockResolvedValue({
 			title: "Whispers from Thornwall Keep",
 			content: "The steward keeps watch as storms gather over old stones.",


### PR DESCRIPTION
- Create tests/factories/ with makeCampaign, makeCampaignResource, makeEntity, makeAuthPayload, makeSessionDigest, makeCommunity
- Update testUtils to re-export factories (deprecate createMockCampaign/createMockResource)
- Migrate campaign, assessment, community-summary, entity, player-handout tests
- Document factories in TESTING_GUIDE.md

Made-with: Cursor