### PR TITLE
Prevent text overflow in chat pane

### DIFF
--- a/src/components/MemoizedMarkdown.tsx
+++ b/src/components/MemoizedMarkdown.tsx
@@ -4,7 +4,7 @@ import remarkGfm from "remark-gfm";
 
 export const MemoizedMarkdown = memo(
 	({ content }: { content: string }) => (
-		<div className="markdown-body">
+		<div className="markdown-body min-w-0 overflow-hidden">
 			<ReactMarkdown
 				remarkPlugins={[remarkGfm]}
 				components={{
@@ -13,7 +13,7 @@ export const MemoizedMarkdown = memo(
 						const match = /language-(\w+)/.exec(className || "");
 						const isInline = !match;
 						return !isInline ? (
-							<pre className="bg-neutral-100 dark:bg-neutral-800 rounded-md p-4 overflow-x-auto">
+							<pre className="bg-neutral-100 dark:bg-neutral-800 rounded-md p-4 overflow-x-auto max-w-full">
 								<code className={className} {...props}>
 									{children}
 								</code>

--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -56,12 +56,12 @@ export function ChatMessageList({
 					return (
 						<div key={m.id}>
 							<div
-								className={`flex ${isUser ? "justify-end" : "justify-start"}`}
+								className={`flex min-w-0 ${isUser ? "justify-end" : "justify-start"}`}
 							>
 								<div
-									className={`${isUser ? "flex flex-row-reverse gap-2 max-w-[85%]" : "w-full"}`}
+									className={`min-w-0 ${isUser ? "flex flex-row-reverse gap-2 max-w-[85%]" : "w-full"}`}
 								>
-									<div className={isUser ? "flex-1" : "w-full"}>
+									<div className={`min-w-0 ${isUser ? "flex-1" : "w-full"}`}>
 										<div>
 											{(() => {
 												// Find the index of the last text part in the original parts array
@@ -87,9 +87,12 @@ export function ChatMessageList({
 														const isLastTextPart = i === lastTextPartIndex;
 
 														return (
-															<div key={`${m.id}-text-${i}`}>
+															<div
+																key={`${m.id}-text-${i}`}
+																className="min-w-0"
+															>
 																<Card
-																	className={`p-4 rounded-xl bg-neutral-100/80 dark:bg-neutral-900/80 backdrop-blur-sm ${
+																	className={`p-4 rounded-xl bg-neutral-100/80 dark:bg-neutral-900/80 backdrop-blur-sm min-w-0 ${
 																		isUser
 																			? "rounded-br-none"
 																			: "rounded-bl-none border-assistant-border"

--- a/src/styles.css
+++ b/src/styles.css
@@ -132,6 +132,11 @@ html {
 	font-weight: 400;
 	letter-spacing: -0.011em;
 	font-size: 0.95rem;
+	/* Prevent text overflow: wrap long words/URLs and constrain width */
+	min-width: 0;
+	max-width: 100%;
+	overflow-wrap: break-word;
+	word-break: break-word;
 }
 
 /* Headings */
@@ -221,6 +226,7 @@ html {
 	overflow-x: auto;
 	margin-bottom: 1.25em;
 	border: 1px solid var(--color-neutral-200);
+	max-width: 100%;
 }
 
 .markdown-body pre code {


### PR DESCRIPTION
- Add overflow-wrap and word-break to markdown-body for long words/URLs
- Add min-w-0 to flex chain and Card for proper shrinking
- Constrain markdown and pre blocks with max-width/min-width
- Fix chat message layout to contain content within pane

Made-with: Cursor