### PR TITLE
feat(search): add entity search result caching (#489)

### DIFF
--- a/docs/ENTITY_SEARCH_CACHING.md
+++ b/docs/ENTITY_SEARCH_CACHING.md
@@ -1,0 +1,50 @@
+# Entity search results caching
+
+Caches semantic search results for entity search to avoid repeated embedding generation and Vectorize queries when the same campaign and query are searched again.
+
+## Design
+
+- **Storage:** Cloudflare Cache API (`caches.default`)
+- **TTL:** 5 minutes via `Cache-Control: max-age=300`
+- **Cache key format:** `entity-search/${campaignId}/v${version}/${hash}`
+- **Hash input:** `campaignId:normalizedQuery:entityType:topK`
+- **Version-based invalidation:** Per-campaign version in D1; incremented on entity create/update/delete
+
+## Entry points
+
+1. **searchCampaignContext** (`src/tools/campaign-context/search-tools.ts`) – agent gameplay
+2. **handleSearchEntityInGraph** (`src/routes/graph-visualization.ts`) – graph UI search
+
+## Flow
+
+1. Check cache before running semantic search (embedding + Vectorize).
+2. On cache hit: use cached entity IDs and scores, fetch full entities from DB.
+3. On cache miss: run semantic search, then store result in cache.
+
+## Invalidation
+
+When any entity in a campaign is created, updated, or deleted, `EntitySearchCacheService.incrementCampaignCacheVersion` is called from `EntityDAO`. The version is stored in `entity_search_cache_version` (D1). Old cache keys reference the previous version and are effectively stale; new searches use the updated version.
+
+## Profiling and metrics
+
+- **searchCampaignContext:** Logs `[Tool] searchCampaignContext - Semantic search cache hit: N entities` on cache hit, or `Semantic search found N entities via embeddings in Xms` on miss.
+- To measure hit rate: count log lines containing "cache hit" vs "via embeddings" over a time window.
+
+## D1 table
+
+```sql
+CREATE TABLE IF NOT EXISTS entity_search_cache_version (
+  campaign_id TEXT PRIMARY KEY,
+  cache_version INTEGER NOT NULL DEFAULT 0
+);
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `migrations/0012_entity_search_cache_version.sql` | D1 schema |
+| `src/services/search/entity-search-cache-service.ts` | Cache get/set, version read/increment |
+| `src/dao/entity-dao.ts` | Calls invalidation on entity CUD |
+| `src/tools/campaign-context/search-tools.ts` | Cache integration in searchCampaignContext |
+| `src/routes/graph-visualization.ts` | Cache integration in handleSearchEntityInGraph |

--- a/migrations/0012_entity_search_cache_version.sql
+++ b/migrations/0012_entity_search_cache_version.sql
@@ -1,0 +1,6 @@
+-- Per-campaign version for entity search cache invalidation.
+-- Incremented on entity create/update/delete; used in cache keys.
+CREATE TABLE IF NOT EXISTS entity_search_cache_version (
+  campaign_id TEXT PRIMARY KEY,
+  cache_version INTEGER NOT NULL DEFAULT 0
+);

--- a/scripts/sync-docs-to-wiki.js
+++ b/scripts/sync-docs-to-wiki.js
@@ -79,6 +79,11 @@ const FILE_MAPPINGS = [
 		dest: "Technical/Checklist-Status-System.md",
 		process: true,
 	},
+	{
+		src: "docs/ENTITY_SEARCH_CACHING.md",
+		dest: "Technical/Entity-Search-Caching.md",
+		process: true,
+	},
 ];
 
 function exec(cmd, options = {}) {

--- a/src/dao/entity-dao.ts
+++ b/src/dao/entity-dao.ts
@@ -324,6 +324,17 @@ export class EntityDAO extends BaseDAOClass {
 			stmt.bind(JSON.stringify(u.metadata), u.shardStatus, u.entityId)
 		);
 		await this.db.batch(batch);
+
+		// Invalidate entity search cache for affected campaigns
+		const entityIds = updates.map((u) => u.entityId);
+		const placeholders = entityIds.map(() => "?").join(", ");
+		const rows = await this.queryAll<{ campaign_id: string }>(
+			`SELECT DISTINCT campaign_id FROM entities WHERE id IN (${placeholders})`,
+			entityIds
+		);
+		for (const row of rows) {
+			await incrementCampaignCacheVersion(this.db, row.campaign_id);
+		}
 	}
 
 	async getEntityById(entityId: string): Promise<Entity | null> {

--- a/src/dao/entity-dao.ts
+++ b/src/dao/entity-dao.ts
@@ -3,6 +3,7 @@ import {
 	type RelationshipType,
 } from "@/lib/entity/relationship-types";
 import { RelationshipUpsertError } from "@/lib/errors";
+import { incrementCampaignCacheVersion } from "@/services/search/entity-search-cache-service";
 import { BaseDAOClass } from "./base-dao";
 
 /** D1 platform limit: max 100 bound params per query. We use 2×N (from + to IN), so N ≤ 49. */
@@ -215,6 +216,7 @@ export class EntityDAO extends BaseDAOClass {
 			shardStatus ?? null,
 			entity.embeddingId ?? null,
 		]);
+		await incrementCampaignCacheVersion(this.db, entity.campaignId);
 	}
 
 	async updateEntity(
@@ -291,6 +293,13 @@ export class EntityDAO extends BaseDAOClass {
 
 		values.push(entityId);
 		await this.execute(sql, values);
+		const row = await this.queryFirst<{ campaign_id: string }>(
+			"SELECT campaign_id FROM entities WHERE id = ?",
+			[entityId]
+		);
+		if (row) {
+			await incrementCampaignCacheVersion(this.db, row.campaign_id);
+		}
 	}
 
 	/**
@@ -692,11 +701,18 @@ export class EntityDAO extends BaseDAOClass {
 	}
 
 	async deleteEntity(entityId: string): Promise<void> {
+		const row = await this.queryFirst<{ campaign_id: string }>(
+			"SELECT campaign_id FROM entities WHERE id = ?",
+			[entityId]
+		);
 		await this.execute(
 			"DELETE FROM entity_relationships WHERE from_entity_id = ? OR to_entity_id = ?",
 			[entityId, entityId]
 		);
 		await this.execute("DELETE FROM entities WHERE id = ?", [entityId]);
+		if (row) {
+			await incrementCampaignCacheVersion(this.db, row.campaign_id);
+		}
 	}
 
 	async upsertRelationship(

--- a/src/routes/graph-visualization.ts
+++ b/src/routes/graph-visualization.ts
@@ -1,3 +1,4 @@
+import type { D1Database } from "@cloudflare/workers-types";
 import type { Context } from "hono";
 import type { Community } from "@/dao/community-dao";
 import type { CommunitySummary } from "@/dao/community-summary-dao";
@@ -22,6 +23,12 @@ import type { Env } from "@/middleware/auth";
 import type { AuthPayload } from "@/services/core/auth-service";
 import { ProviderEmbeddingService } from "@/services/embedding/provider-embedding-service";
 import { getLLMRateLimitService } from "@/services/llm/llm-rate-limit-service";
+import {
+	buildCacheKey,
+	getCachedSearchResult,
+	getCampaignCacheVersion,
+	setCachedSearchResult,
+} from "@/services/search/entity-search-cache-service";
 import { EntitySemanticSearchService } from "@/services/vectorize/entity-semantic-search-service";
 import type {
 	CommunityGraphData,
@@ -479,14 +486,71 @@ export async function handleSearchEntityInGraph(c: ContextWithAuth) {
 					c.env.VECTORIZE,
 					getQueryEmbedding
 				);
-				const matches = await semanticSearch.searchEntities(
-					campaignId,
-					entityName,
-					{
-						topK: SEMANTIC_TOP_K,
-						minScore: SEMANTIC_SIMILARITY_THRESHOLD,
+				let matches: { entityId: string; score: number }[] = [];
+
+				// Try cache first (avoids embedding + Vectorize call)
+				if (c.env.DB) {
+					try {
+						const cacheVersion = await getCampaignCacheVersion(
+							c.env.DB as D1Database,
+							campaignId
+						);
+						const normalizedQuery = entityName.toLowerCase().trim();
+						const cacheKey = buildCacheKey(
+							campaignId,
+							cacheVersion,
+							normalizedQuery,
+							undefined,
+							SEMANTIC_TOP_K
+						);
+						const cached = await getCachedSearchResult(cacheKey);
+						if (cached && cached.entityIds.length > 0) {
+							matches = cached.entityIds
+								.map((id, i) => ({
+									entityId: id,
+									score: cached.scores[i] ?? 0,
+								}))
+								.filter((m) => m.score >= SEMANTIC_SIMILARITY_THRESHOLD);
+						}
+					} catch {
+						// Fall through to semantic search on cache miss/failure
 					}
-				);
+				}
+
+				if (matches.length === 0) {
+					matches = await semanticSearch.searchEntities(
+						campaignId,
+						entityName,
+						{
+							topK: SEMANTIC_TOP_K,
+							minScore: SEMANTIC_SIMILARITY_THRESHOLD,
+						}
+					);
+					// Cache result for next time
+					if (c.env.DB && matches.length > 0) {
+						try {
+							const cacheVersion = await getCampaignCacheVersion(
+								c.env.DB as D1Database,
+								campaignId
+							);
+							const normalizedQuery = entityName.toLowerCase().trim();
+							const cacheKey = buildCacheKey(
+								campaignId,
+								cacheVersion,
+								normalizedQuery,
+								undefined,
+								SEMANTIC_TOP_K
+							);
+							await setCachedSearchResult(cacheKey, {
+								entityIds: matches.map((m) => m.entityId),
+								scores: matches.map((m) => m.score),
+							});
+						} catch {
+							// Ignore cache write failures
+						}
+					}
+				}
+
 				for (const m of matches) {
 					const entity = await daoFactory.entityDAO.getEntityById(m.entityId);
 					if (

--- a/src/services/search/entity-search-cache-service.ts
+++ b/src/services/search/entity-search-cache-service.ts
@@ -1,0 +1,167 @@
+/**
+ * Entity search result caching via Cloudflare Cache API.
+ * Caches semantic search results (entity IDs + scores) to avoid repeated
+ * embedding generation and Vectorize queries for the same campaign/query.
+ */
+
+import type { D1Database } from "@cloudflare/workers-types";
+import { logger } from "@/lib/logger";
+
+const CACHE_TTL_SEC = 300; // 5 minutes
+const CACHE_KEY_PREFIX = "https://cache/internal/entity-search";
+
+export interface CachedEntitySearchResult {
+	entityIds: string[];
+	scores: number[];
+}
+
+/**
+ * Simple hash for cache keys (same style as ContextAssemblyService).
+ */
+function simpleHash(str: string): string {
+	let hash = 0;
+	for (let i = 0; i < str.length; i++) {
+		const char = str.charCodeAt(i);
+		hash = (hash << 5) - hash + char;
+		hash = hash & hash;
+	}
+	return Math.abs(hash).toString(36);
+}
+
+/**
+ * Build cache key from campaign, version, and query params.
+ */
+export function buildCacheKey(
+	campaignId: string,
+	cacheVersion: number,
+	normalizedQuery: string,
+	entityType: string | undefined,
+	topK: number
+): string {
+	const payload = `${campaignId}:${normalizedQuery}:${entityType ?? ""}:${topK}`;
+	const hash = simpleHash(payload);
+	return `${CACHE_KEY_PREFIX}/${campaignId}/v${cacheVersion}/${hash}`;
+}
+
+/**
+ * Get campaign cache version from D1. Inserts row if missing.
+ */
+export async function getCampaignCacheVersion(
+	db: D1Database,
+	campaignId: string
+): Promise<number> {
+	try {
+		const row = await db
+			.prepare(
+				"SELECT cache_version FROM entity_search_cache_version WHERE campaign_id = ?"
+			)
+			.bind(campaignId)
+			.first<{ cache_version: number }>();
+
+		if (row) {
+			return row.cache_version;
+		}
+
+		await db
+			.prepare(
+				"INSERT OR IGNORE INTO entity_search_cache_version (campaign_id, cache_version) VALUES (?, 0)"
+			)
+			.bind(campaignId)
+			.run();
+
+		const after = await db
+			.prepare(
+				"SELECT cache_version FROM entity_search_cache_version WHERE campaign_id = ?"
+			)
+			.bind(campaignId)
+			.first<{ cache_version: number }>();
+
+		return after?.cache_version ?? 0;
+	} catch (error) {
+		logger
+			.scope("[EntitySearchCache]")
+			.warn("Failed to get campaign cache version, using 0", {
+				campaignId,
+				error,
+			});
+		return 0;
+	}
+}
+
+/**
+ * Increment campaign cache version (invalidates all cached searches for that campaign).
+ * Called from EntityDAO on entity create/update/delete.
+ */
+export async function incrementCampaignCacheVersion(
+	db: D1Database,
+	campaignId: string
+): Promise<void> {
+	try {
+		await db
+			.prepare(
+				`INSERT INTO entity_search_cache_version (campaign_id, cache_version)
+         VALUES (?, 1)
+         ON CONFLICT(campaign_id) DO UPDATE SET cache_version = cache_version + 1`
+			)
+			.bind(campaignId)
+			.run();
+	} catch (error) {
+		logger
+			.scope("[EntitySearchCache]")
+			.warn("Failed to increment campaign cache version", {
+				campaignId,
+				error,
+			});
+	}
+}
+
+/**
+ * Fetch cached semantic search result if present.
+ */
+export async function getCachedSearchResult(
+	cacheKey: string
+): Promise<CachedEntitySearchResult | null> {
+	try {
+		const cache = (globalThis as unknown as { caches: { default: Cache } })
+			.caches.default;
+		const request = new Request(cacheKey);
+		const cached = await cache.match(request);
+		if (!cached || !cached.ok) return null;
+		const body = (await cached.json()) as CachedEntitySearchResult;
+		if (!body?.entityIds || !Array.isArray(body.entityIds)) return null;
+		return {
+			entityIds: body.entityIds,
+			scores: Array.isArray(body.scores) ? body.scores : [],
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Store semantic search result in cache.
+ */
+export async function setCachedSearchResult(
+	cacheKey: string,
+	result: CachedEntitySearchResult
+): Promise<void> {
+	try {
+		const cache = (globalThis as unknown as { caches: { default: Cache } })
+			.caches.default;
+		const request = new Request(cacheKey);
+		const response = new Response(JSON.stringify(result), {
+			headers: {
+				"Content-Type": "application/json",
+				"Cache-Control": `max-age=${CACHE_TTL_SEC}`,
+			},
+		});
+		await cache.put(request, response);
+	} catch (error) {
+		logger
+			.scope("[EntitySearchCache]")
+			.warn("Failed to store search result in cache", {
+				cacheKey: cacheKey.slice(0, 80),
+				error,
+			});
+	}
+}

--- a/src/tools/campaign-context/search-tools.ts
+++ b/src/tools/campaign-context/search-tools.ts
@@ -1,4 +1,4 @@
-import type { VectorizeIndex } from "@cloudflare/workers-types";
+import type { D1Database, VectorizeIndex } from "@cloudflare/workers-types";
 import { tool } from "ai";
 import { z } from "zod";
 import { AUTH_CODES, type ToolResult } from "@/app-constants";
@@ -10,6 +10,12 @@ import { STRUCTURED_ENTITY_TYPES } from "@/lib/entity/entity-types";
 import { WorldStateChangelogService } from "@/services/graph/world-state-changelog-service";
 import type { PlanningContextService } from "@/services/rag/planning-context-service";
 import { getPlanningServices } from "@/services/rag/rag-service-factory";
+import {
+	buildCacheKey,
+	getCachedSearchResult,
+	getCampaignCacheVersion,
+	setCachedSearchResult,
+} from "@/services/search/entity-search-cache-service";
 import { EntityEmbeddingService } from "@/services/vectorize/entity-embedding-service";
 import {
 	commonSchemas,
@@ -427,46 +433,40 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 							hasSearchQuery && planningService !== null && env.VECTORIZE;
 
 						if (shouldUseSemanticSearch && planningService) {
-							// Use semantic search as the primary method for all queries
-							try {
-								const queryEmbeddings =
-									await planningService.generateEmbeddings([
-										queryIntent.searchQuery,
-									]);
-								const queryEmbedding = queryEmbeddings[0];
+							// For list-all queries, use a higher topK; for focused searches, use a more targeted topK
+							const searchTopK = queryIntent.isListAll
+								? Math.min(effectiveLimit * 2, 500)
+								: targetEntityType
+									? 20
+									: 10;
+							const normalizedQuery =
+								queryIntent.searchQuery?.toLowerCase().trim() ?? "";
 
-								if (queryEmbedding) {
-									const entityEmbeddingService = new EntityEmbeddingService(
-										env.VECTORIZE as VectorizeIndex | undefined
+							// Try cache first (avoids embedding + Vectorize call)
+							let cacheHit = false;
+							if (env.DB) {
+								try {
+									const cacheVersion = await getCampaignCacheVersion(
+										env.DB as D1Database,
+										campaignId
 									);
-
-									// For list-all queries, use a higher topK to get more results
-									// For focused searches, use a more targeted topK
-									const searchTopK = queryIntent.isListAll
-										? Math.min(effectiveLimit * 2, 500) // Get more results for list-all
-										: targetEntityType
-											? 20
-											: 10; // Focused search
-
-									const similarEntities =
-										await entityEmbeddingService.findSimilarByEmbedding(
-											queryEmbedding,
-											{
-												campaignId,
-												entityType: targetEntityType || undefined,
-												topK: searchTopK,
-											}
-										);
-
-									// Store similarity scores for later use in sorting
-									for (const similar of similarEntities) {
-										entitySimilarityScores.set(similar.entityId, similar.score);
-									}
-
-									// Get full entity details for semantic matches
-									const entityIds = similarEntities.map((e) => e.entityId);
-									if (entityIds.length > 0) {
-										// For list-all, we might need to fetch more entities to fill the limit
+									const cacheKey = buildCacheKey(
+										campaignId,
+										cacheVersion,
+										normalizedQuery,
+										targetEntityType ?? undefined,
+										searchTopK
+									);
+									const cached = await getCachedSearchResult(cacheKey);
+									if (cached && cached.entityIds.length > 0) {
+										cacheHit = true;
+										for (let i = 0; i < cached.entityIds.length; i++) {
+											entitySimilarityScores.set(
+												cached.entityIds[i],
+												cached.scores[i] ?? 0
+											);
+										}
+										const entityIds = cached.entityIds;
 										const fetchLimit = queryIntent.isListAll
 											? effectiveLimit + 1
 											: 100;
@@ -479,8 +479,6 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 													entityIds,
 												}
 											);
-
-										// For list-all queries, get total count for accurate reporting
 										if (queryIntent.isListAll && totalCount === undefined) {
 											totalCount =
 												await daoFactory.entityDAO.getEntityCountByCampaign(
@@ -490,25 +488,122 @@ Use ONLY explicit relationships shown in results. Do NOT infer from content text
 														: {}
 												);
 										}
-
 										console.log(
-											`[Tool] searchCampaignContext - Semantic search found ${entities.length} entities via embeddings${queryIntent.isListAll ? " (list-all mode)" : ""}`
+											`[Tool] searchCampaignContext - Semantic search cache hit: ${entities.length} entities`
 										);
-									} else {
-										throw new Error("No semantic matches found");
 									}
-								} else {
-									throw new Error("Failed to generate embedding");
+								} catch (cacheErr) {
+									console.warn(
+										"[Tool] searchCampaignContext - Cache lookup failed, falling through to semantic search:",
+										cacheErr
+									);
 								}
-							} catch (searchError) {
-								console.log(
-									`[Tool] searchCampaignContext - Semantic search failed, falling back to database query:`,
-									searchError instanceof Error
-										? searchError.message
-										: String(searchError)
-								);
-								// Fall through to database query below
-								entities = [];
+							}
+
+							if (!cacheHit) {
+								// Use semantic search (embedding + Vectorize)
+								try {
+									const semanticStart = Date.now();
+									const queryEmbeddings =
+										await planningService.generateEmbeddings([
+											queryIntent.searchQuery,
+										]);
+									const queryEmbedding = queryEmbeddings[0];
+
+									if (queryEmbedding) {
+										const entityEmbeddingService = new EntityEmbeddingService(
+											env.VECTORIZE as VectorizeIndex | undefined
+										);
+
+										const similarEntities =
+											await entityEmbeddingService.findSimilarByEmbedding(
+												queryEmbedding,
+												{
+													campaignId,
+													entityType: targetEntityType || undefined,
+													topK: searchTopK,
+												}
+											);
+
+										// Store similarity scores for later use in sorting
+										for (const similar of similarEntities) {
+											entitySimilarityScores.set(
+												similar.entityId,
+												similar.score
+											);
+										}
+
+										// Cache result for next time
+										if (env.DB && similarEntities.length > 0) {
+											try {
+												const cacheVersion = await getCampaignCacheVersion(
+													env.DB as D1Database,
+													campaignId
+												);
+												const cacheKey = buildCacheKey(
+													campaignId,
+													cacheVersion,
+													normalizedQuery,
+													targetEntityType ?? undefined,
+													searchTopK
+												);
+												await setCachedSearchResult(cacheKey, {
+													entityIds: similarEntities.map((e) => e.entityId),
+													scores: similarEntities.map((e) => e.score),
+												});
+											} catch {
+												// ignore cache write failures
+											}
+										}
+
+										// Get full entity details for semantic matches
+										const entityIds = similarEntities.map((e) => e.entityId);
+										if (entityIds.length > 0) {
+											// For list-all, we might need to fetch more entities to fill the limit
+											const fetchLimit = queryIntent.isListAll
+												? effectiveLimit + 1
+												: 100;
+											entities =
+												await daoFactory.entityDAO.listEntitiesByCampaign(
+													campaignId,
+													{
+														limit: fetchLimit,
+														entityType: targetEntityType || undefined,
+														entityIds,
+													}
+												);
+
+											// For list-all queries, get total count for accurate reporting
+											if (queryIntent.isListAll && totalCount === undefined) {
+												totalCount =
+													await daoFactory.entityDAO.getEntityCountByCampaign(
+														campaignId,
+														targetEntityType
+															? { entityType: targetEntityType }
+															: {}
+													);
+											}
+
+											const semanticMs = Date.now() - semanticStart;
+											console.log(
+												`[Tool] searchCampaignContext - Semantic search found ${entities.length} entities via embeddings in ${semanticMs}ms${queryIntent.isListAll ? " (list-all mode)" : ""}`
+											);
+										} else {
+											throw new Error("No semantic matches found");
+										}
+									} else {
+										throw new Error("Failed to generate embedding");
+									}
+								} catch (searchError) {
+									console.log(
+										`[Tool] searchCampaignContext - Semantic search failed, falling back to database query:`,
+										searchError instanceof Error
+											? searchError.message
+											: String(searchError)
+									);
+									// Fall through to database query below
+									entities = [];
+								}
 							}
 						}
 


### PR DESCRIPTION
- Add D1 migration for entity_search_cache_version table
- Add EntitySearchCacheService with Cloudflare Cache API
- Invalidate cache on entity create/update/delete
- Integrate cache in searchCampaignContext tool
- Integrate cache in handleSearchEntityInGraph
- Add docs/ENTITY_SEARCH_CACHING.md
- Add ENTITY_SEARCH_CACHING to wiki sync

Made-with: Cursor