### PR TITLE
Free tier: 150k one-time trial tokens, 25MB storage, 2/6 retries

### DIFF
--- a/docs/LIMITS.md
+++ b/docs/LIMITS.md
@@ -33,9 +33,9 @@ Purchased one-off credits add directly to your daily and hourly token limits. If
 
 Defined in `SUBSCRIPTION_TIERS` in `src/app-constants.ts`:
 
-| Tier | Max campaigns | Max files | Storage | TPH | QPH | TPD | QPD | Monthly tokens | Resources/campaign/hour | Retries/file/day | Retries/file/month |
-|------|---------------|-----------|---------|-----|-----|-----|-----|----------------|-------------------------|------------------|--------------------|
-| Free | 1 | 5 | 5 MB | 120k | 300 | 10k | 50 | 10k | 5 | 1 | 3 |
+| Tier | Max campaigns | Max files | Storage | TPH | QPH | TPD | QPD | Trial tokens | Resources/campaign/hour | Retries/file/day | Retries/file/month |
+|------|---------------|-----------|---------|-----|-----|-----|-----|--------------|-------------------------|------------------|--------------------|
+| Free | 1 | 5 | 25 MB | 120k | 300 | 10k | 50 | 150k (one-time) | 5 | 2 | 6 |
 | Basic | 5 | 25 | 1 GB | 600k | 600 | 500k | 500 | — | 20 | 3 | 15 |
 | Pro | 999,999 | 100 | 5 GB | 1.2M | 1,200 | 1M | 1,000 | — | 50 | 5 | 50 |
 
@@ -44,6 +44,7 @@ Defined in `SUBSCRIPTION_TIERS` in `src/app-constants.ts`:
 - **TPD** = tokens per day  
 - **QPD** = requests per day  
 - **Retries** = indexation/entity extraction retries per file  
+- **Free tier trial tokens** = 150k tokens total, ever (no reset). Supports a full "try the app" flow: 5 files, campaign creation, next steps, and session readout. One-time trial semantics; upgrade for recurring capacity.  
 
 ## Authentication
 

--- a/migrations/0013_user_free_tier_usage.sql
+++ b/migrations/0013_user_free_tier_usage.sql
@@ -1,0 +1,9 @@
+-- Cumulative token usage for free-tier one-time trial; never resets.
+CREATE TABLE IF NOT EXISTS user_free_tier_usage (
+  username text primary key,
+  tokens_used integer not null default 0,
+  updated_at datetime default current_timestamp,
+  foreign key (username) references users(username) on delete cascade
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_free_tier_usage_username ON user_free_tier_usage(username);

--- a/src/app-constants.ts
+++ b/src/app-constants.ts
@@ -326,8 +326,10 @@ export interface TierLimits {
 	qph: number; // queries per hour (was qpm * 60)
 	tpd: number;
 	qpd: number;
-	/** Monthly token cap for free tier only; undefined for paid tiers */
+	/** Monthly token cap; undefined for paid tiers and when using lifetimeTokens */
 	monthlyTokens?: number;
+	/** One-time trial token cap for free tier; undefined for paid tiers. When set, replaces monthlyTokens. */
+	lifetimeTokens?: number;
 	/** Per-file retries per day for indexation/entity extraction retry */
 	retriesPerFilePerDay: number;
 	/** Per-file retries per month for indexation/entity extraction retry */
@@ -340,14 +342,14 @@ export const SUBSCRIPTION_TIERS: Record<SubscriptionTier, TierLimits> = {
 	free: {
 		maxCampaigns: 1,
 		maxFiles: 5,
-		storageBytes: 5 * 1024 * 1024, // 5MB
-		tph: 120_000, // was 2k/min * 60
-		qph: 300, // 5/min * 60 = queries per hour
+		storageBytes: 25 * 1024 * 1024, // 25MB
+		tph: 120_000,
+		qph: 300,
 		tpd: 10_000,
 		qpd: 50,
-		monthlyTokens: 10_000,
-		retriesPerFilePerDay: 1,
-		retriesPerFilePerMonth: 3,
+		lifetimeTokens: 150_000, // One-time trial capacity; no monthly reset
+		retriesPerFilePerDay: 2,
+		retriesPerFilePerMonth: 6,
 		resourcesPerCampaignPerHour: 5,
 	},
 	basic: {

--- a/src/components/billing/BillingPage.tsx
+++ b/src/components/billing/BillingPage.tsx
@@ -379,16 +379,22 @@ export function BillingPage({ onBack }: BillingPageProps) {
 								<td className="py-2">Tokens per day</td>
 								<td className="py-2 text-right">{formatNumber(limits.tpd)}</td>
 							</tr>
-							{limits.monthlyTokens !== undefined && (
+							{(limits.lifetimeTokens !== undefined ||
+								limits.monthlyTokens !== undefined) && (
 								<>
 									<tr>
-										<td className="py-2">Monthly tokens (free tier)</td>
+										<td className="py-2">
+											{limits.lifetimeTokens !== undefined
+												? "Trial tokens"
+												: "Monthly tokens (free tier)"}
+										</td>
 										<td className="py-2 text-right">
 											{status.monthlyUsage !== undefined
 												? `${formatNumber(status.monthlyUsage)} / `
 												: ""}
 											{formatNumber(
-												limits.monthlyTokens + (status.creditsRemaining ?? 0)
+												(limits.lifetimeTokens ?? limits.monthlyTokens ?? 0) +
+													(status.creditsRemaining ?? 0)
 											)}
 										</td>
 									</tr>

--- a/src/components/billing/CreditPurchaseSection.tsx
+++ b/src/components/billing/CreditPurchaseSection.tsx
@@ -52,7 +52,9 @@ export function CreditPurchaseSection({
 }: CreditPurchaseSectionProps) {
 	const [helpExpanded, setHelpExpanded] = useState(false);
 
-	const hasMonthlyLimit = status.limits.monthlyTokens !== undefined;
+	const hasFreeTierQuota =
+		status.limits.monthlyTokens !== undefined ||
+		status.limits.lifetimeTokens !== undefined;
 
 	const jwt =
 		typeof window !== "undefined"
@@ -84,7 +86,8 @@ export function CreditPurchaseSection({
 		}
 	}
 
-	const baseLimit = status.limits.monthlyTokens ?? 0;
+	const baseLimit =
+		status.limits.lifetimeTokens ?? status.limits.monthlyTokens ?? 0;
 	const credits = status.creditsRemaining ?? 0;
 	const effectiveLimit = baseLimit + credits;
 	const monthlyUsage = status.monthlyUsage ?? 0;
@@ -126,10 +129,12 @@ export function CreditPurchaseSection({
 				)}
 			</div>
 
-			{hasMonthlyLimit && (
+			{hasFreeTierQuota && (
 				<div className="mb-4">
 					<p className="text-sm text-neutral-600 dark:text-neutral-400">
-						This month:{" "}
+						{status.limits.lifetimeTokens !== undefined
+							? "Trial: "
+							: "This month: "}
 						<strong className="text-neutral-800 dark:text-neutral-200">
 							{monthlyUsage.toLocaleString()} /{" "}
 							{effectiveLimit.toLocaleString()} tokens

--- a/src/components/billing/QuotaWarningModal.tsx
+++ b/src/components/billing/QuotaWarningModal.tsx
@@ -35,7 +35,8 @@ export function QuotaWarningModal({
 						Usage:{" "}
 						<strong>
 							{monthlyUsage.toLocaleString()} / {monthlyLimit.toLocaleString()}{" "}
-							tokens this month
+							tokens
+							{reason.includes("trial") ? "" : " this month"}
 						</strong>
 					</p>
 				)}

--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -35,6 +35,7 @@ import { SubscriptionDAO } from "./subscription-dao";
 import { UserCreditsDAO } from "./user-credits-dao";
 import type { UserStorageUsage } from "./user-dao";
 import { UserDAO } from "./user-dao";
+import { UserFreeTierUsageDAO } from "./user-free-tier-usage-dao";
 import { UserMonthlyUsageDAO } from "./user-monthly-usage-dao";
 
 // Cache for DAO factory instances
@@ -65,6 +66,7 @@ export interface DAOFactory {
 	campaignResourceProposalDAO: CampaignResourceProposalDAO;
 	subscriptionDAO: SubscriptionDAO;
 	userMonthlyUsageDAO: UserMonthlyUsageDAO;
+	userFreeTierUsageDAO: UserFreeTierUsageDAO;
 	userCreditsDAO: UserCreditsDAO;
 	fileRetryUsageDAO: FileRetryUsageDAO;
 	resourceAddLogDAO: ResourceAddLogDAO;
@@ -104,6 +106,7 @@ export class DAOFactoryImpl implements DAOFactory {
 	public readonly campaignResourceProposalDAO: CampaignResourceProposalDAO;
 	public readonly subscriptionDAO: SubscriptionDAO;
 	public readonly userMonthlyUsageDAO: UserMonthlyUsageDAO;
+	public readonly userFreeTierUsageDAO: UserFreeTierUsageDAO;
 	public readonly userCreditsDAO: UserCreditsDAO;
 	public readonly fileRetryUsageDAO: FileRetryUsageDAO;
 	public readonly resourceAddLogDAO: ResourceAddLogDAO;
@@ -138,6 +141,7 @@ export class DAOFactoryImpl implements DAOFactory {
 		this.campaignResourceProposalDAO = new CampaignResourceProposalDAO(db);
 		this.subscriptionDAO = new SubscriptionDAO(db);
 		this.userMonthlyUsageDAO = new UserMonthlyUsageDAO(db);
+		this.userFreeTierUsageDAO = new UserFreeTierUsageDAO(db);
 		this.userCreditsDAO = new UserCreditsDAO(db);
 		this.fileRetryUsageDAO = new FileRetryUsageDAO(db);
 		this.resourceAddLogDAO = new ResourceAddLogDAO(db);

--- a/src/dao/user-free-tier-usage-dao.ts
+++ b/src/dao/user-free-tier-usage-dao.ts
@@ -1,0 +1,27 @@
+import { BaseDAOClass } from "./base-dao";
+
+/**
+ * Tracks cumulative token usage for free-tier one-time trial.
+ * Usage never resets; when lifetimeTokens limit is exceeded, user must upgrade.
+ */
+export class UserFreeTierUsageDAO extends BaseDAOClass {
+	async getLifetimeUsage(username: string): Promise<number> {
+		const row = await this.queryFirst<{ tokens_used: number }>(
+			"SELECT tokens_used FROM user_free_tier_usage WHERE username = ?",
+			[username]
+		);
+		return row?.tokens_used ?? 0;
+	}
+
+	async incrementUsage(username: string, tokens: number): Promise<void> {
+		const now = new Date().toISOString();
+		const sql = `
+      INSERT INTO user_free_tier_usage (username, tokens_used, updated_at)
+      VALUES (?, ?, ?)
+      ON CONFLICT(username) DO UPDATE SET
+        tokens_used = tokens_used + excluded.tokens_used,
+        updated_at = excluded.updated_at
+    `;
+		await this.execute(sql, [username, tokens, now]);
+	}
+}

--- a/src/hooks/useBillingStatus.ts
+++ b/src/hooks/useBillingStatus.ts
@@ -11,6 +11,7 @@ export interface BillingLimits {
 	tpd: number;
 	qpd: number;
 	monthlyTokens?: number;
+	lifetimeTokens?: number;
 	resourcesPerCampaignPerHour?: number;
 }
 

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -197,12 +197,17 @@ export async function handleBillingStatus(c: ContextWithAuth) {
 	const dao = getDAOFactory(c.env);
 	const sub = await dao.subscriptionDAO.getByUsername(auth.username);
 
-	// Free tier: include monthly usage and credits for quota visibility
+	// Free tier: include usage and credits for quota visibility (lifetime trial or monthly)
 	let monthlyUsage: number | undefined;
 	let creditsRemaining: number | undefined;
-	if (tier === "free" && limits.monthlyTokens !== undefined) {
+	if (
+		tier === "free" &&
+		(limits.lifetimeTokens !== undefined || limits.monthlyTokens !== undefined)
+	) {
 		[monthlyUsage, creditsRemaining] = await Promise.all([
-			dao.userMonthlyUsageDAO.getCurrentMonthUsage(auth.username),
+			limits.lifetimeTokens !== undefined
+				? dao.userFreeTierUsageDAO.getLifetimeUsage(auth.username)
+				: dao.userMonthlyUsageDAO.getCurrentMonthUsage(auth.username),
 			dao.userCreditsDAO.getCredits(auth.username),
 		]);
 	}
@@ -221,6 +226,7 @@ export async function handleBillingStatus(c: ContextWithAuth) {
 			tpd: limits.tpd,
 			qpd: limits.qpd,
 			monthlyTokens: limits.monthlyTokens,
+			lifetimeTokens: limits.lifetimeTokens,
 			resourcesPerCampaignPerHour: limits.resourcesPerCampaignPerHour,
 		},
 		monthlyUsage,

--- a/src/services/llm/llm-rate-limit-service.ts
+++ b/src/services/llm/llm-rate-limit-service.ts
@@ -64,7 +64,21 @@ export class LLMRateLimitService {
 		const dao = getDAOFactory(this.env);
 		let creditsRemaining = 0;
 
-		if (limits.monthlyTokens !== undefined) {
+		if (limits.lifetimeTokens !== undefined) {
+			const [lifetimeUsage, credits] = await Promise.all([
+				dao.userFreeTierUsageDAO.getLifetimeUsage(username),
+				dao.userCreditsDAO.getCredits(username),
+			]);
+			creditsRemaining = credits;
+			const effectiveLimit = limits.lifetimeTokens + credits;
+			if (lifetimeUsage >= effectiveLimit) {
+				return {
+					allowed: false,
+					reason: `Trial token limit (${effectiveLimit.toLocaleString()}) exceeded. Upgrade for more capacity.`,
+					limitType: "daily",
+				};
+			}
+		} else if (limits.monthlyTokens !== undefined) {
 			const [monthlyUsage, credits] = await Promise.all([
 				dao.userMonthlyUsageDAO.getCurrentMonthUsage(username),
 				dao.userCreditsDAO.getCredits(username),
@@ -181,7 +195,44 @@ export class LLMRateLimitService {
 		const tier = await subService.getTier(username);
 		const limits = subService.getTierLimits(tier);
 
-		// Free tier: check monthly cap with estimated tokens
+		// Free tier: check lifetime trial or monthly cap with estimated tokens
+		if (limits.lifetimeTokens !== undefined) {
+			const dao = getDAOFactory(this.env);
+			const [lifetimeUsage, creditsRemaining] = await Promise.all([
+				dao.userFreeTierUsageDAO.getLifetimeUsage(username),
+				dao.userCreditsDAO.getCredits(username),
+			]);
+			const effectiveLimit = limits.lifetimeTokens + creditsRemaining;
+			const wouldExceed = lifetimeUsage + estimatedTokens > effectiveLimit;
+			const alreadyExceeded = lifetimeUsage >= effectiveLimit;
+
+			if (alreadyExceeded) {
+				return {
+					allowed: false,
+					reason: `Trial token limit (${effectiveLimit.toLocaleString()}) exceeded. Upgrade for more capacity.`,
+					wouldExceed: true,
+					monthlyUsage: lifetimeUsage,
+					monthlyLimit: effectiveLimit,
+					creditsRemaining,
+				};
+			}
+			if (wouldExceed) {
+				return {
+					allowed: false,
+					reason: `This action would exceed your trial token limit. You have ${(effectiveLimit - lifetimeUsage).toLocaleString()} tokens remaining.`,
+					wouldExceed: true,
+					monthlyUsage: lifetimeUsage,
+					monthlyLimit: effectiveLimit,
+					creditsRemaining,
+				};
+			}
+			return {
+				allowed: true,
+				monthlyUsage: lifetimeUsage,
+				monthlyLimit: effectiveLimit,
+				creditsRemaining,
+			};
+		}
 		if (limits.monthlyTokens !== undefined) {
 			const dao = getDAOFactory(this.env);
 			const [monthlyUsage, creditsRemaining] = await Promise.all([
@@ -248,11 +299,13 @@ export class LLMRateLimitService {
 		const dao = getDAOFactory(this.env);
 		await dao.llmUsageDAO.insertUsage(username, tokens, queryCount, model);
 
-		// Free tier: track monthly usage for cap
+		// Free tier: track usage for cap (lifetime trial or monthly)
 		const subService = getSubscriptionService(this.env);
 		const tier = await subService.getTier(username);
 		const limits = subService.getTierLimits(tier);
-		if (limits.monthlyTokens !== undefined) {
+		if (limits.lifetimeTokens !== undefined) {
+			await dao.userFreeTierUsageDAO.incrementUsage(username, tokens);
+		} else if (limits.monthlyTokens !== undefined) {
 			await dao.userMonthlyUsageDAO.incrementUsage(username, tokens);
 		}
 	}
@@ -287,17 +340,23 @@ export class LLMRateLimitService {
 
 		const dao = getDAOFactory(this.env);
 
-		// Free tier: include monthly usage and credits for UI
+		// Free tier: include usage and credits for UI (lifetime trial or monthly)
 		// Paid tiers: fetch credits so effective limits reflect purchased one-offs
 		let monthlyUsage: number | undefined;
 		let monthlyLimit: number | undefined;
 		let creditsRemaining: number | undefined;
-		if (limits.monthlyTokens !== undefined) {
+		if (limits.lifetimeTokens !== undefined) {
+			[monthlyUsage, creditsRemaining] = await Promise.all([
+				dao.userFreeTierUsageDAO.getLifetimeUsage(username),
+				dao.userCreditsDAO.getCredits(username),
+			]);
+			monthlyLimit = limits.lifetimeTokens + (creditsRemaining ?? 0);
+		} else if (limits.monthlyTokens !== undefined) {
 			[monthlyUsage, creditsRemaining] = await Promise.all([
 				dao.userMonthlyUsageDAO.getCurrentMonthUsage(username),
 				dao.userCreditsDAO.getCredits(username),
 			]);
-			monthlyLimit = limits.monthlyTokens + creditsRemaining;
+			monthlyLimit = limits.monthlyTokens + (creditsRemaining ?? 0);
 		} else {
 			creditsRemaining = await dao.userCreditsDAO.getCredits(username);
 		}
@@ -364,11 +423,21 @@ export class LLMRateLimitService {
 					: null;
 		}
 
-		// Free tier: also at limit if monthly cap exceeded
-		const atMonthlyLimit =
+		// Free tier: also at limit if trial/monthly cap exceeded
+		const atTierCapLimit =
 			monthlyLimit !== undefined &&
 			monthlyUsage !== undefined &&
 			monthlyUsage >= monthlyLimit;
+
+		// Lifetime trial has no reset; monthly has next month
+		const tierCapNextReset =
+			atTierCapLimit && limits.monthlyTokens !== undefined
+				? new Date(
+						new Date().getFullYear(),
+						new Date().getMonth() + 1,
+						1
+					).toISOString()
+				: null;
 
 		return {
 			tph,
@@ -379,16 +448,9 @@ export class LLMRateLimitService {
 			qphLimit: limits.qph,
 			tpdLimit: tpdLimitEffective,
 			qpdLimit: limits.qpd,
-			nextResetAt:
-				atMonthlyLimit && limits.monthlyTokens !== undefined
-					? new Date(
-							new Date().getFullYear(),
-							new Date().getMonth() + 1,
-							1
-						).toISOString()
-					: nextResetAt,
-			atLimit: atLimit || atMonthlyLimit,
-			limitType: atMonthlyLimit ? "daily" : limitType,
+			nextResetAt: atTierCapLimit ? tierCapNextReset : nextResetAt,
+			atLimit: atLimit || atTierCapLimit,
+			limitType: atTierCapLimit ? "daily" : limitType,
 			isAdmin: false,
 			monthlyUsage,
 			monthlyLimit,

--- a/tests/routes/billing.test.ts
+++ b/tests/routes/billing.test.ts
@@ -25,11 +25,16 @@ const mockAuthUserDAO = {
 };
 const mockUserMonthlyUsageDAO = { getCurrentMonthUsage: vi.fn() };
 const mockUserCreditsDAO = { getCredits: vi.fn() };
+const mockUserFreeTierUsageDAO = {
+	getLifetimeUsage: vi.fn().mockResolvedValue(0),
+	incrementUsage: vi.fn().mockResolvedValue(undefined),
+};
 const mockDAOFactory = {
 	subscriptionDAO: mockSubscriptionDAO,
 	authUserDAO: mockAuthUserDAO,
 	userMonthlyUsageDAO: mockUserMonthlyUsageDAO,
 	userCreditsDAO: mockUserCreditsDAO,
+	userFreeTierUsageDAO: mockUserFreeTierUsageDAO,
 };
 
 vi.mock("@/dao/dao-factory", () => ({


### PR DESCRIPTION
- Add lifetimeTokens (150k) to replace monthlyTokens for free tier
- Add user_free_tier_usage table and UserFreeTierUsageDAO
- Update LLMRateLimitService to track lifetime usage for free tier
- Update billing routes and UI for trial semantics
- Update docs/LIMITS.md with new free tier limits

Made-with: Cursor