### PR TITLE
feat: token-aware retry for entity extraction (#536)

### DIFF
--- a/src/lib/file/text-chunking-utils.ts
+++ b/src/lib/file/text-chunking-utils.ts
@@ -92,3 +92,36 @@ export function chunkTextByCharacterCount(
 
 	return chunks.length > 0 ? chunks : [text];
 }
+
+const TRUNCATION_SUFFIX =
+	"\n\n[Content truncated for context limit - retrying with reduced length]";
+
+/**
+ * Truncate content at a sentence boundary for retry after context-length error.
+ * Target ~60% of current length to stay within model limits.
+ *
+ * @param content - The text to truncate
+ * @param maxChars - Maximum characters to keep
+ * @returns Truncated content ending at sentence boundary, or original if short enough
+ */
+export function truncateContentAtSentenceBoundary(
+	content: string,
+	maxChars: number
+): string {
+	const MIN_TRUNCATION_CHARS = 2000;
+	const effectiveMax = Math.max(MIN_TRUNCATION_CHARS, maxChars);
+
+	if (!content || content.length <= effectiveMax) {
+		return content;
+	}
+
+	const searchRegion = content.slice(0, effectiveMax);
+	const lastPeriod = searchRegion.lastIndexOf(".");
+	const lastExclamation = searchRegion.lastIndexOf("!");
+	const lastQuestion = searchRegion.lastIndexOf("?");
+	const lastSentence = Math.max(lastPeriod, lastExclamation, lastQuestion);
+
+	const breakPoint =
+		lastSentence > effectiveMax * 0.5 ? lastSentence + 1 : effectiveMax;
+	return content.slice(0, breakPoint).trim() + TRUNCATION_SUFFIX;
+}

--- a/src/services/campaign/entity-staging-service.ts
+++ b/src/services/campaign/entity-staging-service.ts
@@ -12,6 +12,7 @@ import { normalizeEntityType } from "@/lib/entity/entity-types";
 import {
 	chunkTextByCharacterCount,
 	chunkTextByPages,
+	truncateContentAtSentenceBoundary,
 } from "@/lib/file/text-chunking-utils";
 import { notifyCampaignMembers } from "@/lib/notifications";
 import { R2Helper } from "@/lib/r2";
@@ -111,6 +112,19 @@ function cosineSimilarity(a: number[], b: number[]): number {
 	}
 	if (magA === 0 || magB === 0) return 0;
 	return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+}
+
+function isContextLengthError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const message = error.message.toLowerCase();
+	return (
+		message.includes("maximum context length") ||
+		message.includes("context length") ||
+		message.includes("too many tokens") ||
+		message.includes("reduce the length") ||
+		message.includes("maximum context size") ||
+		message.includes("input too long")
+	);
 }
 
 /**
@@ -440,6 +454,7 @@ export async function stageEntitiesFromResource(
 
 		const failedChunks: number[] = [];
 		const chunkRetryCounts: Map<number, number> = new Map(); // Track retry count per chunk index
+		const chunkContentByRetry: Map<number, string> = new Map(); // Trimmed content for context-length retries
 		const chunksToRetry: number[] = []; // Chunks that need retrying
 		let successfulChunks = 0;
 
@@ -595,10 +610,10 @@ export async function stageEntitiesFromResource(
 					);
 				}
 
-				// Only retry rate-limit errors. Other model/parsing failures should
-				// be treated as one-shot failures to avoid retry storms and CPU overruns.
+				// Retry rate-limit errors with same payload; retry context-length errors with trimmed content.
+				const isContextLength = isContextLengthError(chunkError);
 				if (isRateLimit && retryCount < MAX_CHUNK_RETRIES) {
-					// Increment retry count and schedule retry
+					// Increment retry count and schedule retry (same payload)
 					chunkRetryCounts.set(chunkIndex, retryCount + 1);
 					const rateLimitWaitMs = 5000; // Wait 5 seconds for rate limit
 					console.log(
@@ -607,15 +622,36 @@ export async function stageEntitiesFromResource(
 					await new Promise((resolve) => setTimeout(resolve, rateLimitWaitMs));
 
 					return false; // Indicates failure but will be retried
-				} else {
-					// Max retries exceeded - mark as permanently failed
-					console.error(
-						`[EntityStaging] Chunk ${chunkNumber} failed after ${MAX_CHUNK_RETRIES} retry attempts, giving up`
-					);
-					failedChunks.push(chunkNumber);
-					chunkRetryCounts.delete(chunkIndex);
-					return false; // Permanently failed
 				}
+				if (isContextLength && retryCount < MAX_CHUNK_RETRIES) {
+					// Trim content to ~60% for retry; each subsequent retry trims again
+					// `chunk` is the content we just failed with (original or previously trimmed)
+					const currentContent = chunk;
+					const targetChars = Math.floor(currentContent.length * 0.6);
+					const trimmedContent = truncateContentAtSentenceBoundary(
+						currentContent,
+						targetChars
+					);
+					if (trimmedContent.length >= 2000) {
+						chunkContentByRetry.set(chunkIndex, trimmedContent);
+						chunkRetryCounts.set(chunkIndex, retryCount + 1);
+						console.log(
+							`[EntityStaging] Context length error on chunk ${chunkNumber}, will retry with trimmed content (${trimmedContent.length} chars, was ${currentContent.length})`
+						);
+						return false; // Will be retried with trimmed content
+					}
+					// Trimmed content too short - give up
+					console.warn(
+						`[EntityStaging] Chunk ${chunkNumber} still exceeds context limit after trim (min 2000 chars); giving up`
+					);
+				}
+				// Max retries exceeded - mark as permanently failed
+				console.error(
+					`[EntityStaging] Chunk ${chunkNumber} failed after ${MAX_CHUNK_RETRIES} retry attempts, giving up`
+				);
+				failedChunks.push(chunkNumber);
+				// Keep retry count so caller won't re-queue (newRetryCount >= MAX_CHUNK_RETRIES)
+				return false; // Permanently failed
 			}
 		};
 
@@ -643,7 +679,10 @@ export async function stageEntitiesFromResource(
 				continue;
 			}
 
-			const success = await processChunk(chunkIndex, chunks[chunkIndex], true);
+			// Use trimmed content for context-length retries; otherwise original chunk
+			const contentToProcess =
+				chunkContentByRetry.get(chunkIndex) ?? chunks[chunkIndex];
+			const success = await processChunk(chunkIndex, contentToProcess, true);
 			if (success) {
 				successfulChunks++;
 			} else {
@@ -699,6 +738,11 @@ export async function stageEntitiesFromResource(
 				success: true,
 				entityCount: 0,
 				stagedEntities: [],
+				...(failedChunks.length > 0 && {
+					failedChunks,
+					successfulChunks,
+					totalChunks: chunks.length,
+				}),
 			};
 		}
 

--- a/tests/lib/text-chunking-utils.test.ts
+++ b/tests/lib/text-chunking-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	chunkTextByCharacterCount,
 	chunkTextByPages,
+	truncateContentAtSentenceBoundary,
 } from "@/lib/file/text-chunking-utils";
 
 describe("chunkTextByPages", () => {
@@ -64,5 +65,41 @@ describe("chunkTextByCharacterCount", () => {
 		expect(chunks.join(" ").replace(/\s+/g, " ").trim()).toBe(
 			text.replace(/\s+/g, " ").trim()
 		);
+	});
+});
+
+describe("truncateContentAtSentenceBoundary", () => {
+	it("returns content as-is when shorter than maxChars", () => {
+		const text = "Short content.";
+		expect(truncateContentAtSentenceBoundary(text, 5000)).toBe(text);
+	});
+
+	it("truncates at sentence boundary when exceeding maxChars", () => {
+		const text = "First sentence. Second sentence. ".repeat(200);
+		expect(text.length).toBeGreaterThan(2000);
+		const result = truncateContentAtSentenceBoundary(text, 1500);
+		expect(result.length).toBeLessThan(text.length);
+		expect(result).toContain("First sentence.");
+		expect(result).toContain("[Content truncated for context limit");
+	});
+
+	it("respects minimum truncation chars of 2000", () => {
+		const text = "a".repeat(5000);
+		const result = truncateContentAtSentenceBoundary(text, 1000);
+		expect(result.length).toBeGreaterThanOrEqual(2000);
+	});
+
+	it("breaks at last sentence boundary before maxChars", () => {
+		const part1 = "Sentence one. ".repeat(150);
+		const part2 = "Sentence two. ".repeat(150);
+		const text = part1 + part2;
+		const result = truncateContentAtSentenceBoundary(text, 2500);
+		expect(result).toContain("[Content truncated for context limit");
+		// Content before suffix should end at sentence boundary
+		const beforeSuffix = result.replace(
+			/\n\n\[Content truncated for context limit[^\]]*\]$/,
+			""
+		);
+		expect(beforeSuffix.endsWith(".")).toBe(true);
 	});
 });

--- a/tests/services/campaign/entity-staging-service.test.ts
+++ b/tests/services/campaign/entity-staging-service.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ContentExtractionProvider } from "@/services/campaign/content-extraction-provider";
+import { stageEntitiesFromResource } from "@/services/campaign/entity-staging-service";
+
+const CONTEXT_LENGTH_THRESHOLD = 5000;
+
+const mockState = vi.hoisted(() => ({
+	extractCalls: [] as string[],
+	throwContextLength: true,
+	alwaysThrow: false,
+}));
+
+vi.mock("@/dao/dao-factory", () => ({
+	getDAOFactory: vi.fn(),
+}));
+
+vi.mock("@/services/llm/llm-rate-limit-service", () => ({
+	getLLMRateLimitService: vi.fn().mockReturnValue({
+		recordUsage: vi.fn().mockResolvedValue(undefined),
+	}),
+}));
+
+vi.mock("@/lib/notifications", () => ({
+	notifyCampaignMembers: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/services/rag/entity-extraction-service", () => ({
+	EntityExtractionService: vi.fn().mockImplementation(function (this: any) {
+		this.extractEntities = vi
+			.fn()
+			.mockImplementation(async (opts: { content: string }) => {
+				mockState.extractCalls.push(opts.content);
+				const shouldThrow =
+					mockState.alwaysThrow ||
+					(mockState.throwContextLength &&
+						opts.content.length > CONTEXT_LENGTH_THRESHOLD);
+				if (shouldThrow) {
+					throw new Error("maximum context length exceeded");
+				}
+				return [];
+			});
+	}),
+}));
+
+vi.mock("@/services/character-sheet/character-sheet-detection-service", () => ({
+	CharacterSheetDetectionService: vi.fn().mockImplementation(function (
+		this: any
+	) {
+		this.detectCharacterSheet = vi.fn().mockResolvedValue({
+			confidence: 0.1,
+			characterName: null,
+		});
+		this.isConfidentDetection = () => false;
+	}),
+}));
+
+import { getDAOFactory } from "@/dao/dao-factory";
+
+describe("entity-staging-service context-length retry", () => {
+	const mockEnv = { DB: {} } as any;
+	const mockResource = {
+		id: "resource-1",
+		file_key: "campaign/file.pdf",
+		file_name: "file.pdf",
+		campaign_id: "campaign-1",
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockState.extractCalls = [];
+		mockState.throwContextLength = true;
+		mockState.alwaysThrow = false;
+		(getDAOFactory as any).mockReturnValue({
+			entityDAO: {},
+			entityImportanceDAO: {},
+		});
+	});
+
+	it("retries with trimmed content on context-length error and succeeds", async () => {
+		// Content > 5000 chars triggers context-length error; trimmed content (< 5000) succeeds
+		const longContent =
+			"First sentence. ".repeat(400) + "Second part. ".repeat(100);
+		expect(longContent.length).toBeGreaterThan(CONTEXT_LENGTH_THRESHOLD);
+
+		const contentProvider: ContentExtractionProvider = {
+			extractContent: async () => ({
+				success: true,
+				content: longContent,
+				metadata: { isPDF: false },
+			}),
+		};
+
+		const result = await stageEntitiesFromResource({
+			env: mockEnv,
+			username: "user-1",
+			campaignId: "campaign-1",
+			campaignName: "Test Campaign",
+			resource: mockResource,
+			campaignRagBasePath: "/rag",
+			llmApiKey: "test-key",
+			contentExtractionProvider: contentProvider,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.failedChunks ?? []).toHaveLength(0);
+		expect(mockState.extractCalls.length).toBeGreaterThanOrEqual(2);
+		// First call has full content; later calls have trimmed content
+		expect(mockState.extractCalls[0].length).toBe(longContent.length);
+		const lastCall = mockState.extractCalls[mockState.extractCalls.length - 1];
+		expect(lastCall.length).toBeLessThanOrEqual(CONTEXT_LENGTH_THRESHOLD);
+		expect(lastCall).toContain("[Content truncated for context limit");
+	});
+
+	it("retries multiple times and reports failedChunks when context-length persists", async () => {
+		// Always throw context-length regardless of content length
+		mockState.alwaysThrow = true;
+
+		const contentProvider: ContentExtractionProvider = {
+			extractContent: async () => ({
+				success: true,
+				content: "x".repeat(10000),
+				metadata: { isPDF: false },
+			}),
+		};
+
+		const result = await stageEntitiesFromResource({
+			env: mockEnv,
+			username: "user-1",
+			campaignId: "campaign-1",
+			campaignName: "Test Campaign",
+			resource: mockResource,
+			campaignRagBasePath: "/rag",
+			llmApiKey: "test-key",
+			contentExtractionProvider: contentProvider,
+		});
+
+		// Staging completes; with alwaysThrow we get 0 entities
+		expect(result.success).toBe(true);
+		expect(result.entityCount).toBe(0);
+		// Multiple extraction attempts (initial + retries with trimmed content)
+		expect(mockState.extractCalls.length).toBeGreaterThanOrEqual(3);
+		// When all retries fail, failedChunks should be populated (if returned)
+		if (result.failedChunks) {
+			expect(result.failedChunks.length).toBeGreaterThan(0);
+		}
+	});
+});


### PR DESCRIPTION
- Add isContextLengthError() to detect context-length errors from providers
- Add truncateContentAtSentenceBoundary() for content trimming at retry
- Retry context-length errors with trimmed content (~60%) instead of same payload
- Track chunkContentByRetry for context-length retries; keep retry count for proper loop exit
- Include failedChunks in zero-entities result when chunks failed
- Add tests for truncation and context-length retry behavior

Made-with: Cursor