### PR TITLE
feat(planning-context): cache extractEntityNamesWithLLM results per c…

### DIFF
--- a/src/services/rag/planning-context-service.ts
+++ b/src/services/rag/planning-context-service.ts
@@ -67,6 +67,28 @@ export interface IndexedSection {
 export class PlanningContextService extends BaseRAGService {
 	private readonly defaultDecayRate = 0.1;
 
+	private static entityNamesCache = new Map<
+		string,
+		{ names: string[]; expiresAt: number }
+	>();
+	private readonly entityNamesCacheTTL = 5 * 60 * 1000; // 5 minutes
+
+	private buildEntityNamesCacheKey(campaignId: string, query: string): string {
+		const normalized = query.trim().toLowerCase().replace(/\s+/g, " ");
+		const queryHash = this.simpleHash(normalized);
+		return `entity-names:${campaignId}:${queryHash}`;
+	}
+
+	private simpleHash(str: string): string {
+		let hash = 0;
+		for (let i = 0; i < str.length; i++) {
+			const char = str.charCodeAt(i);
+			hash = (hash << 5) - hash + char;
+			hash = hash & hash;
+		}
+		return Math.abs(hash).toString(36);
+	}
+
 	/**
 	 * Extract indexable sections from a session digest
 	 */
@@ -343,8 +365,21 @@ export class PlanningContextService extends BaseRAGService {
 	/**
 	 * Use LLM to intelligently extract entity names from query
 	 * More reliable than manual parsing - understands context and intent
+	 * Results are cached per (campaignId, query) with 5-minute TTL.
 	 */
-	private async extractEntityNamesWithLLM(query: string): Promise<string[]> {
+	private async extractEntityNamesWithLLM(
+		campaignId: string,
+		query: string
+	): Promise<string[]> {
+		const cacheKey = this.buildEntityNamesCacheKey(campaignId, query);
+		const cached = PlanningContextService.entityNamesCache.get(cacheKey);
+		if (cached && cached.expiresAt > Date.now()) {
+			return cached.names;
+		}
+		if (cached && cached.expiresAt <= Date.now()) {
+			PlanningContextService.entityNamesCache.delete(cacheKey);
+		}
+
 		try {
 			const apiKey =
 				typeof this.openaiApiKey === "string" ? this.openaiApiKey : "";
@@ -401,6 +436,10 @@ export class PlanningContextService extends BaseRAGService {
 				);
 			}
 
+			PlanningContextService.entityNamesCache.set(cacheKey, {
+				names: entityNames,
+				expiresAt: Date.now() + this.entityNamesCacheTTL,
+			});
 			return entityNames;
 		} catch (error) {
 			console.warn(
@@ -497,7 +536,10 @@ export class PlanningContextService extends BaseRAGService {
 			// Method 2: LLM-based entity name extraction (if semantic search didn't find enough)
 			// Use intelligent LLM extraction instead of manual parsing
 			if (foundEntities.size < maxEntities) {
-				const llmExtractedNames = await this.extractEntityNamesWithLLM(query);
+				const llmExtractedNames = await this.extractEntityNamesWithLLM(
+					campaignId,
+					query
+				);
 
 				if (llmExtractedNames.length > 0) {
 					console.log(

--- a/tests/services/planning-context-service.test.ts
+++ b/tests/services/planning-context-service.test.ts
@@ -1,11 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDAOFactory } from "@/dao/dao-factory";
+import { createLLMProvider } from "@/services/llm/llm-provider-factory";
 import { PlanningContextService } from "@/services/rag/planning-context-service";
 import type { SessionDigestWithData } from "@/types/session-digest";
 
 vi.mock("@/dao/dao-factory", () => ({
 	getDAOFactory: vi.fn(),
 }));
+
+vi.mock("@/services/llm/llm-provider-factory", () => ({
+	createLLMProvider: vi.fn(),
+}));
+
+function clearEntityNamesCache(): void {
+	(PlanningContextService as any).entityNamesCache?.clear();
+}
 
 describe("PlanningContextService", () => {
 	let service: PlanningContextService;
@@ -494,6 +503,69 @@ describe("PlanningContextService", () => {
 			await service.indexChangelogEntry(emptyChangelogEntry);
 
 			expect(mockVectorize.upsert).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("extractEntityNamesWithLLM cache", () => {
+		const mockGenerateStructuredOutput = vi.fn();
+
+		beforeEach(() => {
+			clearEntityNamesCache();
+			mockGenerateStructuredOutput.mockResolvedValue({
+				entityNames: ["Gandalf", "Frodo"],
+			});
+			vi.mocked(createLLMProvider).mockReturnValue({
+				generateStructuredOutput: mockGenerateStructuredOutput,
+			} as any);
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("returns cached result for same (campaignId, query) without calling LLM again", async () => {
+			const extract = (service as any).extractEntityNamesWithLLM.bind(service);
+
+			const result1 = await extract("campaign-1", "What about Gandalf?");
+			const result2 = await extract("campaign-1", "What about Gandalf?");
+
+			expect(result1).toEqual(["Gandalf", "Frodo"]);
+			expect(result2).toEqual(["Gandalf", "Frodo"]);
+			expect(mockGenerateStructuredOutput).toHaveBeenCalledTimes(1);
+		});
+
+		it("calls LLM again for different campaignId", async () => {
+			const extract = (service as any).extractEntityNamesWithLLM.bind(service);
+
+			await extract("campaign-1", "What about Gandalf?");
+			await extract("campaign-2", "What about Gandalf?");
+
+			expect(mockGenerateStructuredOutput).toHaveBeenCalledTimes(2);
+		});
+
+		it("calls LLM again for different query", async () => {
+			const extract = (service as any).extractEntityNamesWithLLM.bind(service);
+
+			await extract("campaign-1", "What about Gandalf?");
+			await extract("campaign-1", "Tell me about the dragon");
+
+			expect(mockGenerateStructuredOutput).toHaveBeenCalledTimes(2);
+		});
+
+		it("does not return expired entries (cache miss after TTL)", async () => {
+			vi.useFakeTimers();
+			const extract = (service as any).extractEntityNamesWithLLM.bind(service);
+
+			const result1 = await extract("campaign-1", "What about Gandalf?");
+			expect(result1).toEqual(["Gandalf", "Frodo"]);
+			expect(mockGenerateStructuredOutput).toHaveBeenCalledTimes(1);
+
+			// Advance time past 5-minute TTL
+			vi.advanceTimersByTime(6 * 60 * 1000);
+
+			const result2 = await extract("campaign-1", "What about Gandalf?");
+			expect(result2).toEqual(["Gandalf", "Frodo"]);
+			expect(mockGenerateStructuredOutput).toHaveBeenCalledTimes(2);
 		});
 	});
 });


### PR DESCRIPTION
…ampaign/query (#535)

- Add static in-memory cache keyed by (campaignId, query) with 5-min TTL
- Normalize query before hashing for better hit rate
- Lazy eviction of expired entries on read
- Add tests: cache hit, cache miss (different campaign/query), TTL expiry

Made-with: Cursor