### PR TITLE
Add PIPELINE_LIGHT tier for low-complexity structured extraction (#534)

### DIFF
--- a/src/app-constants.ts
+++ b/src/app-constants.ts
@@ -235,6 +235,8 @@ export const MODEL_CONFIG = {
 		ANALYSIS: "gpt-5-mini",
 		// Model for non-interactive structured/background pipeline steps
 		PIPELINE_STRUCTURED: "gpt-5-mini",
+		// Lighter model for low-complexity structured extraction (entity extraction, summaries, metadata)
+		PIPELINE_LIGHT: "gpt-4o-mini",
 		// Model for non-interactive analysis/evaluation pipeline steps
 		PIPELINE_ANALYSIS: "gpt-5-mini",
 		// Model for metadata analysis (checklist coverage, campaign readiness)
@@ -250,6 +252,7 @@ export const MODEL_CONFIG = {
 		INTERACTIVE: "claude-sonnet-4-6",
 		ANALYSIS: "claude-sonnet-4-6",
 		PIPELINE_STRUCTURED: "claude-sonnet-4-6",
+		PIPELINE_LIGHT: "claude-haiku-4-5",
 		PIPELINE_ANALYSIS: "claude-sonnet-4-6",
 		METADATA_ANALYSIS: "claude-sonnet-4-6",
 		SESSION_PLANNING: "claude-sonnet-4-6",
@@ -293,6 +296,7 @@ export type TextGenerationTier =
 	| "INTERACTIVE"
 	| "ANALYSIS"
 	| "PIPELINE_STRUCTURED"
+	| "PIPELINE_LIGHT"
 	| "PIPELINE_ANALYSIS"
 	| "METADATA_ANALYSIS"
 	| "SESSION_PLANNING";

--- a/src/services/graph/community-summary-service.ts
+++ b/src/services/graph/community-summary-service.ts
@@ -14,7 +14,7 @@ import { createLLMProvider } from "@/services/llm/llm-provider-factory";
  */
 const SUMMARY_CONFIG = {
 	// LLM Configuration
-	DEFAULT_MODEL: getGenerationModelForProvider("PIPELINE_STRUCTURED"),
+	DEFAULT_MODEL: getGenerationModelForProvider("PIPELINE_LIGHT"),
 	DEFAULT_TEMPERATURE: 0.3,
 	DEFAULT_MAX_TOKENS: 2000,
 	LLM_PROVIDER: MODEL_CONFIG.PROVIDER.DEFAULT,

--- a/src/services/rag/entity-extraction-service.ts
+++ b/src/services/rag/entity-extraction-service.ts
@@ -305,7 +305,7 @@ CONTENT END`;
 				provider: MODEL_CONFIG.PROVIDER.DEFAULT,
 				apiKey,
 				// Use non-interactive structured pipeline tier for extraction
-				defaultModel: getGenerationModelForProvider("PIPELINE_STRUCTURED"),
+				defaultModel: getGenerationModelForProvider("PIPELINE_LIGHT"),
 				defaultTemperature: 0.1,
 				defaultMaxTokens: MAX_EXTRACTION_RESPONSE_TOKENS,
 			});
@@ -314,7 +314,7 @@ CONTENT END`;
 			const result = await llmProvider.generateStructuredOutput<
 				z.infer<typeof EntityExtractionSchema>
 			>(prompt, {
-				model: getGenerationModelForProvider("PIPELINE_STRUCTURED"),
+				model: getGenerationModelForProvider("PIPELINE_LIGHT"),
 				temperature: 0.1,
 				maxTokens: MAX_EXTRACTION_RESPONSE_TOKENS,
 				username: usageOptions?.username,

--- a/src/tools/campaign-context/suggestion-tools.ts
+++ b/src/tools/campaign-context/suggestion-tools.ts
@@ -663,7 +663,7 @@ async function analyzeMetadataCoverage(
 		const llmProvider = createLLMProvider({
 			provider: MODEL_CONFIG.PROVIDER.DEFAULT,
 			apiKey: providerApiKey,
-			defaultModel: getGenerationModelForProvider("METADATA_ANALYSIS"),
+			defaultModel: getGenerationModelForProvider("PIPELINE_LIGHT"),
 			defaultTemperature: MODEL_CONFIG.PARAMETERS.METADATA_ANALYSIS_TEMPERATURE,
 			defaultMaxTokens: MODEL_CONFIG.PARAMETERS.METADATA_ANALYSIS_MAX_TOKENS,
 		});
@@ -671,7 +671,7 @@ async function analyzeMetadataCoverage(
 		const result = await llmProvider.generateStructuredOutput<
 			z.infer<typeof coverageSchema>
 		>(prompt, {
-			model: getGenerationModelForProvider("METADATA_ANALYSIS"),
+			model: getGenerationModelForProvider("PIPELINE_LIGHT"),
 			temperature: MODEL_CONFIG.PARAMETERS.METADATA_ANALYSIS_TEMPERATURE,
 			maxTokens: MODEL_CONFIG.PARAMETERS.METADATA_ANALYSIS_MAX_TOKENS,
 		});


### PR DESCRIPTION
- Add PIPELINE_LIGHT tier with gpt-4o-mini (OpenAI) and claude-haiku-4-5 (Anthropic)
- Migrate entity extraction, community summaries, and metadata analysis to use it
- Reduces cost on pipeline tasks where frontier models are not required

Made-with: Cursor