### PR TITLE
Batch Cloudflare AI calls in library content/metadata services (#532)

### DIFF
--- a/src/services/file/library-content-search-service.ts
+++ b/src/services/file/library-content-search-service.ts
@@ -3,6 +3,9 @@ import type { Env } from "@/middleware/auth";
 
 const LLM_MODEL = "@cf/meta/llama-3.1-8b-instruct";
 
+/** Max concurrent AI requests to stay within Cloudflare Workers AI limits */
+const AI_CONCURRENCY_LIMIT = 8;
+
 const CONTENT_TYPES = [
 	"monsters",
 	"npcs",
@@ -60,81 +63,93 @@ export class LibraryContentSearchService {
 
 			const allResults: any[] = [];
 
-			// Query each content type individually to avoid truncation
-			for (const contentType of CONTENT_TYPES) {
-				try {
-					console.log(
-						`[LibraryContentSearchService] Querying for ${contentType}...`
-					);
-
-					const typeSpecificPrompt =
-						RPG_EXTRACTION_PROMPTS.getTypeSpecificExtractionPrompt(contentType);
-
-					const aiResponse = await this.env.AI.run(LLM_MODEL, {
-						messages: [
-							{
-								role: "system",
-								content: typeSpecificPrompt,
-							},
-							{
-								role: "user",
-								content: query,
-							},
-						],
-						max_tokens: 2000,
-						temperature: 0.1,
-					});
-
-					// Parse the AI response for this content type
-					const responseText = aiResponse.response as string;
-					console.log(
-						`[LibraryContentSearchService] ${contentType} response: ${responseText.substring(0, 200)}...`
-					);
-
-					// Clean up the response - remove markdown formatting if present
-					const cleanResponse = this.cleanJsonResponse(responseText);
-
+			// Query content types with bounded concurrency to avoid Cloudflare AI limits
+			const settled: PromiseSettledResult<{
+				contentType: (typeof CONTENT_TYPES)[number];
+				aiResponse: unknown;
+			}>[] = new Array(CONTENT_TYPES.length);
+			let nextIndex = 0;
+			const numWorkers = Math.min(AI_CONCURRENCY_LIMIT, CONTENT_TYPES.length);
+			const workers = Array.from({ length: numWorkers }, async () => {
+				while (true) {
+					const i = nextIndex++;
+					if (i >= CONTENT_TYPES.length) return;
+					const contentType = CONTENT_TYPES[i];
 					try {
-						const parsedContent = JSON.parse(cleanResponse);
-						if (
-							parsedContent[contentType] &&
-							Array.isArray(parsedContent[contentType])
-						) {
-							// Convert to search result format
-							parsedContent[contentType].forEach((item: any, index: number) => {
-								if (item && typeof item === "object") {
-									allResults.push({
-										id: item.id || `${contentType}_${index}_${Date.now()}`,
-										score: 0.9 - index * 0.01,
-										metadata: {
-											entityType: contentType,
-											...item,
-										},
-										text:
-											item.summary ||
-											item.description ||
-											item.name ||
-											JSON.stringify(item),
-									});
-								}
-							});
-							console.log(
-								`[LibraryContentSearchService] Extracted ${parsedContent[contentType].length} ${contentType}`
+						const typeSpecificPrompt =
+							RPG_EXTRACTION_PROMPTS.getTypeSpecificExtractionPrompt(
+								contentType
 							);
-						}
-					} catch (parseError) {
-						console.warn(
-							`[LibraryContentSearchService] Failed to parse ${contentType} response:`,
-							parseError
-						);
-						// Continue with other content types
+						const aiResponse = await this.env.AI!.run(LLM_MODEL, {
+							messages: [
+								{ role: "system", content: typeSpecificPrompt },
+								{ role: "user", content: query },
+							],
+							max_tokens: 2000,
+							temperature: 0.1,
+						});
+						settled[i] = {
+							status: "fulfilled",
+							value: { contentType, aiResponse },
+						};
+					} catch (error) {
+						settled[i] = { status: "rejected", reason: error };
 					}
-				} catch (typeError) {
+				}
+			});
+			await Promise.all(workers);
+
+			for (let i = 0; i < settled.length; i++) {
+				const result = settled[i];
+				const contentType = CONTENT_TYPES[i];
+				if (result.status === "rejected") {
 					console.warn(
 						`[LibraryContentSearchService] Error querying ${contentType}:`,
-						typeError
+						result.reason
 					);
-					// Continue with other content types
+					continue;
+				}
+				const { aiResponse } = result.value;
+
+				const responseText = (aiResponse as any).response as string;
+				console.log(
+					`[LibraryContentSearchService] ${contentType} response: ${responseText.substring(0, 200)}...`
+				);
+
+				const cleanResponse = this.cleanJsonResponse(responseText);
+
+				try {
+					const parsedContent = JSON.parse(cleanResponse);
+					if (
+						parsedContent[contentType] &&
+						Array.isArray(parsedContent[contentType])
+					) {
+						parsedContent[contentType].forEach((item: any, index: number) => {
+							if (item && typeof item === "object") {
+								allResults.push({
+									id: item.id || `${contentType}_${index}_${Date.now()}`,
+									score: 0.9 - index * 0.01,
+									metadata: {
+										entityType: contentType,
+										...item,
+									},
+									text:
+										item.summary ||
+										item.description ||
+										item.name ||
+										JSON.stringify(item),
+								});
+							}
+						});
+						console.log(
+							`[LibraryContentSearchService] Extracted ${parsedContent[contentType].length} ${contentType}`
+						);
+					}
+				} catch (parseError) {
+					console.warn(
+						`[LibraryContentSearchService] Failed to parse ${contentType} response:`,
+						parseError
+					);
 				}
 			}
 

--- a/src/services/file/library-metadata-service.ts
+++ b/src/services/file/library-metadata-service.ts
@@ -12,7 +12,6 @@ const TPM_LIMIT = 30000;
 const MAX_CONTENT_TOKENS =
 	TPM_LIMIT - PROMPT_TOKENS_ESTIMATE - MAX_RESPONSE_TOKENS;
 const MAX_CHUNK_SIZE = Math.floor(MAX_CONTENT_TOKENS * CHARS_PER_TOKEN); // ~42k characters
-const CHUNK_PROCESSING_DELAY_MS = 2000;
 
 export interface SemanticMetadataResult {
 	displayName: string;
@@ -65,15 +64,13 @@ export class LibraryMetadataService {
 				`[LibraryMetadataService] Processing ${chunks.length} chunk(s) for metadata generation (max chunk size: ${MAX_CHUNK_SIZE} chars)`
 			);
 
-			// Process chunks and merge results
+			// Process all chunks in parallel
 			const allTags: Set<string> = new Set();
 			const allDescriptions: string[] = [];
 			const allDisplayNames: string[] = [];
 
-			for (let i = 0; i < chunks.length; i++) {
-				const chunk = chunks[i];
+			const promises = chunks.map((chunk, i) => {
 				const chunkPreview = chunk.substring(0, Math.min(1000, chunk.length));
-
 				const semanticPrompt = getSemanticMetadataPrompt(
 					fileName,
 					fileKey,
@@ -83,55 +80,48 @@ export class LibraryMetadataService {
 					chunks.length,
 					i
 				);
-
-				try {
-					if (i > 0) {
-						await new Promise((resolve) =>
-							setTimeout(resolve, CHUNK_PROCESSING_DELAY_MS)
-						);
-					}
-
-					console.log(
-						`[LibraryMetadataService] Processing chunk ${i + 1}/${chunks.length} for metadata generation`
-					);
-
-					const response = await this.env.AI.run(LLM_MODEL, {
-						messages: [
-							{
-								role: "user",
-								content: semanticPrompt,
-							},
-						],
+				console.log(
+					`[LibraryMetadataService] Processing chunk ${i + 1}/${chunks.length} for metadata generation`
+				);
+				return this.env
+					.AI!.run(LLM_MODEL, {
+						messages: [{ role: "user", content: semanticPrompt }],
 						max_tokens: MAX_RESPONSE_TOKENS,
-					});
+					})
+					.then((response) => ({ response }));
+			});
 
-					const responseText = this.extractResponseText(response);
+			const settled = await Promise.allSettled(promises);
 
-					// Try to extract JSON from the response
-					const jsonMatch = responseText.match(/\{[\s\S]*\}/);
-					if (jsonMatch) {
-						try {
-							const parsed = JSON.parse(jsonMatch[0]);
-							if (parsed.displayName) allDisplayNames.push(parsed.displayName);
-							if (parsed.description) allDescriptions.push(parsed.description);
-							if (Array.isArray(parsed.tags)) {
-								for (const tag of parsed.tags) {
-									allTags.add(tag);
-								}
-							}
-						} catch (parseError) {
-							console.warn(
-								`[LibraryMetadataService] Failed to parse JSON from chunk ${i + 1}:`,
-								parseError
-							);
-						}
-					}
-				} catch (error) {
+			for (let i = 0; i < settled.length; i++) {
+				const result = settled[i];
+				if (result.status === "rejected") {
 					console.error(
 						`[LibraryMetadataService] Error processing chunk ${i + 1}:`,
-						error
+						result.reason
 					);
-					// Continue with other chunks even if one fails
+					continue;
+				}
+				const { response } = result.value;
+				const responseText = this.extractResponseText(response);
+
+				const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+				if (jsonMatch) {
+					try {
+						const parsed = JSON.parse(jsonMatch[0]);
+						if (parsed.displayName) allDisplayNames.push(parsed.displayName);
+						if (parsed.description) allDescriptions.push(parsed.description);
+						if (Array.isArray(parsed.tags)) {
+							for (const tag of parsed.tags) {
+								allTags.add(tag);
+							}
+						}
+					} catch (parseError) {
+						console.warn(
+							`[LibraryMetadataService] Failed to parse JSON from chunk ${i + 1}:`,
+							parseError
+						);
+					}
 				}
 			}
 

--- a/tests/services/library-content-search-service.test.ts
+++ b/tests/services/library-content-search-service.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LibraryContentSearchService } from "@/services/file/library-content-search-service";
+
+const mockAI = {
+	run: vi.fn(),
+};
+
+const mockEnv = {
+	AI: mockAI,
+} as any;
+
+describe("LibraryContentSearchService", () => {
+	let service: LibraryContentSearchService;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		service = new LibraryContentSearchService(mockEnv);
+	});
+
+	describe("searchContent", () => {
+		it("should call AI.run in parallel for all content types", async () => {
+			mockAI.run.mockResolvedValue({
+				response: JSON.stringify({ monsters: [] }),
+			});
+
+			await service.searchContent("goblin");
+
+			// CONTENT_TYPES has 30 types - all should be invoked in parallel
+			expect(mockAI.run).toHaveBeenCalledTimes(30);
+			// All calls should use the same model
+			expect(mockAI.run).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					messages: expect.any(Array),
+					max_tokens: 2000,
+					temperature: 0.1,
+				})
+			);
+		});
+
+		it("should merge results from multiple content types", async () => {
+			mockAI.run
+				.mockResolvedValueOnce({
+					response: JSON.stringify({
+						monsters: [
+							{
+								id: "goblin-1",
+								type: "monster",
+								name: "Goblin",
+								summary: "A small creature",
+								tags: ["small"],
+								source: { doc: "mm" },
+							},
+						],
+					}),
+				})
+				.mockResolvedValue({ response: "{}" });
+
+			const results = await service.searchContent("goblin");
+
+			expect(results.length).toBeGreaterThanOrEqual(1);
+			expect(results[0]).toMatchObject({
+				id: "goblin-1",
+				metadata: expect.objectContaining({
+					entityType: "monsters",
+					name: "Goblin",
+					summary: "A small creature",
+				}),
+				text: "A small creature",
+			});
+		});
+
+		it("should continue when some content type calls fail", async () => {
+			mockAI.run
+				.mockRejectedValueOnce(new Error("AI error"))
+				.mockResolvedValueOnce({
+					response: JSON.stringify({
+						npcs: [
+							{
+								id: "fireball",
+								type: "spell",
+								name: "Fireball",
+								summary: "Explosive spell",
+								tags: ["evocation"],
+								source: { doc: "phb" },
+							},
+						],
+					}),
+				})
+				.mockResolvedValue({ response: "{}" });
+
+			const results = await service.searchContent("fireball");
+
+			expect(results.length).toBeGreaterThanOrEqual(1);
+			expect(results[0].metadata).toMatchObject({
+				entityType: "npcs",
+				name: "Fireball",
+			});
+		});
+
+		it("should return empty array when AI binding is not available", async () => {
+			const envWithoutAI = { AI: undefined } as any;
+			const serviceWithoutAI = new LibraryContentSearchService(envWithoutAI);
+
+			const results = await serviceWithoutAI.searchContent("query");
+
+			expect(results).toEqual([]);
+			expect(mockAI.run).not.toHaveBeenCalled();
+		});
+
+		it("should handle malformed JSON in AI response", async () => {
+			mockAI.run.mockResolvedValue({
+				response: "not valid json {",
+			});
+
+			const results = await service.searchContent("query");
+
+			expect(results).toEqual([]);
+		});
+	});
+});

--- a/tests/services/library-metadata-service.test.ts
+++ b/tests/services/library-metadata-service.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LibraryMetadataService } from "@/services/file/library-metadata-service";
+
+const mockAI = {
+	run: vi.fn(),
+};
+
+const mockEnv = {
+	AI: mockAI,
+} as any;
+
+describe("LibraryMetadataService", () => {
+	let service: LibraryMetadataService;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		service = new LibraryMetadataService(mockEnv);
+	});
+
+	describe("generateSemanticMetadata", () => {
+		it("should call AI.run in parallel for all chunks", async () => {
+			mockAI.run.mockResolvedValue({
+				response: JSON.stringify({
+					displayName: "Test Document",
+					description: "A test document",
+					tags: ["test", "document"],
+				}),
+			});
+
+			const result = await service.generateSemanticMetadata(
+				"test.pdf",
+				"uploads/test.pdf",
+				"user-123",
+				"Short content"
+			);
+
+			expect(mockAI.run).toHaveBeenCalledTimes(1);
+			expect(result).toEqual({
+				displayName: "Test Document",
+				description: "A test document",
+				tags: ["test", "document"],
+			});
+		});
+
+		it("should process multiple chunks in parallel", async () => {
+			// Content larger than MAX_CHUNK_SIZE (~42k chars) triggers chunking
+			const largeContent = "x".repeat(50000);
+			mockAI.run
+				.mockResolvedValueOnce({
+					response: JSON.stringify({
+						displayName: "Chunk 1 Name",
+						description: "First chunk description",
+						tags: ["chunk1"],
+					}),
+				})
+				.mockResolvedValueOnce({
+					response: JSON.stringify({
+						displayName: "Chunk 2 Name",
+						description: "Second chunk description",
+						tags: ["chunk2"],
+					}),
+				});
+
+			const result = await service.generateSemanticMetadata(
+				"large.pdf",
+				"uploads/large.pdf",
+				"user-123",
+				largeContent
+			);
+
+			// Should have 2 chunks
+			expect(mockAI.run).toHaveBeenCalledTimes(2);
+			// Merge: displayName from first, descriptions joined, tags combined
+			expect(result?.displayName).toBe("Chunk 1 Name");
+			expect(result?.description).toContain("First chunk");
+			expect(result?.description).toContain("Second chunk");
+			expect(result?.tags).toContain("chunk1");
+			expect(result?.tags).toContain("chunk2");
+		});
+
+		it("should continue when some chunk calls fail", async () => {
+			const largeContent = "x".repeat(50000);
+			mockAI.run
+				.mockRejectedValueOnce(new Error("AI error"))
+				.mockResolvedValueOnce({
+					response: JSON.stringify({
+						displayName: "Surviving Chunk",
+						description: "From successful chunk",
+						tags: ["ok"],
+					}),
+				});
+
+			const result = await service.generateSemanticMetadata(
+				"large.pdf",
+				"uploads/large.pdf",
+				"user-123",
+				largeContent
+			);
+
+			expect(result).toEqual({
+				displayName: "Surviving Chunk",
+				description: "From successful chunk",
+				tags: ["ok"],
+			});
+		});
+
+		it("should return undefined when AI binding is not available", async () => {
+			const envWithoutAI = { AI: undefined } as any;
+			const serviceWithoutAI = new LibraryMetadataService(envWithoutAI);
+
+			const result = await serviceWithoutAI.generateSemanticMetadata(
+				"test.pdf",
+				"uploads/test.pdf",
+				"user-123",
+				"content"
+			);
+
+			expect(result).toBeUndefined();
+			expect(mockAI.run).not.toHaveBeenCalled();
+		});
+
+		it("should use filename as display name when no content", async () => {
+			mockAI.run.mockResolvedValue({
+				response: JSON.stringify({
+					displayName: "From AI",
+					description: "Filename analysis",
+					tags: ["empty"],
+				}),
+			});
+
+			const result = await service.generateSemanticMetadata(
+				"my-document.pdf",
+				"uploads/my-document.pdf",
+				"user-123",
+				""
+			);
+
+			expect(result?.displayName).toBe("From AI");
+		});
+	});
+});


### PR DESCRIPTION
- Replace sequential env.AI.run loops with bounded parallel execution
- library-content-search-service: worker pool with 8 concurrent AI requests
- library-metadata-service: Promise.allSettled over chunks, remove 2s delay
- Add unit tests for both services

Made-with: Cursor