### PR TITLE
Parallelize search and batch community lookups in getSessionReadoutCo…

### DIFF
--- a/src/tools/campaign-context/recap-tools.ts
+++ b/src/tools/campaign-context/recap-tools.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { MODEL_CONFIG, type ToolResult } from "@/app-constants";
+import type { Community } from "@/dao/community-dao";
 import { getDAOFactory } from "@/dao/dao-factory";
 import type { PlanningTaskStatus } from "@/dao/planning-task-dao";
 import { getEnvVar } from "@/lib/env-utils";
@@ -259,6 +260,42 @@ function extractTargetSessionFromTitle(title: string): number | null {
 }
 
 /**
+ * Batch load communities for multiple entities. Returns a map from entityId to
+ * communities containing that entity. More efficient than per-entity lookups.
+ */
+async function batchLoadCommunitiesByEntity(
+	campaignId: string,
+	entityIds: string[],
+	communityDAO: {
+		findCommunitiesContainingEntities: (
+			cid: string,
+			eids: string[]
+		) => Promise<Community[]>;
+	}
+): Promise<Map<string, Community[]>> {
+	if (entityIds.length === 0) {
+		return new Map();
+	}
+	const uniqueIds = [...new Set(entityIds)];
+	const communities = await communityDAO.findCommunitiesContainingEntities(
+		campaignId,
+		uniqueIds
+	);
+	const entityIdsSet = new Set(uniqueIds);
+	const result = new Map<string, Community[]>();
+	for (const c of communities) {
+		for (const eid of c.entityIds) {
+			if (entityIdsSet.has(eid)) {
+				const list = result.get(eid) ?? [];
+				list.push(c);
+				result.set(eid, list);
+			}
+		}
+	}
+	return result;
+}
+
+/**
  * Strip graph-RAG metadata (relationship headers, MEMBER_OF lines, etc.) from
  * entity text so the readout contains only narrative/content for the DM.
  */
@@ -374,7 +411,27 @@ export const getSessionReadoutContext = tool({
 				);
 			}
 
-			const steps: Array<{
+			const opts = {
+				env,
+				toolCallId: `${toolCallId}-step`,
+			} as ToolExecuteOptions;
+
+			const baseSearchArgs = {
+				campaignId,
+				jwt,
+				searchOriginalFiles: false,
+				includeTraversedEntities: true,
+				offset: 0,
+				limit: 50,
+				forSessionReadout: true,
+			};
+
+			async function processTaskForReadout(task: {
+				id: string;
+				title: string;
+				completionNotes: string | null;
+				createdAt: string;
+			}): Promise<{
 				task: {
 					id: string;
 					title: string;
@@ -384,14 +441,8 @@ export const getSessionReadoutContext = tool({
 				instruction: string;
 				readoutBlock: string;
 				entityResults: Array<{ entityId: string; title: string; text: string }>;
-			}> = [];
-
-			const opts = {
-				env,
-				toolCallId: `${toolCallId}-step`,
-			} as ToolExecuteOptions;
-
-			for (const task of completedTasks) {
+				entityIds: string[];
+			}> {
 				const notesSlice = (task.completionNotes ?? "").slice(0, 400).trim();
 				const queryFromTask = [task.title, notesSlice]
 					.filter(Boolean)
@@ -399,20 +450,8 @@ export const getSessionReadoutContext = tool({
 					.trim();
 				const searchQuery = queryFromTask || task.title;
 
-				const searchArgs = {
-					campaignId,
-					jwt,
-					searchOriginalFiles: false,
-					includeTraversedEntities: true,
-					offset: 0,
-					limit: 50,
-					forSessionReadout: true,
-				};
-
-				const searchRes = (await searchCampaignContext.execute?.(
-					{ ...searchArgs, query: searchQuery },
-					opts
-				)) as
+				// Run initial search and notes-only search in parallel when both apply
+				type SearchRes =
 					| {
 							result: {
 								success: boolean;
@@ -420,28 +459,29 @@ export const getSessionReadoutContext = tool({
 							};
 					  }
 					| undefined;
+				const [searchRes, notesOnlyRes] = (await Promise.all([
+					searchCampaignContext.execute?.(
+						{ ...baseSearchArgs, query: searchQuery },
+						opts
+					),
+					notesSlice && notesSlice.length > 80
+						? searchCampaignContext.execute?.(
+								{ ...baseSearchArgs, query: notesSlice },
+								opts
+							)
+						: Promise.resolve(undefined),
+				])) as [SearchRes, SearchRes];
 
 				const initialResults: SearchResultItem[] =
 					searchRes?.result?.success && searchRes?.result?.data?.results
 						? searchRes.result.data.results
 						: [];
 
-				if (notesSlice && notesSlice.length > 80) {
-					const notesOnlyRes = (await searchCampaignContext.execute?.(
-						{ ...searchArgs, query: notesSlice },
-						opts
-					)) as
-						| {
-								result: {
-									success: boolean;
-									data?: { results?: SearchResultItem[] };
-								};
-						  }
-						| undefined;
-					const notesResults =
-						notesOnlyRes?.result?.success && notesOnlyRes?.result?.data?.results
-							? notesOnlyRes.result.data.results
-							: [];
+				if (
+					notesOnlyRes?.result?.success &&
+					notesOnlyRes?.result?.data?.results
+				) {
+					const notesResults = notesOnlyRes.result.data.results;
 					const seenIds = new Set(
 						initialResults.map((r) => r.entityId).filter(Boolean)
 					);
@@ -461,16 +501,10 @@ export const getSessionReadoutContext = tool({
 				if (entityIds.length > 0) {
 					const traverseRes = (await searchCampaignContext.execute?.(
 						{
-							campaignId,
-							jwt,
+							...baseSearchArgs,
 							query: task.title,
-							searchOriginalFiles: false,
 							traverseFromEntityIds: entityIds,
 							traverseDepth: 2,
-							includeTraversedEntities: true,
-							offset: 0,
-							limit: 50,
-							forSessionReadout: true,
 						},
 						opts
 					)) as
@@ -516,55 +550,13 @@ export const getSessionReadoutContext = tool({
 								: v.text,
 					}));
 
-				// Debug logging: which entities and communities are feeding this step's readout.
-				// This helps inspect which data points are actually being used when
-				// constructing the session plan.
-				const communitiesByEntity: Record<
-					string,
-					{ id: string; level: number; entityCount: number }[]
-				> = {};
-
-				for (const entity of entityResults) {
-					try {
-						const communities =
-							await communityDAO.findCommunitiesContainingEntity(
-								campaignId,
-								entity.entityId
-							);
-						if (communities.length > 0) {
-							communitiesByEntity[entity.entityId] = communities.map((c) => ({
-								id: c.id,
-								level: c.level,
-								entityCount: c.entityIds.length,
-							}));
-						}
-					} catch (communityError) {
-						console.warn(
-							"[getSessionReadoutContext] Failed to load communities for entity",
-							entity.entityId,
-							communityError
-						);
-					}
-				}
-
-				console.log("[getSessionReadoutContext] Step context summary", {
-					campaignId,
-					taskId: task.id,
-					taskTitle: task.title,
-					entityResults: entityResults.map((e) => ({
-						entityId: e.entityId,
-						title: e.title,
-					})),
-					communitiesByEntity,
-				});
-
 				const readoutBlock = [
 					`## ${task.title}`,
 					"",
 					...entityResults.flatMap((e) => [`### ${e.title}`, "", e.text, ""]),
 				].join("\n");
 
-				steps.push({
+				return {
 					task: {
 						id: task.id,
 						title: task.title,
@@ -575,8 +567,57 @@ export const getSessionReadoutContext = tool({
 						"Transform the readoutBlock below into part of a session plan for the DM. Use the full entity content (Background, Character Traits, Emotional Stakes, NPC Reactions, mechanics, etc.) but present it as a scene or encounter in the plan: Description, Helpful DM Info, Dialogue, player options. Do not expose graph structure or relationship metadata. Output should read like a session script outline the DM can run at the table—not a raw dump of entity data. Include all substantive detail from the readoutBlock.",
 					readoutBlock,
 					entityResults,
-				});
+					entityIds: entityResults.map((e) => e.entityId),
+				};
 			}
+
+			const taskResults = await Promise.all(
+				completedTasks.map((task) => processTaskForReadout(task))
+			);
+
+			const allEntityIds = [
+				...new Set(taskResults.flatMap((r) => r.entityIds)),
+			];
+			const communitiesByEntityId = await batchLoadCommunitiesByEntity(
+				campaignId,
+				allEntityIds,
+				communityDAO
+			);
+
+			const steps = taskResults.map((tr) => {
+				const communitiesByEntity: Record<
+					string,
+					{ id: string; level: number; entityCount: number }[]
+				> = {};
+				for (const entity of tr.entityResults) {
+					const communities = communitiesByEntityId.get(entity.entityId) ?? [];
+					if (communities.length > 0) {
+						communitiesByEntity[entity.entityId] = communities.map((c) => ({
+							id: c.id,
+							level: c.level,
+							entityCount: c.entityIds.length,
+						}));
+					}
+				}
+
+				console.log("[getSessionReadoutContext] Step context summary", {
+					campaignId,
+					taskId: tr.task.id,
+					taskTitle: tr.task.title,
+					entityResults: tr.entityResults.map((e) => ({
+						entityId: e.entityId,
+						title: e.title,
+					})),
+					communitiesByEntity,
+				});
+
+				return {
+					task: tr.task,
+					instruction: tr.instruction,
+					readoutBlock: tr.readoutBlock,
+					entityResults: tr.entityResults,
+				};
+			});
 
 			// Generate session plan via LLM and persist
 			const providerEnvVar =

--- a/tests/tools/recap-tools.test.ts
+++ b/tests/tools/recap-tools.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFindCommunitiesContainingEntity = vi.fn();
+const mockFindCommunitiesContainingEntities = vi.fn();
+
+const mockPlanningTaskDAO = {
+	listByCampaign: vi.fn(),
+};
+
+const mockSessionDigestDAO = {
+	getNextSessionNumber: vi.fn(),
+};
+
+const mockSessionPlanReadoutDAO = {
+	get: vi.fn(),
+};
+
+const mockCommunityDAO = {
+	findCommunitiesContainingEntity: mockFindCommunitiesContainingEntity,
+	findCommunitiesContainingEntities: mockFindCommunitiesContainingEntities,
+};
+
+const mockDaoFactory = {
+	planningTaskDAO: mockPlanningTaskDAO,
+	sessionDigestDAO: mockSessionDigestDAO,
+	sessionPlanReadoutDAO: mockSessionPlanReadoutDAO,
+	communityDAO: mockCommunityDAO,
+};
+
+vi.mock("@/dao/dao-factory", () => ({
+	getDAOFactory: vi.fn(() => mockDaoFactory),
+}));
+
+const mockSearchExecute = vi.fn();
+vi.mock("@/tools/campaign-context/search-tools", () => ({
+	searchCampaignContext: {
+		execute: (...args: unknown[]) => mockSearchExecute(...args),
+	},
+}));
+
+vi.mock("@/tools/utils", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/tools/utils")>();
+	return {
+		...actual,
+		requireCanSeeSpoilersForTool: vi
+			.fn()
+			.mockResolvedValue({ userId: "user-1" }),
+		requireCampaignAccessForTool: vi.fn().mockResolvedValue({}),
+		requireGMRole: vi.fn().mockResolvedValue(undefined),
+	};
+});
+
+import { getSessionReadoutContext } from "@/tools/campaign-context/recap-tools";
+
+describe("getSessionReadoutContext", () => {
+	const jwt = "x.eyJ1c2VybmFtZSI6InRlc3QtdXNlciJ9.y";
+	const campaignId = "campaign-1";
+	const options = {
+		toolCallId: "readout-1",
+		env: { DB: {} },
+	} as any;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockSessionDigestDAO.getNextSessionNumber.mockResolvedValue(2);
+		mockSessionPlanReadoutDAO.get.mockResolvedValue(null);
+
+		mockPlanningTaskDAO.listByCampaign.mockResolvedValue([
+			{
+				id: "task-1",
+				title: "Prep Vallaki",
+				completionNotes: "Reviewed NPCs and locations",
+				createdAt: "2024-01-01T00:00:00Z",
+				targetSessionNumber: 2,
+			},
+			{
+				id: "task-2",
+				title: "Set up the Feast",
+				completionNotes: null,
+				createdAt: "2024-01-02T00:00:00Z",
+				targetSessionNumber: 2,
+			},
+		]);
+
+		mockSearchExecute.mockImplementation(
+			async (_input: { query?: string; traverseFromEntityIds?: string[] }) => {
+				if (_input.traverseFromEntityIds) {
+					return {
+						result: {
+							success: true,
+							data: {
+								results: _input.traverseFromEntityIds.map((id) => ({
+									entityId: id,
+									title: `Entity ${id}`,
+									text: `Content for ${id}`,
+								})),
+							},
+						},
+					};
+				}
+				return {
+					result: {
+						success: true,
+						data: {
+							results: [
+								{
+									entityId: "entity-1",
+									title: "Entity 1",
+									text: "ENTITY CONTENT (may contain unverified mentions):\n\nSome content",
+								},
+							],
+						},
+					},
+				};
+			}
+		);
+
+		mockFindCommunitiesContainingEntities.mockResolvedValue([
+			{
+				id: "comm-1",
+				campaignId,
+				level: 1,
+				parentCommunityId: null,
+				entityIds: ["entity-1", "entity-2"],
+				createdAt: "2024-01-01T00:00:00Z",
+			},
+		]);
+	});
+
+	it("uses batch community lookup instead of per-entity loop", async () => {
+		const result = await getSessionReadoutContext.execute?.(
+			{ campaignId, jwt, forceRegenerate: true },
+			options
+		);
+
+		expect(mockFindCommunitiesContainingEntity).not.toHaveBeenCalled();
+		expect(mockFindCommunitiesContainingEntities).toHaveBeenCalledTimes(1);
+		expect(mockFindCommunitiesContainingEntities).toHaveBeenCalledWith(
+			campaignId,
+			expect.arrayContaining(["entity-1"])
+		);
+		expect(
+			Array.isArray(mockFindCommunitiesContainingEntities.mock.calls[0][1])
+		).toBe(true);
+	});
+
+	it("runs search calls in parallel across tasks", async () => {
+		let concurrentCount = 0;
+		let maxConcurrent = 0;
+		mockSearchExecute.mockImplementation(async () => {
+			concurrentCount++;
+			maxConcurrent = Math.max(maxConcurrent, concurrentCount);
+			await new Promise((r) => setTimeout(r, 10));
+			concurrentCount--;
+			return {
+				result: {
+					success: true,
+					data: {
+						results: [
+							{
+								entityId: "entity-1",
+								title: "Entity 1",
+								text: "ENTITY CONTENT:\n\nContent",
+							},
+						],
+					},
+				},
+			};
+		});
+
+		await getSessionReadoutContext.execute?.(
+			{ campaignId, jwt, forceRegenerate: true },
+			options
+		);
+
+		expect(maxConcurrent).toBeGreaterThanOrEqual(2);
+	});
+});


### PR DESCRIPTION
…ntext (#531)

- Run task processing in parallel with Promise.all
- Within each task: run initial and notes-only search in parallel, then traverse
- Batch community lookups: single findCommunitiesContainingEntities call
- Add batchLoadCommunitiesByEntity helper
- Add unit tests for parallel search and batch community lookup

Made-with: Cursor