### PR TITLE
feat: cache analyzeUserState with 5-min TTL (fixes #530)

### DIFF
--- a/src/services/core/assessment-service.ts
+++ b/src/services/core/assessment-service.ts
@@ -24,7 +24,20 @@ export type {
 	ToolRecommendation,
 };
 
+interface UserStateCacheEntry {
+	data: UserState;
+	expiresAt: number;
+}
+
 export class AssessmentService {
+	private static userStateCache = new Map<string, UserStateCacheEntry>();
+	private static readonly userStateCacheTTL = 5 * 60 * 1000; // 5 minutes
+
+	/** Clear user state cache (for test isolation). */
+	static clearUserStateCache(): void {
+		AssessmentService.userStateCache.clear();
+	}
+
 	private assessmentDAO: AssessmentDAO;
 	private env: Env;
 
@@ -34,10 +47,21 @@ export class AssessmentService {
 	}
 
 	/**
-	 * Analyze user's current state for contextual guidance
+	 * Analyze user's current state for contextual guidance.
+	 * Results are cached per username with 5-minute TTL to reduce latency and DB load.
 	 */
 	async analyzeUserState(username: string): Promise<UserState> {
 		try {
+			const now = Date.now();
+			const cached = AssessmentService.userStateCache.get(username);
+			if (cached && cached.expiresAt > now) {
+				return cached.data;
+			}
+
+			if (cached && cached.expiresAt <= now) {
+				AssessmentService.userStateCache.delete(username);
+			}
+
 			// Get campaign and resource counts
 			const campaignCount = await this.assessmentDAO.getCampaignCount(username);
 			const resourceCount = await this.assessmentDAO.getResourceCount(username);
@@ -54,7 +78,7 @@ export class AssessmentService {
 			// Calculate total session time (approximated by activity count)
 			const totalSessionTime = recentActivity.length * 30; // Rough estimate: 30 minutes per activity
 
-			return {
+			const userState: UserState = {
 				isFirstTime: campaignCount === 0 && resourceCount === 0,
 				hasCampaigns: campaignCount > 0,
 				hasResources: resourceCount > 0,
@@ -64,6 +88,13 @@ export class AssessmentService {
 				lastLoginDate,
 				totalSessionTime,
 			};
+
+			AssessmentService.userStateCache.set(username, {
+				data: userState,
+				expiresAt: now + AssessmentService.userStateCacheTTL,
+			});
+
+			return userState;
 		} catch (error) {
 			console.error("Failed to analyze user state:", error);
 			throw new UserStateAnalysisError();

--- a/tests/services/assessment-service.test.ts
+++ b/tests/services/assessment-service.test.ts
@@ -66,6 +66,10 @@ describe("AssessmentService", () => {
 	});
 
 	describe("analyzeUserState", () => {
+		beforeEach(() => {
+			AssessmentService.clearUserStateCache();
+		});
+
 		it("should analyze first-time user state correctly", async () => {
 			const username = "testuser";
 
@@ -123,6 +127,44 @@ describe("AssessmentService", () => {
 			await expect(
 				assessmentService.analyzeUserState(username)
 			).rejects.toThrow("Failed to analyze user state");
+		});
+
+		it("returns cached result on second call within TTL", async () => {
+			const username = "testuser";
+
+			mockDAO.getCampaignCount.mockResolvedValue(1);
+			mockDAO.getResourceCount.mockResolvedValue(0);
+			mockDAO.getRecentActivity.mockResolvedValue([]);
+			mockDAO.getLastActivity.mockResolvedValue("2024-01-01T00:00:00Z");
+
+			const result1 = await assessmentService.analyzeUserState(username);
+			const result2 = await assessmentService.analyzeUserState(username);
+
+			expect(result1).toEqual(result2);
+			expect(result1.campaignCount).toBe(1);
+			expect(mockDAO.getCampaignCount).toHaveBeenCalledTimes(1);
+		});
+
+		it("refetches after TTL expires", async () => {
+			vi.useFakeTimers();
+			const username = "testuser";
+
+			mockDAO.getCampaignCount.mockResolvedValue(1);
+			mockDAO.getResourceCount.mockResolvedValue(0);
+			mockDAO.getRecentActivity.mockResolvedValue([]);
+			mockDAO.getLastActivity.mockResolvedValue("2024-01-01T00:00:00Z");
+
+			const result1 = await assessmentService.analyzeUserState(username);
+			expect(result1.campaignCount).toBe(1);
+			expect(mockDAO.getCampaignCount).toHaveBeenCalledTimes(1);
+
+			vi.advanceTimersByTime(6 * 60 * 1000);
+
+			const result2 = await assessmentService.analyzeUserState(username);
+			expect(result2.campaignCount).toBe(1);
+			expect(mockDAO.getCampaignCount).toHaveBeenCalledTimes(2);
+
+			vi.useRealTimers();
 		});
 	});
 


### PR DESCRIPTION
- Add in-memory cache to AssessmentService.analyzeUserState()
- Reduce latency and DB load for CampaignHelpAgent chat turns
- Add clearUserStateCache() for test isolation
- Add tests for cache hit and TTL expiry

Made-with: Cursor