### PR TITLE
feat: trim system prompt and move rarely-needed rules on-demand (fixe…

### DIFF
--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -29,6 +29,7 @@ import { submitSupportRequestTool } from "@/tools/common/support-tools";
 import type { CampaignRole } from "@/types/campaign";
 import type { Explainability } from "@/types/explainability";
 import { type ChatMessage, SimpleChatAgent } from "./simple-chat-agent";
+import { MESSAGE_HISTORY_REFERENCE_RULE } from "./system-prompts";
 
 interface Env {
 	Chat: DurableObjectNamespace;
@@ -62,6 +63,10 @@ const RULES_AWARE_AGENT_TYPES = new Set([
 	"session-digest",
 	"rules-reference",
 ]);
+
+/** Patterns that suggest the user is making an ambiguous reference (e.g. "the next one", "that one") */
+const AMBIGUOUS_REFERENCE_PATTERN =
+	/\b(the next one|that one|these|those|the first one|move to the next)\b/i;
 
 /** Write a single text message as UI stream chunks (text-start, text-delta, text-end). */
 function writeTextChunks(
@@ -571,6 +576,29 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 					} catch (rulesError) {
 						log.warn("Failed to inject campaign rules context", rulesError);
 					}
+				}
+
+				// On-demand: inject getMessageHistory rule only when user message suggests ambiguous references
+				const getToolsForRoleForCheck = (
+					this as unknown as {
+						getToolsForRole?: (r: CampaignRole | null) => Record<string, any>;
+					}
+				).getToolsForRole;
+				const toolsForTurn =
+					typeof getToolsForRoleForCheck === "function"
+						? getToolsForRoleForCheck(campaignRole)
+						: this.tools;
+				const hasMessageHistory =
+					toolsForTurn && "getMessageHistory" in toolsForTurn;
+				const userContent =
+					typeof lastUserMessage?.content === "string"
+						? lastUserMessage.content
+						: "";
+				const hasAmbiguousRef = AMBIGUOUS_REFERENCE_PATTERN.test(userContent);
+				if (hasMessageHistory && hasAmbiguousRef) {
+					supplementalSystemContext.push(
+						`## On-demand rule (ambiguous reference detected):\n${MESSAGE_HISTORY_REFERENCE_RULE}`
+					);
 				}
 
 				log.debug("Built minimal message context", {

--- a/src/agents/campaign-help-agent.ts
+++ b/src/agents/campaign-help-agent.ts
@@ -12,6 +12,7 @@ import {
  */
 const CAMPAIGN_HELP_SYSTEM_PROMPT = buildSystemPrompt({
 	agentName: "Campaign Help Agent",
+	conversationRules: "minimal",
 	responsibilities: [
 		"First-Time User Experience: Guide new users through the app's core value proposition and features",
 		"Prompt Suggestions: Suggest useful prompts and actions users can try to get value from the app",

--- a/src/agents/rules-reference-agent.ts
+++ b/src/agents/rules-reference-agent.ts
@@ -12,6 +12,7 @@ import {
 
 const RULES_REFERENCE_AGENT_SYSTEM_PROMPT = buildSystemPrompt({
 	agentName: "Rules reference agent",
+	conversationRules: "minimal",
 	responsibilities: [
 		"Rules lookup: Answer system mechanics questions using indexed campaign rule resources and rules entities.",
 		"Citation-first answers: Always ground answers in cited source excerpts or house rules from tool results.",

--- a/src/agents/system-prompts.ts
+++ b/src/agents/system-prompts.ts
@@ -1,3 +1,6 @@
+/** Conversation rule preset: minimal = core only; dataRetrieval = core + NO IMPROVISATION + PLAIN LANGUAGE */
+export type ConversationRulesPreset = "minimal" | "dataRetrieval";
+
 export interface SystemPromptConfig {
 	agentName: string;
 	responsibilities: string[];
@@ -5,6 +8,8 @@ export interface SystemPromptConfig {
 	workflowGuidelines: string[];
 	importantNotes?: string[];
 	specialization?: string;
+	/** Rule preset. dataRetrieval (default) adds NO IMPROVISATION and PLAIN LANGUAGE for agents that search campaign data. minimal for creative/suggestion agents. */
+	conversationRules?: ConversationRulesPreset;
 }
 
 /**
@@ -66,6 +71,15 @@ export function buildSystemPrompt(config: SystemPromptConfig): string {
 		? `\n## Specialization:\n${config.specialization}`
 		: "";
 
+	const useDataRetrievalRules = config.conversationRules !== "minimal";
+
+	const dataRetrievalRules = useDataRetrievalRules
+		? `
+
+- **CRITICAL - NO IMPROVISATION: Base your responses ONLY on information found through tool calls (search results, campaign data, etc.). If tools return zero results or insufficient information, DO NOT improvise, generate, or create new content based on your training data. Instead: (1) Clearly report what you searched for and what you found (or didn't find), (2) Explain that you cannot generate new content without permission, and (3) Ask the user if they would prefer to use existing approved content from their campaign as a first priority, or if they would like you to help create something new. Only generate new content if explicitly requested by the user after you've explained the search results and they've chosen option (b).**
+- **CRITICAL - PLAIN LANGUAGE: Users are not expected to be technical. When explaining what you searched or found, use simple, everyday language. NEVER use jargon like "semantic search", "entity graph", "campaign context/entities", "query" (as a technical term), "graph traversal", or "embedding". Say instead: "I looked through your campaign for...", "I checked your notes and characters...", "I didn't find any connection between them in your saved information", "your session notes and characters". Keep explanations clear and accessible.**`
+		: "";
+
 	return `You are a specialized ${config.agentName} for LoreSmith AI.
 
 ## Your Responsibilities:
@@ -78,22 +92,16 @@ ${toolMappings}
 ${workflowGuidelines}${importantNotes}${specialization}
 
 ## CRITICAL CONVERSATION RULES:
-- **NEVER use canned responses, templates, or pre-written text**
-- **ALWAYS be conversational, natural, and engaging**
-- **Ask questions naturally as part of the conversation flow**
-- **Avoid formal structures like "Campaign Name:" or "Campaign Theme:"**
-- **Make each interaction feel personal and unique**
-- **Use the tools directly when you have enough information - don't ask for more details unless absolutely necessary**
-- **Do NOT use emojis in assistant responses**
-- **Do NOT use em dashes in assistant responses; use commas, colons, or a simple hyphen instead**
-- **CRITICAL - Follow-up Questions and Conversational References: When users make ambiguous references (e.g., 'the next one', 'the first one', 'move to the next X', 'that one', 'these', 'those options'), you MUST use getMessageHistory (if available) to retrieve recent conversation history to understand what they're referring to. Search for messages containing keywords related to the reference (e.g., if user says 'the next faction', search for 'faction' in recent messages). This allows you to understand iterative workflows, lists that were previously discussed, and follow-up questions without overflowing the context window. Only retrieve the most recent relevant messages (limit: 10-20) to keep the context focused.**
-- **CRITICAL - NO IMPROVISATION: Base your responses ONLY on information found through tool calls (search results, campaign data, etc.). If tools return zero results or insufficient information, DO NOT improvise, generate, or create new content based on your training data. Instead: (1) Clearly report what you searched for and what you found (or didn't find), (2) Explain that you cannot generate new content without permission, and (3) Ask the user if they would prefer to use existing approved content from their campaign as a first priority, or if they would like you to help create something new. Only generate new content if explicitly requested by the user after you've explained the search results and they've chosen option (b).**
-- **CRITICAL - PLAIN LANGUAGE: Users are not expected to be technical. When explaining what you searched or found, use simple, everyday language. NEVER use jargon like "semantic search", "entity graph", "campaign context/entities", "query" (as a technical term), "graph traversal", or "embedding". Say instead: "I looked through your campaign for...", "I checked your notes and characters...", "I didn't find any connection between them in your saved information", "your session notes and characters". Keep explanations clear and accessible.**
-
-**IMPORTANT**: After using tools, always provide a helpful response to the user explaining what you found and what they should do next.
+- **Be conversational, natural, and engaging. Never use canned responses or templates.**
+- **Avoid formal structures like "Campaign Name:" or "Campaign Theme:". Use tools directly when you have enough information.**
+- **Do NOT use emojis or em dashes in responses; use commas, colons, or a simple hyphen instead.**
+- **After using tools, provide a helpful response explaining what you found and what they should do next.**${dataRetrievalRules}
 
 You are focused, efficient, conversational, and always prioritize helping users effectively through natural dialogue.`;
 }
+
+/** Rule injected on-demand when user message suggests ambiguous references. Only for agents with getMessageHistory. */
+export const MESSAGE_HISTORY_REFERENCE_RULE = `**CRITICAL - Follow-up Questions and Conversational References: When users make ambiguous references (e.g., 'the next one', 'the first one', 'move to the next X', 'that one', 'these', 'those options'), you MUST use getMessageHistory to retrieve recent conversation history to understand what they're referring to. Search for messages containing keywords related to the reference (e.g., if user says 'the next faction', search for 'faction' in recent messages). Only retrieve the most recent relevant messages (limit: 10-20) to keep the context focused.**`;
 
 /**
  * Common tool mapping format for consistency

--- a/tests/agents/system-prompts.test.ts
+++ b/tests/agents/system-prompts.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildSystemPrompt } from "../../src/agents/system-prompts";
+import { estimateTokenCount } from "../../src/lib/token-utils";
+
+const MINIMAL_CONFIG = {
+	agentName: "Test Agent",
+	responsibilities: ["Test responsibility"],
+	tools: { "test action": "testTool" },
+	workflowGuidelines: ["Test guideline"],
+};
+
+describe("buildSystemPrompt", () => {
+	it("produces valid prompt with minimal config", () => {
+		const prompt = buildSystemPrompt(MINIMAL_CONFIG);
+		expect(prompt).toContain("You are a specialized Test Agent");
+		expect(prompt).toContain("Test responsibility");
+		expect(prompt).toContain("CRITICAL CONVERSATION RULES");
+	});
+
+	it("conversationRules minimal has fewer tokens than dataRetrieval", () => {
+		const minimalPrompt = buildSystemPrompt({
+			...MINIMAL_CONFIG,
+			conversationRules: "minimal",
+		});
+		const dataRetrievalPrompt = buildSystemPrompt({
+			...MINIMAL_CONFIG,
+			conversationRules: "dataRetrieval",
+		});
+		const minimalTokens = estimateTokenCount(minimalPrompt);
+		const dataRetrievalTokens = estimateTokenCount(dataRetrievalPrompt);
+		expect(minimalTokens).toBeLessThan(dataRetrievalTokens);
+		// Document expected savings: dataRetrieval adds NO IMPROVISATION + PLAIN LANGUAGE (~220 tokens)
+		expect(dataRetrievalTokens - minimalTokens).toBeGreaterThan(100);
+	});
+
+	it("default (dataRetrieval) includes NO IMPROVISATION and PLAIN LANGUAGE", () => {
+		const defaultPrompt = buildSystemPrompt(MINIMAL_CONFIG);
+		expect(defaultPrompt).toContain("NO IMPROVISATION");
+		expect(defaultPrompt).toContain("PLAIN LANGUAGE");
+	});
+
+	it("minimal excludes NO IMPROVISATION and PLAIN LANGUAGE", () => {
+		const minimalPrompt = buildSystemPrompt({
+			...MINIMAL_CONFIG,
+			conversationRules: "minimal",
+		});
+		expect(minimalPrompt).not.toContain("NO IMPROVISATION");
+		expect(minimalPrompt).not.toContain("PLAIN LANGUAGE");
+	});
+});


### PR DESCRIPTION
…s #529)

- Add conversationRules preset (minimal | dataRetrieval) to SystemPromptConfig
- Condense core CRITICAL rules; NO IMPROVISATION + PLAIN LANGUAGE only for dataRetrieval
- Inject getMessageHistory rule on-demand when user message has ambiguous refs
- Use minimal rules for campaign-help and rules-reference agents
- Add token-delta tests for buildSystemPrompt

Made-with: Cursor