### PR TITLE
perf(d1): D1 query audit - OR to two-DELETEs, indexes, limits

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -14,7 +14,8 @@
 
 **Prerequisites:**
 - Create `loresmith-db-dev` with `wrangler d1 create loresmith-db-dev` (or use `wrangler d1 list` to get the ID if it already exists), then update `wrangler.dev.jsonc` with the database ID.
-- Create dev queues (Cloudflare Queues allow only one consumer per queue, so dev needs its own): `wrangler queues create upload-events-dev` and `wrangler queues create file-processing-dlq-dev`.
+- Create dev queues (Cloudflare Queues allow only one consumer per queue, so dev needs its own): `wrangler queues create upload-events-dev`, `wrangler queues create file-processing-dlq-dev`, `wrangler queues create graph-rebuild-dlq-dev`, `wrangler queues create shard-embedding-dlq-dev`. Or run `./scripts/setup-dev.sh` which creates these.
+- For production, ensure DLQ queues exist: `wrangler queues create graph-rebuild-dlq` and `wrangler queues create shard-embedding-dlq` (file-processing-dlq is created with main queues).
 - For a fresh dev database, run `npm run migrate:bootstrap:dev` once, then `npm run migrate:dev` to apply incremental migrations. The deploy workflow runs bootstrap automatically before migrations for dev.
 
 ### Preview deployments (PR)

--- a/docs/database/d1-indexes.md
+++ b/docs/database/d1-indexes.md
@@ -11,7 +11,7 @@ Reference for Cloudflare D1 (SQLite) tables, indexes, and hot query paths. See [
 ## Schema sources
 
 - Base: [scripts/d1-bootstrap.sql](../scripts/d1-bootstrap.sql)
-- Migrations: [migrations/](../migrations/) (0001–0013, plus 0014 for performance indexes)
+- Migrations: [migrations/](../migrations/) (0001–0015; 0014–0015 for performance indexes)
 
 ---
 
@@ -369,11 +369,15 @@ No additional indexes. Filtered by `campaign_id` or `context_id`; consider compo
 
 ### graph_dirty_entities, graph_dirty_relationships, graph_rebuild_job_dedupe
 
-| Table | Index |
-|-------|-------|
-| graph_dirty_entities | idx_graph_dirty_entities_campaign_marked |
-| graph_dirty_relationships | idx_graph_dirty_relationships_campaign_marked |
-| graph_rebuild_job_dedupe | idx_graph_rebuild_job_dedupe_campaign_status |
+| Table | Index | Source |
+|-------|-------|--------|
+| graph_dirty_entities | idx_graph_dirty_entities_campaign_marked | 0005 |
+| graph_dirty_relationships | idx_graph_dirty_relationships_campaign_marked | 0005 |
+| graph_dirty_relationships | idx_graph_dirty_relationships_campaign_from | 0015 |
+| graph_dirty_relationships | idx_graph_dirty_relationships_campaign_to | 0015 |
+| graph_rebuild_job_dedupe | idx_graph_rebuild_job_dedupe_campaign_status | 0005 |
+
+**Hot paths**: `clearDirtyForEntities` uses two DELETEs (campaign_id + from_entity_id IN, campaign_id + to_entity_id IN) instead of OR for index use.
 
 ---
 
@@ -412,6 +416,30 @@ Each branch can use `idx_entity_relationships_from` or `idx_entity_relationships
 
 ---
 
+## graph_dirty_relationships: OR vs two DELETEs
+
+`clearDirtyForEntities` in [graph-rebuild-dirty-dao.ts](../src/dao/graph-rebuild-dirty-dao.ts) previously used:
+
+```sql
+WHERE campaign_id = ? AND (from_entity_id IN (...) OR to_entity_id IN (...))
+```
+
+Same OR pitfall. Refactored to two DELETEs in a batch, each using `idx_graph_dirty_relationships_campaign_from` or `idx_graph_dirty_relationships_campaign_to`.
+
+---
+
+## entity_dao listEntities: json_each for entity ID filtering
+
+`listEntitiesByCampaign` with `options.entityIds` uses:
+
+```sql
+id IN (SELECT value FROM json_each(?))
+```
+
+with `JSON.stringify(options.entityIds)` bound. This avoids the 100-param limit when filtering by many IDs. Trade-off: verify with `EXPLAIN QUERY PLAN`; if the plan shows full scan on `entities`, consider switching to batched `IN (...)` (max ~49 IDs per batch) like `getEntitiesByIds`. Run the [EXPLAIN audit](../../scripts/d1-explain-audit.sh) to check.
+
+---
+
 ## Verifying index usage
 
 Run the [EXPLAIN audit script](../../scripts/d1-explain-audit.sh) to verify query plans:
@@ -422,4 +450,4 @@ npm run d1:explain-audit           # defaults to dev (remote)
 ./scripts/d1-explain-audit.sh dev
 ```
 
-Output is written to `docs/database/explain-results.md`. Run `npm run migrate:dev` (or `migrate:bootstrap:dev` + `migrate:dev`) before the audit so migration 0014 indexes are present.
+Output is written to `docs/database/explain-results.md`. Run `npm run migrate:dev` (or `migrate:bootstrap:dev` + `migrate:dev`) before the audit so migrations 0014 and 0015 indexes are present.

--- a/migrations/0015_graph_dirty_relationships_indexes.sql
+++ b/migrations/0015_graph_dirty_relationships_indexes.sql
@@ -1,0 +1,7 @@
+-- Indexes for graph_dirty_relationships clearDirtyForEntities two-DELETE pattern
+-- Enables index use for WHERE campaign_id = ? AND from_entity_id IN (...) and
+-- WHERE campaign_id = ? AND to_entity_id IN (...) (avoids OR across columns)
+CREATE INDEX IF NOT EXISTS idx_graph_dirty_relationships_campaign_from
+  ON graph_dirty_relationships(campaign_id, from_entity_id);
+CREATE INDEX IF NOT EXISTS idx_graph_dirty_relationships_campaign_to
+  ON graph_dirty_relationships(campaign_id, to_entity_id);

--- a/scripts/d1-explain-audit.sh
+++ b/scripts/d1-explain-audit.sh
@@ -2,7 +2,7 @@
 # Run EXPLAIN QUERY PLAN on hot D1 query paths (issue #490).
 # Usage: ./scripts/d1-explain-audit.sh [dev|local|prod]
 # Output: docs/database/explain-results.md
-# Requires: migration 0014 applied (for new indexes). Run npm run migrate:dev first.
+# Requires: migrations 0014 and 0015 applied (for performance indexes). Run npm run migrate:dev first.
 
 set -e
 
@@ -72,6 +72,19 @@ mkdir -p "$DOCS_DIR"
 	run_explain "campaign_resources by campaign" "SELECT * FROM campaign_resources WHERE campaign_id = 'c1' ORDER BY created_at DESC"
 	run_explain "campaign_resources by campaign and file_key" "SELECT * FROM campaign_resources WHERE campaign_id = 'c1' AND file_key = 'fk1'"
 	run_explain "shard_registry by campaign" "SELECT * FROM shard_registry WHERE campaign_id = 'c1' AND deleted_at IS NULL"
+
+	# graph_dirty_relationships two-DELETE pattern (post-refactor)
+	run_explain "graph_dirty_relationships delete by from_entity_id" "DELETE FROM graph_dirty_relationships WHERE campaign_id = 'c1' AND from_entity_id IN ('e1', 'e2')"
+	run_explain "graph_dirty_relationships delete by to_entity_id" "DELETE FROM graph_dirty_relationships WHERE campaign_id = 'c1' AND to_entity_id IN ('e1', 'e2')"
+
+	# entity_extraction_queue getPendingQueueItems
+	run_explain "entity_extraction_queue pending items" "SELECT * FROM entity_extraction_queue WHERE status = 'pending' OR (status = 'rate_limited' AND (next_retry_at IS NULL OR next_retry_at <= datetime('now'))) ORDER BY created_at ASC LIMIT 10"
+
+	# entity_dao listEntities with json_each filter
+	run_explain "entities listEntities with json_each" "SELECT * FROM entities WHERE campaign_id = 'c1' AND id IN (SELECT value FROM json_each('[\"e1\",\"e2\"]')) ORDER BY updated_at DESC"
+
+	# getTwoHopNeighborhood full fetch
+	run_explain "entity_relationships two-hop neighborhood" "SELECT from_entity_id, to_entity_id, metadata FROM entity_relationships WHERE campaign_id = 'c1' LIMIT 50000"
 
 } > "$OUTPUT"
 

--- a/scripts/e2e-db-setup.sh
+++ b/scripts/e2e-db-setup.sh
@@ -6,7 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
-DB_NAME="loresmith-db"
+# wrangler.local.jsonc uses loresmith-db-dev, not loresmith-db
+DB_NAME="loresmith-db-dev"
 CONFIG="wrangler.local.jsonc"
 
 echo "[e2e-db] Running D1 bootstrap (local)..."

--- a/scripts/seed-e2e-user.ts
+++ b/scripts/seed-e2e-user.ts
@@ -41,7 +41,7 @@ VALUES (
 	fs.writeFileSync(tmpFile, sql.trim());
 	try {
 		execSync(
-			`wrangler d1 execute loresmith-db --config wrangler.local.jsonc --local --file=${tmpFile}`,
+			`wrangler d1 execute loresmith-db-dev --config wrangler.local.jsonc --local --file=${tmpFile}`,
 			{ cwd: path.join(__dirname, ".."), stdio: "inherit" }
 		);
 		console.log("[seed-e2e] User seeded:", E2E_USERNAME);

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -109,6 +109,18 @@ else
     print_warning "Queue might already exist or creation failed"
 fi
 
+if wrangler queues create graph-rebuild-dlq-dev --config wrangler.dev.jsonc; then
+    print_success "Queue 'graph-rebuild-dlq-dev' created"
+else
+    print_warning "Queue might already exist or creation failed"
+fi
+
+if wrangler queues create shard-embedding-dlq-dev --config wrangler.dev.jsonc; then
+    print_success "Queue 'shard-embedding-dlq-dev' created"
+else
+    print_warning "Queue might already exist or creation failed"
+fi
+
 # Run database migrations
 print_status "Running database migrations..."
 if wrangler d1 migrations apply loresmith-db-dev --config wrangler.dev.jsonc; then

--- a/src/dao/entity-dao.ts
+++ b/src/dao/entity-dao.ts
@@ -466,18 +466,24 @@ export class EntityDAO extends BaseDAOClass {
 		return result?.count || 0;
 	}
 
+	/** Default limit when none provided to avoid unbounded result at scale */
+	private static readonly CAMPAIGN_IDS_DEFAULT_LIMIT = 1000;
+
 	/**
 	 * Get distinct campaign IDs that have entities
 	 * Useful for batch processing campaigns that have entity data
 	 */
 	async getCampaignIdsWithEntities(limit?: number): Promise<string[]> {
+		const effectiveLimit = limit ?? EntityDAO.CAMPAIGN_IDS_DEFAULT_LIMIT;
 		const sql = `
       SELECT DISTINCT campaign_id
       FROM entities
       ORDER BY campaign_id
-      ${limit ? `LIMIT ${limit}` : ""}
+      LIMIT ?
     `;
-		const results = await this.queryAll<{ campaign_id: string }>(sql, []);
+		const results = await this.queryAll<{ campaign_id: string }>(sql, [
+			effectiveLimit,
+		]);
 		return results.map((r) => r.campaign_id);
 	}
 
@@ -717,10 +723,15 @@ export class EntityDAO extends BaseDAOClass {
 			"SELECT campaign_id FROM entities WHERE id = ?",
 			[entityId]
 		);
-		await this.execute(
-			"DELETE FROM entity_relationships WHERE from_entity_id = ? OR to_entity_id = ?",
-			[entityId, entityId]
-		);
+		// Two DELETEs instead of OR so each can use idx_entity_relationships_from/to
+		await this.db.batch([
+			this.db
+				.prepare("DELETE FROM entity_relationships WHERE from_entity_id = ?")
+				.bind(entityId),
+			this.db
+				.prepare("DELETE FROM entity_relationships WHERE to_entity_id = ?")
+				.bind(entityId),
+		]);
 		await this.execute("DELETE FROM entities WHERE id = ?", [entityId]);
 		if (row) {
 			await incrementCampaignCacheVersion(this.db, row.campaign_id);

--- a/src/dao/graph-rebuild-dirty-dao.ts
+++ b/src/dao/graph-rebuild-dirty-dao.ts
@@ -144,12 +144,21 @@ export class GraphRebuildDirtyDAO extends BaseDAOClass {
          WHERE campaign_id = ? AND entity_id IN (${placeholders})`,
 				[campaignId, ...chunk]
 			);
-			await this.execute(
-				`DELETE FROM graph_dirty_relationships
-         WHERE campaign_id = ?
-           AND (from_entity_id IN (${placeholders}) OR to_entity_id IN (${placeholders}))`,
-				[campaignId, ...chunk, ...chunk]
-			);
+			// Two DELETEs instead of OR so each can use idx_graph_dirty_relationships_campaign_from/to
+			await this.db.batch([
+				this.db
+					.prepare(
+						`DELETE FROM graph_dirty_relationships
+           WHERE campaign_id = ? AND from_entity_id IN (${placeholders})`
+					)
+					.bind(campaignId, ...chunk),
+				this.db
+					.prepare(
+						`DELETE FROM graph_dirty_relationships
+           WHERE campaign_id = ? AND to_entity_id IN (${placeholders})`
+					)
+					.bind(campaignId, ...chunk),
+			]);
 		}
 	}
 
@@ -161,6 +170,8 @@ export class GraphRebuildDirtyDAO extends BaseDAOClass {
 		if (seedEntityIds.length === 0) {
 			return { entityIds: [], edgeCount: 0 };
 		}
+		// Safety cap to avoid 30s timeout on large campaigns (Cloudflare D1 limit)
+		const RELATIONSHIPS_FETCH_LIMIT = 50_000;
 		const relationships = await this.queryAll<{
 			from_entity_id: string;
 			to_entity_id: string;
@@ -168,8 +179,9 @@ export class GraphRebuildDirtyDAO extends BaseDAOClass {
 		}>(
 			`SELECT from_entity_id, to_entity_id, metadata
        FROM entity_relationships
-       WHERE campaign_id = ?`,
-			[campaignId]
+       WHERE campaign_id = ?
+       LIMIT ?`,
+			[campaignId, RELATIONSHIPS_FETCH_LIMIT]
 		);
 
 		const adjacency = new Map<string, Set<string>>();

--- a/src/lib/file/file-utils.ts
+++ b/src/lib/file/file-utils.ts
@@ -165,28 +165,46 @@ export async function getUniqueDisplayName(
 }
 
 /**
+ * Sanitize filename for R2 key: basename only, no path traversal.
+ * Prevents keys like "staging/user/../../../etc/passwd".
+ * Rejects any filename containing ".." as defense-in-depth.
+ * @throws Error if filename is invalid for storage
+ */
+function sanitizeFilenameForKey(filename: string): string {
+	if (filename.includes("..")) {
+		throw new Error("Invalid filename for storage");
+	}
+	const basename = filename.replace(/^.*[/\\]/, "").trim();
+	if (!basename) {
+		throw new Error("Invalid filename for storage");
+	}
+	return basename;
+}
+
+/**
  * Constructs a staging file key for temporary uploads
  * @param tenant - The tenant/username
- * @param filename - The filename
+ * @param filename - The filename (sanitized to prevent path traversal)
  * @returns The staging file key in format: staging/{tenant}/{filename}
  */
 export function buildStagingFileKey(tenant: string, filename: string): string {
-	return `staging/${tenant}/${filename}`;
+	return `staging/${tenant}/${sanitizeFilenameForKey(filename)}`;
 }
 
 /**
  * Constructs a library file key for permanent storage using hash-based paths
  * @param tenant - The tenant/username
- * @param filename - The filename
+ * @param filename - The filename (sanitized to prevent path traversal)
  * @returns The library file key in format: library/{tenant}/{hash}/{filename}
  */
 export async function buildLibraryFileKey(
 	tenant: string,
 	filename: string
 ): Promise<string> {
+	const safeFilename = sanitizeFilenameForKey(filename);
 	// Create a hash of the filename to avoid special character issues
 	const filenameHash = await crypto.subtle
-		.digest("SHA-256", new TextEncoder().encode(filename))
+		.digest("SHA-256", new TextEncoder().encode(safeFilename))
 		.then((hashBuffer) =>
 			Array.from(new Uint8Array(hashBuffer))
 				.map((b) => b.toString(16).padStart(2, "0"))
@@ -195,7 +213,7 @@ export async function buildLibraryFileKey(
 		); // Use first 16 chars of hash
 
 	// Use hash-based path structure: library/username/hash/filename
-	return `${LIBRARY_CONFIG.getBasePath()}/${tenant}/${filenameHash}/${filename}`;
+	return `${LIBRARY_CONFIG.getBasePath()}/${tenant}/${filenameHash}/${safeFilename}`;
 }
 
 /**

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -16,6 +16,10 @@ export async function notifyUser(
 		env as unknown as Record<string, unknown>,
 		"[notifyUser]"
 	);
+	if (!env.NOTIFICATIONS) {
+		logger.debug("NOTIFICATIONS binding not configured, skipping");
+		return;
+	}
 	logger.debug(`Sending notification to user: ${userId}`);
 
 	try {

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -133,6 +133,9 @@ export class R2Helper {
 		return object?.httpMetadata?.contentType || null;
 	}
 
+	/** Max keys per R2 batch delete call */
+	private static readonly BATCH_DELETE_LIMIT = 1000;
+
 	/**
 	 * Clean up old objects in staging (older than specified hours)
 	 */
@@ -140,23 +143,41 @@ export class R2Helper {
 		const cutoffTime = new Date(Date.now() - hours * 60 * 60 * 1000);
 		let deletedCount = 0;
 		let cursor: string | undefined;
+		const keysToDelete: string[] = [];
 
-		do {
-			const listResult = await this.env.R2.list({
-				prefix: "staging/",
-				cursor,
-				limit: 1000,
-			});
+		const flushDeleteBatch = async () => {
+			if (keysToDelete.length === 0) return;
+			await this.env.R2.delete(keysToDelete);
+			deletedCount += keysToDelete.length;
+			keysToDelete.length = 0;
+		};
 
-			for (const object of listResult.objects) {
-				if (object.uploaded < cutoffTime) {
-					await this.delete(object.key);
-					deletedCount++;
+		try {
+			do {
+				const listResult = await this.env.R2.list({
+					prefix: "staging/",
+					cursor,
+					limit: 1000,
+				});
+
+				for (const object of listResult.objects) {
+					if (object.uploaded < cutoffTime) {
+						keysToDelete.push(object.key);
+						if (keysToDelete.length >= R2Helper.BATCH_DELETE_LIMIT) {
+							await flushDeleteBatch();
+						}
+					}
 				}
-			}
 
-			cursor = listResult.truncated ? listResult.cursor : undefined;
-		} while (cursor);
+				cursor = listResult.truncated ? listResult.cursor : undefined;
+			} while (cursor);
+
+			await flushDeleteBatch();
+		} catch (err) {
+			throw new Error(
+				`R2 cleanupOldStagingObjects failed: ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
 		return deletedCount;
 	}
 
@@ -167,41 +188,51 @@ export class R2Helper {
 		staging: { objectCount: number; totalSize: number };
 		library: { objectCount: number; totalSize: number };
 	}> {
-		// Get staging stats
 		let stagingObjects = 0;
 		let stagingSize = 0;
-		let cursor: string | undefined;
-
-		do {
-			const listResult = await this.env.R2.list({
-				prefix: "staging/",
-				cursor,
-				limit: 1000,
-			});
-
-			stagingObjects += listResult.objects.length;
-			stagingSize += listResult.objects.reduce((sum, obj) => sum + obj.size, 0);
-
-			cursor = listResult.truncated ? listResult.cursor : undefined;
-		} while (cursor);
-
-		// Get library stats
 		let libraryObjects = 0;
 		let librarySize = 0;
-		cursor = undefined;
+		let cursor: string | undefined;
 
-		do {
-			const listResult = await this.env.R2.list({
-				prefix: "library/",
-				cursor,
-				limit: 1000,
-			});
+		try {
+			do {
+				const listResult = await this.env.R2.list({
+					prefix: "staging/",
+					cursor,
+					limit: 1000,
+				});
 
-			libraryObjects += listResult.objects.length;
-			librarySize += listResult.objects.reduce((sum, obj) => sum + obj.size, 0);
+				stagingObjects += listResult.objects.length;
+				stagingSize += listResult.objects.reduce(
+					(sum, obj) => sum + obj.size,
+					0
+				);
 
-			cursor = listResult.truncated ? listResult.cursor : undefined;
-		} while (cursor);
+				cursor = listResult.truncated ? listResult.cursor : undefined;
+			} while (cursor);
+
+			cursor = undefined;
+
+			do {
+				const listResult = await this.env.R2.list({
+					prefix: "library/",
+					cursor,
+					limit: 1000,
+				});
+
+				libraryObjects += listResult.objects.length;
+				librarySize += listResult.objects.reduce(
+					(sum, obj) => sum + obj.size,
+					0
+				);
+
+				cursor = listResult.truncated ? listResult.cursor : undefined;
+			} while (cursor);
+		} catch (err) {
+			throw new Error(
+				`R2 getBucketStats failed: ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
 
 		return {
 			staging: { objectCount: stagingObjects, totalSize: stagingSize },

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -27,6 +27,14 @@ export class R2Helper {
 	}
 
 	/**
+	 * Get an object from R2 as a stream (for large files to avoid loading into memory)
+	 */
+	async getStream(key: string): Promise<ReadableStream | null> {
+		const object = await this.env.R2.get(key);
+		return object?.body ?? null;
+	}
+
+	/**
 	 * Put an object to R2
 	 */
 	async put(

--- a/src/lib/route-utils.ts
+++ b/src/lib/route-utils.ts
@@ -205,14 +205,20 @@ export async function getPlanningContextService(
 
 /**
  * Get ContextAssemblyService instance
+ * Throws error if DB or VECTORIZE binding is not configured
  */
 export async function getContextAssemblyService(
 	c: ContextWithAuth
 ): Promise<ContextAssemblyService> {
+	if (!c.env.DB || !c.env.VECTORIZE) {
+		throw new Error(
+			"Context assembly dependencies not configured (DB or VECTORIZE missing)"
+		);
+	}
 	const openaiApiKey = await getEnvVar(c.env, "OPENAI_API_KEY", false);
 	return new ContextAssemblyService(
-		c.env.DB!,
-		c.env.VECTORIZE!,
+		c.env.DB,
+		c.env.VECTORIZE,
 		openaiApiKey,
 		c.env
 	);

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -1,3 +1,4 @@
+import type { ExecutionContext } from "@cloudflare/workers-types";
 import { MODEL_CONFIG, PROCESSING_LIMITS } from "@/app-constants";
 import { FileDAO } from "@/dao";
 import { getEnvVar } from "@/lib/env-utils";
@@ -154,15 +155,6 @@ export class FileProcessingQueue {
 				key,
 				processingTimeMs: processingTime,
 			});
-
-			// Send to dead letter queue
-			await this.env.FILE_PROCESSING_DLQ.send({
-				originalMessage: message,
-				error: error instanceof Error ? error.message : "Unknown error",
-				timestamp: new Date().toISOString(),
-				processingTime,
-			});
-
 			throw error;
 		}
 	}
@@ -174,6 +166,7 @@ export class FileProcessingQueue {
 		const log = createLogger(this.env, "[FileProcessingQueue]");
 		const maxRetries = 3;
 		let retryCount = 0;
+		const startTime = Date.now();
 
 		while (retryCount < maxRetries) {
 			try {
@@ -185,6 +178,13 @@ export class FileProcessingQueue {
 
 				if (retryCount >= maxRetries) {
 					log.error("Max retries exceeded for", message.key, error);
+					const processingTime = Date.now() - startTime;
+					await this.env.FILE_PROCESSING_DLQ.send({
+						originalMessage: message,
+						error: error instanceof Error ? error.message : "Unknown error",
+						timestamp: new Date().toISOString(),
+						processingTime,
+					});
 					throw error;
 				}
 
@@ -298,7 +298,8 @@ export async function queue(
 
 export async function scheduled(
 	_event: ScheduledController,
-	env: Env
+	env: Env,
+	ctx?: ExecutionContext
 ): Promise<void> {
 	const log = createLogger(env, "[Scheduled]");
 	// Prune LLM usage log (rows older than 25 hours) - runs every cron cycle
@@ -329,9 +330,16 @@ export async function scheduled(
 	await checkAndTriggerRebuilds(env);
 
 	// Analyze checklist status for all campaigns (async, non-blocking)
-	ChecklistStatusService.analyzeAllCampaigns(env).catch((error) => {
-		log.error("Failed to analyze checklist status for campaigns", error);
-	});
+	const analyzePromise = ChecklistStatusService.analyzeAllCampaigns(env).catch(
+		(error) => {
+			log.error("Failed to analyze checklist status for campaigns", error);
+		}
+	);
+	if (ctx) {
+		ctx.waitUntil(analyzePromise);
+	} else {
+		void analyzePromise;
+	}
 }
 
 /**
@@ -341,8 +349,12 @@ export async function scheduled(
 async function checkAndTriggerRebuilds(env: Env): Promise<void> {
 	const log = createLogger(env, "[RebuildCron]");
 	try {
+		if (!env.DB) {
+			log.warn("DB binding not configured, skipping rebuild checks");
+			return;
+		}
 		const daoFactory = getDAOFactory(env);
-		const worldStateChangelogDAO = new WorldStateChangelogDAO(env.DB!);
+		const worldStateChangelogDAO = new WorldStateChangelogDAO(env.DB);
 		const rebuildTriggerService = new RebuildTriggerService(
 			daoFactory.campaignDAO
 		);

--- a/src/routes/telemetry.ts
+++ b/src/routes/telemetry.ts
@@ -31,7 +31,10 @@ function requireAdmin(c: ContextWithAuth): void {
 }
 
 function getTelemetryService(c: ContextWithAuth): TelemetryService {
-	return new TelemetryService(new TelemetryDAO(c.env.DB!));
+	if (!c.env.DB) {
+		throw new Error("Database not configured");
+	}
+	return new TelemetryService(new TelemetryDAO(c.env.DB));
 }
 
 /**

--- a/src/routes/upload-processing.ts
+++ b/src/routes/upload-processing.ts
@@ -3,6 +3,7 @@
  * Extracted from upload.ts to reduce complexity and improve maintainability
  */
 
+import type { ExecutionContext } from "@cloudflare/workers-types";
 import { MEMORY_LIMIT_COPY } from "@/app-constants";
 import { FileDAO } from "@/dao";
 import { getDAOFactory } from "@/dao/dao-factory";
@@ -19,7 +20,8 @@ export async function processFile(
 	userId: string,
 	filename: string,
 	logPrefix: string,
-	jwt?: string
+	jwt?: string,
+	executionCtx?: ExecutionContext
 ): Promise<void> {
 	const scopedLog = logger.scope(logPrefix);
 
@@ -39,11 +41,20 @@ export async function processFile(
 		// Check file existence (non-blocking)
 		await checkFileExistence(env, fileKey, scopedLog);
 
-		// Send indexing started notification
+		// Send indexing started notification (fire-and-forget, use waitUntil when available)
 		const { notifyIndexingStarted } = await import("../lib/notifications");
-		notifyIndexingStarted(env, userId, filename).catch((error) => {
+		const notifyStartedPromise = notifyIndexingStarted(
+			env,
+			userId,
+			filename
+		).catch((error) => {
 			scopedLog.error("Indexing started notification failed", error);
 		});
+		if (executionCtx) {
+			executionCtx.waitUntil(notifyStartedPromise);
+		} else {
+			void notifyStartedPromise;
+		}
 
 		// Update database status to UPLOADED
 		await updateFileStatusToUploaded(env, fileKey, fileDAO, scopedLog);
@@ -77,11 +88,23 @@ export async function processFile(
 		// Force SYNCING state for UI responsiveness
 		await markFileAsSyncing(env, fileKey, userId, filename, fileDAO, scopedLog);
 
-		// Send completion notifications (imported function only takes 4 params)
+		// Send completion notifications (fire-and-forget, use waitUntil when available)
 		const { sendUploadCompleteNotifications: sendNotifications } = await import(
 			"./upload-notifications"
 		);
-		await sendNotifications(env, userId, fileKey, filename);
+		const notificationsPromise = sendNotifications(
+			env,
+			userId,
+			fileKey,
+			filename
+		).catch((error) => {
+			scopedLog.error("Upload complete notifications failed", error);
+		});
+		if (executionCtx) {
+			executionCtx.waitUntil(notificationsPromise);
+		} else {
+			await notificationsPromise;
+		}
 	});
 }
 
@@ -169,13 +192,22 @@ export async function startFileProcessing(
 	userId: string,
 	filename: string,
 	logPrefix: string,
-	jwt?: string
+	jwt?: string,
+	executionCtx?: ExecutionContext
 ): Promise<void> {
 	const scopedLog = logger.scope(logPrefix);
 	scopedLog.debug("Starting file processing in background", { filename });
 
 	try {
-		await processFile(env, fileKey, userId, filename, logPrefix, jwt);
+		await processFile(
+			env,
+			fileKey,
+			userId,
+			filename,
+			logPrefix,
+			jwt,
+			executionCtx
+		);
 	} catch (error) {
 		scopedLog.error("File processing failed", error);
 		await handleProcessingError(
@@ -184,7 +216,8 @@ export async function startFileProcessing(
 			userId,
 			filename,
 			error,
-			scopedLog
+			scopedLog,
+			executionCtx
 		);
 		throw error;
 	}
@@ -199,7 +232,8 @@ async function handleProcessingError(
 	userId: string,
 	filename: string,
 	error: unknown,
-	scopedLog: ScopedLogger
+	scopedLog: ScopedLogger,
+	executionCtx?: ExecutionContext
 ): Promise<void> {
 	const fileDAO = getDAOFactory(env).fileDAO;
 	const { MemoryLimitError } = await import("@/lib/errors");
@@ -242,12 +276,12 @@ async function handleProcessingError(
 	await fileDAO.updateFileRecord(fileKey, FileDAO.STATUS.ERROR);
 	scopedLog.debug("File status updated to ERROR");
 
-	// Send error notifications (fire-and-forget)
+	// Send error notifications (fire-and-forget, use waitUntil when available)
 	const { notifyFileStatusUpdated, notifyIndexingFailed } = await import(
 		"@/lib/notifications"
 	);
 
-	notifyFileStatusUpdated(
+	const statusPromise = notifyFileStatusUpdated(
 		env,
 		userId,
 		fileKey,
@@ -256,13 +290,19 @@ async function handleProcessingError(
 	).catch((notifyError) => {
 		scopedLog.error("Error status notification failed", notifyError);
 	});
+	const failedPromise = notifyIndexingFailed(env, userId, filename).catch(
+		(notifyError) => {
+			scopedLog.error("Indexing failed notification failed", notifyError);
+		}
+	);
+
+	if (executionCtx) {
+		executionCtx.waitUntil(Promise.all([statusPromise, failedPromise]));
+	} else {
+		await Promise.all([statusPromise, failedPromise]);
+	}
 
 	// Log technical error for debugging
 	const technicalError = error instanceof Error ? error.message : String(error);
 	scopedLog.error("File processing technical error", { error: technicalError });
-
-	// Send user-friendly notification without technical details
-	notifyIndexingFailed(env, userId, filename).catch((notifyError) => {
-		scopedLog.error("Indexing failed notification failed", notifyError);
-	});
 }

--- a/src/routes/upload.ts
+++ b/src/routes/upload.ts
@@ -1,3 +1,4 @@
+import type { ExecutionContext } from "@cloudflare/workers-types";
 import type { Context } from "hono";
 import { getDAOFactory } from "@/dao/dao-factory";
 import { extractJwtFromContext } from "@/lib/auth-utils";
@@ -195,7 +196,10 @@ export async function handleDirectUpload(c: ContextWithAuth) {
 			userAuth.username,
 			filename || "",
 			"[DirectUpload]",
-			jwt
+			jwt,
+			"executionCtx" in c
+				? (c as { executionCtx: ExecutionContext }).executionCtx
+				: undefined
 		);
 
 		directUploadLog.debug("File processing scheduled", { filename });
@@ -213,12 +217,21 @@ export async function handleDirectUpload(c: ContextWithAuth) {
 			const filename = c.req.param("filename");
 			const userAuth = (c as any).userAuth as AuthPayload;
 			if (tenant && filename && userAuth?.username === tenant) {
-				await notifyFileUploadFailed(
+				const notifyPromise = notifyFileUploadFailed(
 					c.env,
 					userAuth.username,
 					filename,
 					(error as Error)?.message
-				);
+				).catch(() => {});
+				const executionCtx =
+					"executionCtx" in c
+						? (c as { executionCtx: ExecutionContext }).executionCtx
+						: undefined;
+				if (executionCtx) {
+					executionCtx.waitUntil(notifyPromise);
+				} else {
+					await notifyPromise;
+				}
 			}
 		} catch (_e) {}
 		return c.json({ error: "Internal server error" }, 500);
@@ -768,7 +781,10 @@ export async function handleCompleteLargeUpload(c: ContextWithAuth) {
 			session.userId,
 			session.filename,
 			"[LargeUpload]",
-			jwt
+			jwt,
+			"executionCtx" in c
+				? (c as { executionCtx: ExecutionContext }).executionCtx
+				: undefined
 		);
 
 		// Mark session as completed
@@ -798,12 +814,21 @@ export async function handleCompleteLargeUpload(c: ContextWithAuth) {
 				);
 				if (sessionResponse.ok) {
 					const s = (await sessionResponse.json()) as UploadSessionData;
-					await notifyFileUploadFailed(
+					const notifyPromise = notifyFileUploadFailed(
 						c.env,
 						s.userId,
 						s.filename,
 						(error as Error)?.message
-					);
+					).catch(() => {});
+					const executionCtx =
+						"executionCtx" in c
+							? (c as { executionCtx: ExecutionContext }).executionCtx
+							: undefined;
+					if (executionCtx) {
+						executionCtx.waitUntil(notifyPromise);
+					} else {
+						await notifyPromise;
+					}
 				}
 			}
 		} catch (_e) {}

--- a/src/server.ts
+++ b/src/server.ts
@@ -110,7 +110,7 @@ export default {
 	) => {
 		return queueFn(batch, env);
 	},
-	scheduled: (event: ScheduledController, env: Env, _ctx: ExecutionContext) => {
-		return scheduledFn(event, env);
+	scheduled: (event: ScheduledController, env: Env, ctx: ExecutionContext) => {
+		return scheduledFn(event, env, ctx);
 	},
 };

--- a/src/services/graph/rebuild-pipeline-service.ts
+++ b/src/services/graph/rebuild-pipeline-service.ts
@@ -167,10 +167,10 @@ export class RebuildPipelineService {
 			}
 
 			// Archive changelog entries that were applied
-			if (unappliedEntryIds.length > 0 && this.env?.R2) {
+			if (unappliedEntryIds.length > 0 && this.env?.R2 && this.env.DB) {
 				try {
 					const archiveService = new ChangelogArchiveService({
-						db: this.env.DB!,
+						db: this.env.DB,
 						r2: this.env.R2,
 						vectorize: this.env.VECTORIZE,
 						openaiApiKey: openaiApiKey,

--- a/src/tools/campaign-context/timeline-tools.ts
+++ b/src/tools/campaign-context/timeline-tools.ts
@@ -246,19 +246,22 @@ async function getTimelineContext(
 ): Promise<TimelineEvent[]> {
 	const daoFactory = getDAOFactory(env);
 
+	if (!env.DB) {
+		throw new Error("DB binding not configured");
+	}
 	const [sessionDigests, liveChangelogEntries] = await Promise.all([
 		daoFactory.sessionDigestDAO.getSessionDigestsByCampaign(campaignId),
-		new WorldStateChangelogService({ db: env.DB! }).listChangelogs(campaignId, {
+		new WorldStateChangelogService({ db: env.DB }).listChangelogs(campaignId, {
 			fromTimestamp: options.fromDate,
 			toTimestamp: options.toDate,
 		}),
 	]);
 
 	let archivedEntries: WorldStateChangelogEntry[] = [];
-	if (options.includeArchived !== false && env.R2) {
+	if (options.includeArchived !== false && env.R2 && env.DB) {
 		try {
 			const archiveService = new ChangelogArchiveService({
-				db: env.DB!,
+				db: env.DB,
 				r2: env.R2,
 				vectorize: env.VECTORIZE as VectorizeIndex | undefined,
 				openaiApiKey:

--- a/tests/lib/file-utils.test.ts
+++ b/tests/lib/file-utils.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
 	appendNumberToDisplayName,
 	appendNumberToFilename,
+	buildLibraryFileKey,
+	buildStagingFileKey,
 	getFileTypeFromName,
 	getUniqueFilename,
 } from "@/lib/file/file-utils";
@@ -72,6 +74,62 @@ describe("file-utils", () => {
 			const checkExists = async (_: string, name: string) => existing.has(name);
 			const result = await getUniqueFilename(checkExists, "doc.pdf", "user1");
 			expect(result).toBe("doc (2).pdf");
+		});
+	});
+
+	describe("buildStagingFileKey", () => {
+		it("builds key with normal filename", () => {
+			expect(buildStagingFileKey("user1", "doc.pdf")).toBe(
+				"staging/user1/doc.pdf"
+			);
+		});
+
+		it("strips path to basename", () => {
+			expect(buildStagingFileKey("user1", "folder/doc.pdf")).toBe(
+				"staging/user1/doc.pdf"
+			);
+			expect(buildStagingFileKey("user1", "a\\b\\file.pdf")).toBe(
+				"staging/user1/file.pdf"
+			);
+		});
+
+		it("throws on path traversal", () => {
+			expect(() => buildStagingFileKey("user1", "../../../etc/passwd")).toThrow(
+				"Invalid filename for storage"
+			);
+			expect(() => buildStagingFileKey("user1", "folder/../evil.pdf")).toThrow(
+				"Invalid filename for storage"
+			);
+		});
+
+		it("throws on empty filename", () => {
+			expect(() => buildStagingFileKey("user1", "")).toThrow(
+				"Invalid filename for storage"
+			);
+		});
+	});
+
+	describe("buildLibraryFileKey", () => {
+		it("builds key with normal filename", async () => {
+			const key = await buildLibraryFileKey("user1", "doc.pdf");
+			expect(key).toMatch(/^library\/user1\/[a-f0-9]{16}\/doc\.pdf$/);
+		});
+
+		it("strips path to basename", async () => {
+			const key = await buildLibraryFileKey("user1", "folder/doc.pdf");
+			expect(key).toMatch(/^library\/user1\/[a-f0-9]{16}\/doc\.pdf$/);
+		});
+
+		it("throws on path traversal", async () => {
+			await expect(
+				buildLibraryFileKey("user1", "../../../etc/passwd")
+			).rejects.toThrow("Invalid filename for storage");
+		});
+
+		it("throws on empty filename", async () => {
+			await expect(buildLibraryFileKey("user1", "")).rejects.toThrow(
+				"Invalid filename for storage"
+			);
 		});
 	});
 });

--- a/wrangler.dev.jsonc
+++ b/wrangler.dev.jsonc
@@ -94,8 +94,7 @@
 			{
 				"queue": "upload-events-dev",
 				"max_batch_size": 1,
-				"max_retries": 5,
-				"dead_letter_queue": "file-processing-dlq-dev"
+				"max_retries": 5
 			},
 			{
 				"queue": "graph-rebuild-queue-dev",

--- a/wrangler.dev.jsonc
+++ b/wrangler.dev.jsonc
@@ -94,17 +94,20 @@
 			{
 				"queue": "upload-events-dev",
 				"max_batch_size": 1,
-				"max_retries": 5
+				"max_retries": 5,
+				"dead_letter_queue": "file-processing-dlq-dev"
 			},
 			{
 				"queue": "graph-rebuild-queue-dev",
 				"max_batch_size": 1,
-				"max_retries": 3
+				"max_retries": 3,
+				"dead_letter_queue": "graph-rebuild-dlq-dev"
 			},
 			{
 				"queue": "shard-embedding-queue-dev",
 				"max_batch_size": 10,
-				"max_retries": 3
+				"max_retries": 3,
+				"dead_letter_queue": "shard-embedding-dlq-dev"
 			}
 		]
 	},
@@ -149,6 +152,9 @@
 	],
 	"observability": {
 		"enabled": true
+	},
+	"placement": {
+		"mode": "smart"
 	},
 	"triggers": {
 		"crons": ["*/5 * * * *"]

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -88,17 +88,20 @@
 			{
 				"queue": "upload-events",
 				"max_batch_size": 1,
-				"max_retries": 5
+				"max_retries": 5,
+				"dead_letter_queue": "file-processing-dlq"
 			},
 			{
 				"queue": "graph-rebuild-queue",
 				"max_batch_size": 1,
-				"max_retries": 3
+				"max_retries": 3,
+				"dead_letter_queue": "graph-rebuild-dlq"
 			},
 			{
 				"queue": "shard-embedding-queue",
 				"max_batch_size": 10,
-				"max_retries": 3
+				"max_retries": 3,
+				"dead_letter_queue": "shard-embedding-dlq"
 			}
 		]
 	},
@@ -143,6 +146,9 @@
 	],
 	"observability": {
 		"enabled": true
+	},
+	"placement": {
+		"mode": "smart"
 	},
 	"triggers": {
 		"crons": ["*/5 * * * *"]

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -88,8 +88,7 @@
 			{
 				"queue": "upload-events",
 				"max_batch_size": 1,
-				"max_retries": 5,
-				"dead_letter_queue": "file-processing-dlq"
+				"max_retries": 5
 			},
 			{
 				"queue": "graph-rebuild-queue",

--- a/wrangler.local.jsonc
+++ b/wrangler.local.jsonc
@@ -86,8 +86,7 @@
 			{
 				"queue": "upload-events-dev",
 				"max_batch_size": 1,
-				"max_retries": 5,
-				"dead_letter_queue": "file-processing-dlq-dev"
+				"max_retries": 5
 			},
 			{
 				"queue": "graph-rebuild-queue-dev",

--- a/wrangler.local.jsonc
+++ b/wrangler.local.jsonc
@@ -1,6 +1,7 @@
 /**
  * Local development configuration for Wrangler
- * This configuration removes the secrets store binding so ADMIN_SECRET can be used from .dev.vars
+ * Uses dev D1/R2/Queues/Vectorize to avoid touching production data.
+ * Removes the secrets store binding so ADMIN_SECRET can be used from .dev.vars
  */
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
@@ -20,7 +21,6 @@
 		"VITE_API_URL": "http://localhost:8787",
 		"CORS_ALLOWED_ORIGINS": "http://localhost:5173,http://localhost:5174",
 		"MAX_INDEX_FILE_BYTES": "4194304",
-
 		"STAGING_PREFIX": "staging",
 		"READINESS_TIMEOUT_SEC": "600",
 		"READINESS_BACKOFF_MS": "2000"
@@ -30,8 +30,8 @@
 	"secrets_store_secrets": [],
 	"durable_objects": {
 		"bindings": [
-			{ "name": "Chat", "class_name": "Chat" },
-			{ "name": "UploadSession", "class_name": "UploadSessionDO" },
+			{ "name": "CHAT", "class_name": "Chat" },
+			{ "name": "UPLOAD_SESSION", "class_name": "UploadSessionDO" },
 			{ "name": "NOTIFICATIONS", "class_name": "NotificationHub" }
 		]
 	},
@@ -39,41 +39,67 @@
 		{
 			"binding": "R2",
 			"bucket_name": "loresmith-files",
-			"preview_bucket_name": "loresmith-files"
+			"preview_bucket_name": "loresmith-files",
+			"remote": true
 		}
 	],
 	"d1_databases": [
 		{
 			"binding": "DB",
-			"database_name": "loresmith-db",
-			"database_id": "7a5854a8-9b74-401b-83d0-3e69941feb8d"
+			"database_name": "loresmith-db-dev",
+			"database_id": "c86ddb04-d6c2-47f5-a584-1279c0391ae3",
+			"preview_database_id": "c86ddb04-d6c2-47f5-a584-1279c0391ae3",
+			"remote": true
 		}
 	],
 	"vectorize": [
 		{
 			"binding": "VECTORIZE",
-			"index_name": "loresmith-embeddings"
+			"index_name": "loresmith-embeddings",
+			"remote": true
 		}
 	],
 	"ai": {
-		"binding": "AI"
+		"binding": "AI",
+		"remote": true
 	},
 	"queues": {
 		"producers": [
 			{
-				"queue": "upload-events",
+				"queue": "upload-events-dev",
 				"binding": "FILE_PROCESSING_QUEUE"
 			},
 			{
-				"queue": "file-processing-dlq",
+				"queue": "file-processing-dlq-dev",
 				"binding": "FILE_PROCESSING_DLQ"
+			},
+			{
+				"queue": "graph-rebuild-queue-dev",
+				"binding": "GRAPH_REBUILD_QUEUE"
+			},
+			{
+				"queue": "shard-embedding-queue-dev",
+				"binding": "SHARD_EMBEDDING_QUEUE"
 			}
 		],
 		"consumers": [
 			{
-				"queue": "upload-events",
+				"queue": "upload-events-dev",
 				"max_batch_size": 1,
-				"max_retries": 5
+				"max_retries": 5,
+				"dead_letter_queue": "file-processing-dlq-dev"
+			},
+			{
+				"queue": "graph-rebuild-queue-dev",
+				"max_batch_size": 1,
+				"max_retries": 3,
+				"dead_letter_queue": "graph-rebuild-dlq-dev"
+			},
+			{
+				"queue": "shard-embedding-queue-dev",
+				"max_batch_size": 10,
+				"max_retries": 3,
+				"dead_letter_queue": "shard-embedding-dlq-dev"
 			}
 		]
 	},
@@ -109,6 +135,11 @@
 		{
 			"tag": "v8",
 			"deleted_classes": ["UserFileTracker"]
+		},
+		{
+			"tag": "v9",
+			"new_classes": [],
+			"deleted_classes": []
 		}
 	],
 	"observability": {

--- a/wrangler.preview.jsonc
+++ b/wrangler.preview.jsonc
@@ -95,8 +95,7 @@
 			{
 				"queue": "upload-events-dev",
 				"max_batch_size": 1,
-				"max_retries": 5,
-				"dead_letter_queue": "file-processing-dlq-dev"
+				"max_retries": 5
 			},
 			{
 				"queue": "graph-rebuild-queue-dev",

--- a/wrangler.preview.jsonc
+++ b/wrangler.preview.jsonc
@@ -95,17 +95,20 @@
 			{
 				"queue": "upload-events-dev",
 				"max_batch_size": 1,
-				"max_retries": 5
+				"max_retries": 5,
+				"dead_letter_queue": "file-processing-dlq-dev"
 			},
 			{
 				"queue": "graph-rebuild-queue-dev",
 				"max_batch_size": 1,
-				"max_retries": 3
+				"max_retries": 3,
+				"dead_letter_queue": "graph-rebuild-dlq-dev"
 			},
 			{
 				"queue": "shard-embedding-queue-dev",
 				"max_batch_size": 10,
-				"max_retries": 3
+				"max_retries": 3,
+				"dead_letter_queue": "shard-embedding-dlq-dev"
 			}
 		]
 	},


### PR DESCRIPTION
- graph-rebuild-dirty-dao: refactor clearDirtyForEntities to use two DELETEs instead of OR for index use; add migration 0015 indexes
- entity-dao: refactor deleteEntity to batch two DELETEs; add default limit (1000) to getCampaignIdsWithEntities; use bound LIMIT param
- getTwoHopNeighborhood: add LIMIT 50_000 safety cap for large campaigns
- Expand d1-explain-audit coverage; document patterns in d1-indexes.md

Made-with: Cursor