### PR TITLE
feat(types): TypeScript shared types and DAO audit

### DIFF
--- a/src/dao/assessment-dao.ts
+++ b/src/dao/assessment-dao.ts
@@ -1,4 +1,6 @@
 import type { D1Database } from "@cloudflare/workers-types";
+import type { CampaignResource } from "@/dao/campaign-dao";
+import type { Entity, EntityDAORead } from "@/dao/entity-dao";
 import {
 	ENTITY_TYPE_FACTIONS,
 	ENTITY_TYPE_HOOKS,
@@ -110,8 +112,8 @@ export class AssessmentDAO {
 	 */
 	async getCampaignContext(
 		campaignId: string,
-		entityDAO?: any
-	): Promise<any[]> {
+		entityDAO?: EntityDAORead
+	): Promise<Entity[]> {
 		if (!entityDAO) {
 			throw new Error("entityDAO is required for getCampaignContext");
 		}
@@ -128,7 +130,7 @@ export class AssessmentDAO {
 		];
 
 		// Query entities for each type and combine
-		const allContext: any[] = [];
+		const allContext: Entity[] = [];
 		for (const entityType of conversationalContextTypes) {
 			const entities = await entityDAO.listEntitiesByCampaign(campaignId, {
 				entityType,
@@ -145,8 +147,8 @@ export class AssessmentDAO {
 	 */
 	async getCampaignCharacters(
 		campaignId: string,
-		entityDAO?: any
-	): Promise<any[]> {
+		entityDAO?: EntityDAORead
+	): Promise<Entity[]> {
 		if (!entityDAO) {
 			throw new Error("entityDAO is required for getCampaignCharacters");
 		}
@@ -155,7 +157,7 @@ export class AssessmentDAO {
 		const characterEntityTypes = ["npcs", "pcs"];
 
 		// Query entities for each type and combine
-		const allCharacters: any[] = [];
+		const allCharacters: Entity[] = [];
 		for (const entityType of characterEntityTypes) {
 			const entities = await entityDAO.listEntitiesByCampaign(campaignId, {
 				entityType,
@@ -201,9 +203,9 @@ export class AssessmentDAO {
 	 */
 	async storeNPCs(
 		campaignId: string,
-		npcs: any[],
+		npcs: object[],
 		moduleName: string,
-		entityDAO?: any
+		entityDAO?: EntityDAORead
 	): Promise<void> {
 		if (!entityDAO) {
 			throw new Error("entityDAO is required for storeNPCs");
@@ -211,11 +213,12 @@ export class AssessmentDAO {
 
 		for (const npc of npcs) {
 			const entityId = crypto.randomUUID();
+			const item = npc as { name?: string };
 			await entityDAO.createEntity({
 				id: entityId,
 				campaignId,
 				entityType: ENTITY_TYPE_NPCS,
-				name: npc.name || "Unnamed NPC",
+				name: item.name || "Unnamed NPC",
 				content: npc,
 				metadata: {
 					source: "module",
@@ -232,9 +235,9 @@ export class AssessmentDAO {
 	 */
 	async storeLocations(
 		campaignId: string,
-		locations: any[],
+		locations: object[],
 		moduleName: string,
-		entityDAO?: any
+		entityDAO?: EntityDAORead
 	): Promise<void> {
 		if (!entityDAO) {
 			throw new Error("entityDAO is required for storeLocations");
@@ -242,11 +245,12 @@ export class AssessmentDAO {
 
 		for (const location of locations) {
 			const entityId = crypto.randomUUID();
+			const item = location as { name?: string };
 			await entityDAO.createEntity({
 				id: entityId,
 				campaignId,
 				entityType: ENTITY_TYPE_LOCATIONS,
-				name: location.name || "Unnamed Location",
+				name: item.name || "Unnamed Location",
 				content: location,
 				metadata: {
 					source: "module",
@@ -263,9 +267,9 @@ export class AssessmentDAO {
 	 */
 	async storePlotHooks(
 		campaignId: string,
-		plotHooks: any[],
+		plotHooks: object[],
 		moduleName: string,
-		entityDAO?: any
+		entityDAO?: EntityDAORead
 	): Promise<void> {
 		if (!entityDAO) {
 			throw new Error("entityDAO is required for storePlotHooks");
@@ -273,11 +277,12 @@ export class AssessmentDAO {
 
 		for (const plotHook of plotHooks) {
 			const entityId = crypto.randomUUID();
+			const item = plotHook as { title?: string };
 			await entityDAO.createEntity({
 				id: entityId,
 				campaignId,
 				entityType: ENTITY_TYPE_HOOKS,
-				name: plotHook.title || "Unnamed Plot Hook",
+				name: item.title || "Unnamed Plot Hook",
 				content: plotHook,
 				metadata: {
 					source: "module",
@@ -294,9 +299,9 @@ export class AssessmentDAO {
 	 */
 	async storeStoryBeats(
 		campaignId: string,
-		storyBeats: any[],
+		storyBeats: object[],
 		moduleName: string,
-		entityDAO?: any
+		entityDAO?: EntityDAORead
 	): Promise<void> {
 		if (!entityDAO) {
 			throw new Error("entityDAO is required for storeStoryBeats");
@@ -304,11 +309,12 @@ export class AssessmentDAO {
 
 		for (const storyBeat of storyBeats) {
 			const entityId = crypto.randomUUID();
+			const item = storyBeat as { title?: string };
 			await entityDAO.createEntity({
 				id: entityId,
 				campaignId,
 				entityType: ENTITY_TYPE_PLOT_LINES,
-				name: storyBeat.title || "Unnamed Story Beat",
+				name: item.title || "Unnamed Story Beat",
 				content: storyBeat,
 				metadata: {
 					source: "module",
@@ -325,16 +331,17 @@ export class AssessmentDAO {
 	 */
 	async storeKeyItems(
 		campaignId: string,
-		keyItems: any[],
+		keyItems: object[],
 		moduleName: string,
-		entityDAO?: any
+		entityDAO?: EntityDAORead
 	): Promise<void> {
 		if (!entityDAO) {
 			throw new Error("entityDAO is required for storeKeyItems");
 		}
 
-		for (const item of keyItems) {
+		for (const keyItem of keyItems) {
 			const entityId = crypto.randomUUID();
+			const item = keyItem as { name?: string };
 			await entityDAO.createEntity({
 				id: entityId,
 				campaignId,
@@ -356,9 +363,9 @@ export class AssessmentDAO {
 	 */
 	async storeConflicts(
 		campaignId: string,
-		conflicts: any[],
+		conflicts: object[],
 		moduleName: string,
-		entityDAO?: any
+		entityDAO?: EntityDAORead
 	): Promise<void> {
 		if (!entityDAO) {
 			throw new Error("entityDAO is required for storeConflicts");
@@ -366,11 +373,12 @@ export class AssessmentDAO {
 
 		for (const conflict of conflicts) {
 			const entityId = crypto.randomUUID();
+			const item = conflict as { title?: string };
 			await entityDAO.createEntity({
 				id: entityId,
 				campaignId,
 				entityType: ENTITY_TYPE_FACTIONS,
-				name: conflict.title || "Unnamed Conflict",
+				name: item.title || "Unnamed Conflict",
 				content: conflict,
 				metadata: {
 					source: "module",
@@ -388,8 +396,8 @@ export class AssessmentDAO {
 	 */
 	async getCampaignContextOrdered(
 		campaignId: string,
-		entityDAO?: any
-	): Promise<any[]> {
+		entityDAO?: EntityDAORead
+	): Promise<Entity[]> {
 		if (!entityDAO) {
 			throw new Error("entityDAO is required for getCampaignContextOrdered");
 		}
@@ -404,8 +412,8 @@ export class AssessmentDAO {
 	 */
 	async getCampaignCharactersOrdered(
 		campaignId: string,
-		entityDAO?: any
-	): Promise<any[]> {
+		entityDAO?: EntityDAORead
+	): Promise<Entity[]> {
 		if (!entityDAO) {
 			throw new Error("entityDAO is required for getCampaignCharactersOrdered");
 		}
@@ -417,13 +425,15 @@ export class AssessmentDAO {
 	/**
 	 * Get campaign resources ordered by creation date
 	 */
-	async getCampaignResourcesOrdered(campaignId: string): Promise<any[]> {
+	async getCampaignResourcesOrdered(
+		campaignId: string
+	): Promise<CampaignResource[]> {
 		const result = await this.db
 			.prepare(
 				"SELECT * FROM campaign_resources WHERE campaign_id = ? ORDER BY created_at DESC"
 			)
 			.bind(campaignId)
-			.all();
+			.all<CampaignResource>();
 
 		return result.results || [];
 	}

--- a/src/dao/base-dao.ts
+++ b/src/dao/base-dao.ts
@@ -52,14 +52,15 @@ export abstract class BaseDAOClass implements BaseDAO {
 		return rows.length > 0;
 	}
 
-	protected async queryAll<T = any>(
+	protected async queryAll<T = unknown>(
 		sql: string,
-		params: any[] = []
+		params: import("@/types/utils").SqlParamsInput = []
 	): Promise<T[]> {
 		return this.withD1Retry(async () => {
 			try {
+				const bindParams = params.map((p) => (p === undefined ? null : p));
 				const stmt = this.db.prepare(sql);
-				const result = await stmt.bind(...params).all<T>();
+				const result = await stmt.bind(...bindParams).all<T>();
 				return result.results || [];
 			} catch (error) {
 				throw new Error(
@@ -69,14 +70,15 @@ export abstract class BaseDAOClass implements BaseDAO {
 		});
 	}
 
-	protected async queryFirst<T = any>(
+	protected async queryFirst<T = unknown>(
 		sql: string,
-		params: any[] = []
+		params: import("@/types/utils").SqlParamsInput = []
 	): Promise<T | null> {
 		return this.withD1Retry(async () => {
 			try {
+				const bindParams = params.map((p) => (p === undefined ? null : p));
 				const stmt = this.db.prepare(sql);
-				const result = await stmt.bind(...params).first<T>();
+				const result = await stmt.bind(...bindParams).first<T>();
 				return result;
 			} catch (error) {
 				throw new Error(
@@ -86,11 +88,15 @@ export abstract class BaseDAOClass implements BaseDAO {
 		});
 	}
 
-	protected async execute(sql: string, params: any[] = []): Promise<void> {
+	protected async execute(
+		sql: string,
+		params: import("@/types/utils").SqlParamsInput = []
+	): Promise<void> {
 		return this.withD1Retry(async () => {
 			try {
+				const bindParams = params.map((p) => (p === undefined ? null : p));
 				const stmt = this.db.prepare(sql);
-				await stmt.bind(...params).run();
+				await stmt.bind(...bindParams).run();
 			} catch (error) {
 				throw new Error(
 					`Database execute failed: ${error instanceof Error ? error.message : "Unknown error"}`
@@ -101,12 +107,13 @@ export abstract class BaseDAOClass implements BaseDAO {
 
 	protected async executeAndGetId(
 		sql: string,
-		params: any[] = []
+		params: import("@/types/utils").SqlParamsInput = []
 	): Promise<number> {
 		return this.withD1Retry(async () => {
 			try {
+				const bindParams = params.map((p) => (p === undefined ? null : p));
 				const stmt = this.db.prepare(sql);
-				const result = await stmt.bind(...params).run();
+				const result = await stmt.bind(...bindParams).run();
 				return result.meta?.last_row_id || 0;
 			} catch (error) {
 				throw new Error(

--- a/src/dao/campaign-dao.ts
+++ b/src/dao/campaign-dao.ts
@@ -1,8 +1,17 @@
 import { CAMPAIGN_ROLES } from "@/constants/campaign-roles";
+import type { CampaignResourceRow, CampaignRow } from "@/types/campaign";
+import type { SqlParam, SqlParams } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 import type { CampaignMemberRole } from "./campaign-share-link-dao";
 
 export type { CampaignMemberRole };
+export type { CampaignResourceRow, CampaignRow } from "@/types/campaign";
+
+/** Campaign row from DB; alias for backward compatibility */
+export type Campaign = CampaignRow;
+
+/** Campaign resource row from DB; alias for backward compatibility */
+export type CampaignResource = CampaignResourceRow;
 
 export interface CampaignMember {
 	campaign_id: string;
@@ -10,17 +19,6 @@ export interface CampaignMember {
 	role: CampaignMemberRole;
 	invited_by: string;
 	created_at: string;
-}
-
-export interface Campaign {
-	id: string;
-	name: string;
-	username: string;
-	description?: string;
-	campaignRagBasePath?: string;
-	metadata?: string | null;
-	created_at: string;
-	updated_at: string;
 }
 
 export interface CampaignContext {
@@ -42,23 +40,10 @@ export interface CampaignCharacter {
 	updated_at: string;
 }
 
-export interface CampaignResource {
-	id: string;
-	campaign_id: string;
-	file_key: string;
-	file_name: string;
-	display_name?: string;
-	description?: string;
-	tags?: string;
-	status: string;
-	created_at: string;
-	updated_at?: string;
-}
-
 export interface CampaignWithDetails extends Campaign {
 	context: CampaignContext[];
 	characters: CampaignCharacter[];
-	resources: CampaignResource[];
+	resources: CampaignResourceRow[];
 }
 
 export class CampaignDAO extends BaseDAOClass {
@@ -82,13 +67,13 @@ export class CampaignDAO extends BaseDAOClass {
 		]);
 	}
 
-	async getCampaignsByUser(username: string): Promise<Campaign[]> {
+	async getCampaignsByUser(username: string): Promise<CampaignRow[]> {
 		const sql = `
       select * from campaigns 
       where username = ? 
       order by updated_at desc
     `;
-		return await this.queryAll<Campaign>(sql, [username]);
+		return await this.queryAll<CampaignRow>(sql, [username]);
 	}
 
 	/** True if campaign_members table exists (migration 0001). Avoids failing when migrations not yet run. */
@@ -180,9 +165,9 @@ export class CampaignDAO extends BaseDAOClass {
 		return combined;
 	}
 
-	async getCampaignById(campaignId: string): Promise<Campaign | null> {
+	async getCampaignById(campaignId: string): Promise<CampaignRow | null> {
 		const sql = "select * from campaigns where id = ?";
-		return await this.queryFirst<Campaign>(sql, [campaignId]);
+		return await this.queryFirst<CampaignRow>(sql, [campaignId]);
 	}
 
 	async getCampaignByIdWithMapping(
@@ -210,7 +195,19 @@ export class CampaignDAO extends BaseDAOClass {
       from campaigns 
       where id = ? and username = ?
     `;
-		const asOwner = await this.queryFirst(ownerSql, [campaignId, username]);
+		type CampaignWithMapping = {
+			campaignId: string;
+			name: string;
+			description: string;
+			campaignRagBasePath: string;
+			createdAt: string;
+			updatedAt: string;
+			metadata?: string | null;
+		};
+		const asOwner = await this.queryFirst<CampaignWithMapping>(ownerSql, [
+			campaignId,
+			username,
+		]);
 		if (asOwner) return asOwner;
 
 		// Check campaign_members when table exists (migration 0001)
@@ -229,7 +226,10 @@ export class CampaignDAO extends BaseDAOClass {
       join campaign_members cm on c.id = cm.campaign_id
       where c.id = ? and cm.username = ?
     `;
-		return await this.queryFirst(memberSql, [campaignId, username]);
+		return await this.queryFirst<CampaignWithMapping>(memberSql, [
+			campaignId,
+			username,
+		]);
 	}
 
 	/** Returns 'owner' | editor_gm | readonly_gm | editor_player | readonly_player | null */
@@ -321,12 +321,12 @@ export class CampaignDAO extends BaseDAOClass {
 
 	async updateCampaign(
 		campaignId: string,
-		updates: Partial<Pick<Campaign, "name" | "description">> & {
+		updates: Partial<Pick<CampaignRow, "name" | "description">> & {
 			metadata?: Record<string, unknown> | string | null;
 		}
 	): Promise<void> {
 		const setClause: string[] = [];
-		const values: any[] = [];
+		const values: SqlParams = [];
 
 		for (const [key, value] of Object.entries(updates)) {
 			if (key === "metadata") {
@@ -338,7 +338,7 @@ export class CampaignDAO extends BaseDAOClass {
 				);
 			} else {
 				setClause.push(`${key} = ?`);
-				values.push(value);
+				values.push(value as SqlParam);
 			}
 		}
 
@@ -421,7 +421,9 @@ export class CampaignDAO extends BaseDAOClass {
 		await this.execute(sql, [id, campaignId, characterName, characterData]);
 	}
 
-	async getCampaignResources(campaignId: string): Promise<CampaignResource[]> {
+	async getCampaignResources(
+		campaignId: string
+	): Promise<CampaignResourceRow[]> {
 		const sql = `
       select 
         cr.id,
@@ -439,7 +441,7 @@ export class CampaignDAO extends BaseDAOClass {
       where cr.campaign_id = ? 
       order by cr.created_at desc
     `;
-		return await this.queryAll<CampaignResource>(sql, [campaignId]);
+		return await this.queryAll<CampaignResourceRow>(sql, [campaignId]);
 	}
 
 	async addCampaignResource(

--- a/src/dao/changelog-archive-dao.ts
+++ b/src/dao/changelog-archive-dao.ts
@@ -4,6 +4,7 @@ import type {
 	ChangelogArchiveQueryOptions,
 	CreateChangelogArchiveMetadataInput,
 } from "@/types/changelog-archive";
+import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
 export class ChangelogArchiveDAO extends BaseDAOClass {
@@ -45,7 +46,7 @@ export class ChangelogArchiveDAO extends BaseDAOClass {
 		options: ChangelogArchiveQueryOptions = {}
 	): Promise<ChangelogArchiveMetadata[]> {
 		const conditions: string[] = ["campaign_id = ?"];
-		const params: any[] = [campaignId];
+		const params: SqlParam[] = [campaignId];
 
 		if (options.campaignSessionId !== undefined) {
 			conditions.push(

--- a/src/dao/community-dao.ts
+++ b/src/dao/community-dao.ts
@@ -1,3 +1,4 @@
+import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
 // D1 has a relatively small SQL parameter ceiling; keep IN() batches conservative.
@@ -113,7 +114,7 @@ export class CommunityDAO extends BaseDAOClass {
 		options: { level?: number; limit?: number; offset?: number } = {}
 	): Promise<Community[]> {
 		const conditions = ["campaign_id = ?"];
-		const params: any[] = [campaignId];
+		const params: SqlParam[] = [campaignId];
 
 		if (options.level !== undefined) {
 			conditions.push("level = ?");
@@ -165,7 +166,7 @@ export class CommunityDAO extends BaseDAOClass {
 		updates: UpdateCommunityInput
 	): Promise<void> {
 		const setClauses: string[] = [];
-		const values: any[] = [];
+		const values: SqlParam[] = [];
 
 		if (updates.entityIds !== undefined) {
 			// Update JSON column for backward compatibility during migration

--- a/src/dao/community-summary-dao.ts
+++ b/src/dao/community-summary-dao.ts
@@ -1,3 +1,4 @@
+import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
 // Raw row shape returned directly from D1 queries against the `community_summaries` table.
@@ -84,7 +85,7 @@ export class CommunitySummaryDAO extends BaseDAOClass {
       INNER JOIN communities c ON cs.community_id = c.id
       WHERE cs.community_id = ?
     `;
-		const params: any[] = [communityId];
+		const params: SqlParam[] = [communityId];
 
 		if (campaignId) {
 			sql += " AND c.campaign_id = ?";
@@ -107,7 +108,7 @@ export class CommunitySummaryDAO extends BaseDAOClass {
       INNER JOIN communities c ON cs.community_id = c.id
       WHERE cs.id = ?
     `;
-		const params: any[] = [summaryId];
+		const params: SqlParam[] = [summaryId];
 
 		if (campaignId) {
 			sql += " AND c.campaign_id = ?";
@@ -124,7 +125,7 @@ export class CommunitySummaryDAO extends BaseDAOClass {
 	): Promise<CommunitySummary[]> {
 		// Join with communities table to filter by campaign_id
 		const conditions = ["c.campaign_id = ?"];
-		const params: any[] = [campaignId];
+		const params: SqlParam[] = [campaignId];
 
 		if (options.level !== undefined) {
 			conditions.push("cs.level = ?");
@@ -164,7 +165,7 @@ export class CommunitySummaryDAO extends BaseDAOClass {
 		updates: UpdateCommunitySummaryInput
 	): Promise<void> {
 		const setClauses: string[] = [];
-		const values: any[] = [];
+		const values: SqlParam[] = [];
 
 		if (updates.name !== undefined) {
 			setClauses.push("name = ?");

--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -41,6 +41,11 @@ import { UserMonthlyUsageDAO } from "./user-monthly-usage-dao";
 // Cache for DAO factory instances
 const daoFactoryCache = new WeakMap<D1Database, DAOFactory>();
 
+/** Minimal env shape required for getDAOFactory (DB binding) */
+export interface EnvWithDb {
+	DB?: D1Database;
+}
+
 export interface DAOFactory {
 	authUserDAO: AuthUserDAO;
 	userDAO: UserDAO;
@@ -233,8 +238,8 @@ export function createDAOFactory(db: D1Database | undefined): DAOFactory {
 	return factory;
 }
 
-export function getDAOFactory(env: unknown): DAOFactory {
-	const e = env as { DB?: D1Database };
+export function getDAOFactory(env: EnvWithDb | unknown): DAOFactory {
+	const e = env as EnvWithDb;
 	const db = e?.DB;
 	if (!db) {
 		throw new DAOFactoryError();

--- a/src/dao/entity-dao.ts
+++ b/src/dao/entity-dao.ts
@@ -4,6 +4,7 @@ import {
 } from "@/lib/entity/relationship-types";
 import { RelationshipUpsertError } from "@/lib/errors";
 import { incrementCampaignCacheVersion } from "@/services/search/entity-search-cache-service";
+import type { SqlParam, SqlParams } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
 /** D1 platform limit: max 100 bound params per query. We use 2×N (from + to IN), so N ≤ 49. */
@@ -47,7 +48,9 @@ export interface Entity {
 	campaignId: string;
 	entityType: string;
 	name: string;
+	/** Structured content (entity-type-specific). Cast to known shape when type is known. */
 	content?: unknown;
+	/** Arbitrary metadata; may include resourceId, source, etc. Cast when shape is known. */
 	metadata?: unknown;
 	confidence?: number;
 	sourceType?: string | null;
@@ -126,6 +129,25 @@ export interface CreateEntityRelationshipInput {
 	relationshipType: RelationshipType;
 	strength?: number | null;
 	metadata?: unknown;
+}
+
+/** Minimal EntityDAO interface for DI (e.g. AssessmentDAO). Use for testing and injection. */
+export interface EntityDAORead {
+	listEntitiesByCampaign(
+		campaignId: string,
+		options?: {
+			entityType?: string;
+			sourceId?: string;
+			resourceId?: string;
+			entityIds?: string[];
+			shardStatus?: string | string[];
+			excludeShardStatuses?: string[];
+			limit?: number;
+			offset?: number;
+			orderBy?: "updated_at" | "name";
+		}
+	): Promise<Entity[]>;
+	createEntity(entity: CreateEntityInput): Promise<void>;
 }
 
 // Lightweight representation used by traversal helpers (e.g. breadth-first search)
@@ -225,7 +247,7 @@ export class EntityDAO extends BaseDAOClass {
 		updates: UpdateEntityInput
 	): Promise<void> {
 		const setClauses: string[] = [];
-		const values: any[] = [];
+		const values: SqlParam[] = [];
 
 		if (updates.name !== undefined) {
 			setClauses.push("name = ?");
@@ -371,7 +393,7 @@ export class EntityDAO extends BaseDAOClass {
 		} = {}
 	): Promise<Entity[]> {
 		const conditions = ["campaign_id = ?"];
-		const params: any[] = [campaignId];
+		const params: SqlParam[] = [campaignId];
 
 		if (options.entityType) {
 			conditions.push("entity_type = ?");
@@ -449,7 +471,7 @@ export class EntityDAO extends BaseDAOClass {
 		options: { entityType?: string } = {}
 	): Promise<number> {
 		const conditions = ["campaign_id = ?"];
-		const params: any[] = [campaignId];
+		const params: SqlParam[] = [campaignId];
 
 		if (options.entityType) {
 			conditions.push("entity_type = ?");
@@ -517,7 +539,7 @@ export class EntityDAO extends BaseDAOClass {
 		options: { entityType?: string; limit?: number } = {}
 	): Promise<Entity[]> {
 		const conditions = ["campaign_id = ?"];
-		const params: any[] = [campaignId];
+		const params: SqlParam[] = [campaignId];
 
 		if (options.entityType) {
 			conditions.push("entity_type = ?");
@@ -642,7 +664,7 @@ export class EntityDAO extends BaseDAOClass {
       WHERE campaign_id = ?
         AND LOWER(TRIM(name)) = LOWER(?)
     `;
-		const params: (string | undefined)[] = [campaignId, normalizedName];
+		const params: SqlParams = [campaignId, normalizedName];
 
 		if (entityType !== undefined && entityType !== null && entityType !== "") {
 			sql += ` AND LOWER(entity_type) = LOWER(?)`;
@@ -848,7 +870,7 @@ export class EntityDAO extends BaseDAOClass {
 		entityId: string,
 		options: { relationshipType?: RelationshipType } = {}
 	): Promise<EntityRelationship[]> {
-		const params: any[] = [entityId, entityId];
+		const params: SqlParam[] = [entityId, entityId];
 		const filters: string[] = ["(from_entity_id = ? OR to_entity_id = ?)"];
 
 		if (options.relationshipType) {
@@ -889,7 +911,7 @@ export class EntityDAO extends BaseDAOClass {
 			const typeFilter = options.relationshipType
 				? " AND relationship_type = ?"
 				: "";
-			const params: unknown[] = options.relationshipType
+			const params: SqlParams = options.relationshipType
 				? [
 						...chunk,
 						options.relationshipType,
@@ -1023,7 +1045,7 @@ export class EntityDAO extends BaseDAOClass {
 						.join(", ")})`
 				: "";
 
-		const params: any[] = [
+		const params: SqlParam[] = [
 			entityId,
 			...relationshipTypes,
 			maxDepth,
@@ -1119,7 +1141,7 @@ export class EntityDAO extends BaseDAOClass {
 			if (chunk.length === 0) continue;
 
 			const entityPlaceholders = chunk.map(() => "?").join(", ");
-			const params: any[] = [
+			const params: SqlParam[] = [
 				...chunk,
 				...relationshipTypes,
 				maxDepth,
@@ -1276,7 +1298,7 @@ export class EntityDAO extends BaseDAOClass {
 		updates: UpdateEntityDeduplicationInput
 	): Promise<void> {
 		const setClauses: string[] = [];
-		const values: any[] = [];
+		const values: SqlParam[] = [];
 
 		if (updates.status !== undefined) {
 			setClauses.push("status = ?");

--- a/src/dao/entity-importance-dao.ts
+++ b/src/dao/entity-importance-dao.ts
@@ -1,3 +1,4 @@
+import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
 // Raw row structure for the `entity_importance` table. Matches the D1 schema
@@ -148,7 +149,7 @@ export class EntityImportanceDAO extends BaseDAOClass {
 		options: EntityImportanceQueryOptions = {}
 	): Promise<EntityImportance[]> {
 		const conditions: string[] = ["campaign_id = ?"];
-		const params: any[] = [campaignId];
+		const params: SqlParam[] = [campaignId];
 
 		if (options.minScore !== undefined) {
 			conditions.push("importance_score >= ?");

--- a/src/dao/file/file-dao.ts
+++ b/src/dao/file/file-dao.ts
@@ -4,7 +4,9 @@ import type {
 	VectorizeIndex,
 } from "@cloudflare/workers-types";
 import { BaseDAOClass } from "@/dao/base-dao";
+import type { Env } from "@/middleware/auth";
 import { LibraryRAGService } from "@/services/rag/rag-service";
+import type { SqlParam, SqlParams } from "@/types/utils";
 import { FileProcessingChunksDAO } from "./file-processing-chunks-dao";
 
 export interface FileMetadata {
@@ -17,6 +19,7 @@ export interface FileMetadata {
 	content_type: string;
 	description?: string;
 	tags?: string;
+	status?: string;
 	vector_id?: string;
 	chunk_count?: number;
 	created_at: string;
@@ -52,6 +55,73 @@ export interface PDFChunk {
 
 export interface FileWithChunks extends ParsedFileMetadata {
 	chunks: PDFChunk[];
+}
+
+/** Row shape for file stats by status (GROUP BY status) */
+export interface FileStatsByStatusRow {
+	status: string;
+	count: number;
+}
+
+/** Row shape for file size stats aggregate */
+export interface FileSizeStatsRow {
+	total_size: number;
+	avg_size: number;
+	total_files: number;
+}
+
+/** Row shape for file status info */
+export interface FileStatusInfoRow {
+	status: string;
+	created_at: string;
+	updated_at: string;
+	file_size: number;
+}
+
+/** Row shape for RAG file list (subset of file_metadata) */
+export interface FileForRagRow {
+	file_key: string;
+	file_name: string;
+	display_name?: string;
+	description?: string;
+	tags?: string;
+	status: string;
+	created_at: string;
+	file_size: number;
+	updated_at?: string;
+	processing_error?: string;
+}
+
+/** Row shape for RAG file chunks (subset of file_chunks) */
+export interface FileChunkForRagRow {
+	id: string;
+	file_key: string;
+	chunk_text: string;
+	chunk_index: number;
+	created_at: string;
+}
+
+/** Row shape for storage usage (file_metadata subset) */
+export interface FileStorageUsageRow {
+	username?: string;
+	file_size: number;
+	status: string;
+}
+
+/** Row shape for sync_queue table. file_size may come from joined file_metadata in some queries. */
+export interface SyncQueueRow {
+	id: number;
+	username: string;
+	file_key: string;
+	file_name: string;
+	rag_id: string;
+	status: string;
+	retry_count: number;
+	created_at: string;
+	processed_at: string | null;
+	updated_at: string | null;
+	/** Present when joined with file_metadata */
+	file_size?: number;
 }
 
 export class FileDAO extends BaseDAOClass {
@@ -98,7 +168,7 @@ export class FileDAO extends BaseDAOClass {
 	 */
 	private async queryAndParseFileMetadata(
 		sql: string,
-		params: any[]
+		params: readonly SqlParam[]
 	): Promise<ParsedFileMetadata | null> {
 		const file = await this.queryFirst<FileMetadata>(sql, params);
 
@@ -118,7 +188,7 @@ export class FileDAO extends BaseDAOClass {
 	 */
 	private async queryAndParseMultipleFileMetadata(
 		sql: string,
-		params: any[]
+		params: readonly SqlParam[]
 	): Promise<ParsedFileMetadata[]> {
 		const files = await this.queryAll<FileMetadata>(sql, params);
 
@@ -180,8 +250,11 @@ export class FileDAO extends BaseDAOClass {
       FROM file_metadata
       WHERE username = ? AND file_name = ?
     `;
-		const result = await this.queryFirst(sql, [username, fileName]);
-		return (result?.count as number) > 0;
+		const result = await this.queryFirst<{ count: number }>(sql, [
+			username,
+			fileName,
+		]);
+		return (result?.count ?? 0) > 0;
 	}
 
 	/**
@@ -205,15 +278,15 @@ export class FileDAO extends BaseDAOClass {
       FROM file_metadata
       WHERE username = ? AND display_name = ?
     `;
-		const params: unknown[] = [username, displayName];
+		const params: SqlParams = [username, displayName];
 
 		if (excludeFileKey) {
 			sql += ` AND file_key != ?`;
 			params.push(excludeFileKey);
 		}
 
-		const result = await this.queryFirst(sql, params);
-		return (result?.count as number) > 0;
+		const result = await this.queryFirst<{ count: number }>(sql, params);
+		return (result?.count ?? 0) > 0;
 	}
 
 	async getFilesByUser(username: string): Promise<ParsedFileMetadata[]> {
@@ -385,7 +458,7 @@ export class FileDAO extends BaseDAOClass {
 	async checkFileIndexingStatus(
 		fileKey: string,
 		username: string,
-		env: any
+		env: Env
 	): Promise<{ isIndexed: boolean; error?: string }> {
 		try {
 			// Extract filename from fileKey for search
@@ -426,35 +499,37 @@ export class FileDAO extends BaseDAOClass {
 		return this.queryAndParseMultipleFileMetadata(sql, [username]);
 	}
 
-	async getFileStatsByUser(username: string): Promise<any[]> {
+	async getFileStatsByUser(username: string): Promise<FileStatsByStatusRow[]> {
 		const sql = `
       SELECT status, COUNT(*) as count 
       FROM file_metadata 
       WHERE username = ? 
       GROUP BY status
     `;
-		return await this.queryAll(sql, [username]);
+		return await this.queryAll<FileStatsByStatusRow>(sql, [username]);
 	}
 
-	async getFileSizeStatsByUser(username: string): Promise<any> {
+	async getFileSizeStatsByUser(
+		username: string
+	): Promise<FileSizeStatsRow | null> {
 		const sql = `
       SELECT SUM(file_size) as total_size, AVG(file_size) as avg_size, COUNT(*) as total_files 
       FROM file_metadata 
       WHERE username = ? AND file_size > 0
     `;
-		return await this.queryFirst(sql, [username]);
+		return await this.queryFirst<FileSizeStatsRow>(sql, [username]);
 	}
 
 	async getFileStatusInfo(
 		fileKey: string,
 		username: string
-	): Promise<any | null> {
+	): Promise<FileStatusInfoRow | null> {
 		const sql = `
       SELECT status, created_at, updated_at, file_size 
       FROM file_metadata 
       WHERE file_key = ? AND username = ?
     `;
-		return await this.queryFirst(sql, [fileKey, username]);
+		return await this.queryFirst<FileStatusInfoRow>(sql, [fileKey, username]);
 	}
 
 	async updateFileDescriptionAndTags(
@@ -659,7 +734,7 @@ export class FileDAO extends BaseDAOClass {
 		fileSize?: number
 	): Promise<void> {
 		let sql: string;
-		let params: any[];
+		let params: SqlParam[];
 
 		if (fileSize !== undefined) {
 			sql = `
@@ -766,48 +841,58 @@ export class FileDAO extends BaseDAOClass {
 		}
 	}
 
-	async getFilesForRag(username: string): Promise<any[]> {
+	async getFilesForRag(username: string): Promise<FileForRagRow[]> {
 		const sql = `
       SELECT file_key, file_name, display_name, description, tags, status, created_at, file_size, updated_at, processing_error
       FROM file_metadata 
       WHERE username = ? 
       ORDER BY created_at DESC
     `;
-		return await this.queryAll(sql, [username]);
+		return await this.queryAll<FileForRagRow>(sql, [username]);
 	}
 
-	async getFileForRag(fileKey: string, username: string): Promise<any | null> {
+	async getFileForRag(
+		fileKey: string,
+		username: string
+	): Promise<FileMetadata | null> {
 		const sql = `
       SELECT * FROM file_metadata 
       WHERE file_key = ? AND username = ?
     `;
-		return await this.queryFirst(sql, [fileKey, username]);
+		return await this.queryFirst<FileMetadata>(sql, [fileKey, username]);
 	}
 
-	async getFileChunksForRag(fileKey: string, username: string): Promise<any[]> {
+	async getFileChunksForRag(
+		fileKey: string,
+		username: string
+	): Promise<FileChunkForRagRow[]> {
 		const sql = `
       SELECT id, file_key, chunk_text, chunk_index, created_at 
       FROM file_chunks 
       WHERE file_key = ? AND username = ? 
       ORDER BY chunk_index
     `;
-		return await this.queryAll(sql, [fileKey, username]);
+		return await this.queryAll<FileChunkForRagRow>(sql, [fileKey, username]);
 	}
 
-	async getFileStatsForRag(username: string): Promise<any> {
+	async getFileStatsForRag(username: string): Promise<{
+		uploaded: number;
+		processed: number;
+		processing: number;
+		error: number;
+		total: number;
+	}> {
 		const sql = `
       SELECT * FROM file_metadata 
       WHERE username = ? 
       ORDER BY created_at DESC
     `;
-		const files = await this.queryAll(sql, [username]);
+		const files = await this.queryAll<FileMetadata>(sql, [username]);
 
-		const uploaded = files.filter((f: any) => f.status === "uploaded").length;
-		const processed = files.filter((f: any) => f.status === "processed").length;
-		const processing = files.filter(
-			(f: any) => f.status === "processing"
-		).length;
-		const error = files.filter((f: any) => f.status === "error").length;
+		const uploaded = files.filter((f) => f.status === "uploaded").length;
+		const processed = files.filter((f) => f.status === "processed").length;
+		const processing = files.filter((f) => f.status === "processing").length;
+		const error = files.filter((f) => f.status === "error").length;
 
 		return {
 			uploaded,
@@ -818,23 +903,25 @@ export class FileDAO extends BaseDAOClass {
 		};
 	}
 
-	async getAllFilesForStorageUsage(): Promise<any[]> {
+	async getAllFilesForStorageUsage(): Promise<FileStorageUsageRow[]> {
 		const sql = `
       SELECT username, file_size, status 
       FROM file_metadata 
       ORDER BY created_at DESC
     `;
-		return await this.queryAll(sql, []);
+		return await this.queryAll<FileStorageUsageRow>(sql, []);
 	}
 
-	async getUserFilesForStorageUsage(username: string): Promise<any[]> {
+	async getUserFilesForStorageUsage(
+		username: string
+	): Promise<FileStorageUsageRow[]> {
 		const sql = `
       SELECT file_size, status
       FROM file_metadata
       WHERE username = ?
       ORDER BY created_at DESC
     `;
-		return await this.queryAll(sql, [username]);
+		return await this.queryAll<FileStorageUsageRow>(sql, [username]);
 	}
 
 	async deleteFileForUser(fileKey: string, username: string): Promise<void> {
@@ -914,7 +1001,7 @@ export class FileDAO extends BaseDAOClass {
 		}
 	): Promise<void> {
 		const updates: string[] = [];
-		const values: any[] = [];
+		const values: SqlParam[] = [];
 
 		// Build dynamic update query
 		if (enhancedMetadata.content_summary !== undefined) {
@@ -990,7 +1077,7 @@ export class FileDAO extends BaseDAOClass {
       SELECT * FROM file_metadata 
       WHERE username = ? AND analysis_status = 'completed'
     `;
-		const values: any[] = [username];
+		const values: SqlParam[] = [username];
 
 		if (filters?.content_type_categories) {
 			sql += " AND content_type_categories LIKE ?";
@@ -1016,15 +1103,15 @@ export class FileDAO extends BaseDAOClass {
 			values.push(filters.limit);
 		}
 
-		const files = await this.queryAll(sql, values);
+		const files = await this.queryAll<FileMetadata>(sql, values);
 
 		// Parse tags and filter by campaign themes if specified
-		let parsedFiles = files.map((file: any) => ({
+		let parsedFiles = files.map((file: FileMetadata) => ({
 			...file,
 			tags: this.parseTags(file.tags || null, file.file_key),
-			campaign_themes: file.campaign_themes
+			campaign_themes: (file.campaign_themes
 				? JSON.parse(file.campaign_themes)
-				: [],
+				: []) as string[],
 			recommended_campaign_types: file.recommended_campaign_types
 				? JSON.parse(file.recommended_campaign_types)
 				: [],
@@ -1036,15 +1123,16 @@ export class FileDAO extends BaseDAOClass {
 
 		// Filter by campaign themes if specified
 		if (filters?.campaign_themes && filters.campaign_themes.length > 0) {
-			parsedFiles = parsedFiles.filter((file: any) => {
-				const fileThemes = file.campaign_themes || [];
-				return filters.campaign_themes!.some((theme) =>
-					fileThemes.includes(theme)
-				);
+			const themeFilter = filters.campaign_themes;
+			parsedFiles = parsedFiles.filter((file) => {
+				const fileThemes: string[] = Array.isArray(file.campaign_themes)
+					? file.campaign_themes
+					: [];
+				return themeFilter.some((theme) => fileThemes.includes(theme));
 			});
 		}
 
-		return parsedFiles;
+		return parsedFiles as unknown as ParsedFileMetadata[];
 	}
 
 	/**
@@ -1101,13 +1189,13 @@ export class FileDAO extends BaseDAOClass {
 	/**
 	 * Get pending sync queue items for a user
 	 */
-	async getSyncQueue(username: string): Promise<any[]> {
+	async getSyncQueue(username: string): Promise<SyncQueueRow[]> {
 		const sql = `
       SELECT * FROM sync_queue 
       WHERE username = ? AND status = 'pending'
       ORDER BY created_at ASC
     `;
-		return await this.queryAll(sql, [username]);
+		return await this.queryAll<SyncQueueRow>(sql, [username]);
 	}
 
 	/**
@@ -1144,8 +1232,8 @@ export class FileDAO extends BaseDAOClass {
       FROM sync_queue 
       WHERE status = 'pending'
     `;
-		const results = await this.queryAll(sql, []);
-		return results.map((row: any) => row.username);
+		const results = await this.queryAll<{ username: string }>(sql, []);
+		return results.map((row) => row.username);
 	}
 
 	/** Delegates to FileProcessingChunksDAO. */

--- a/src/dao/file/file-processing-chunks-dao.ts
+++ b/src/dao/file/file-processing-chunks-dao.ts
@@ -1,4 +1,5 @@
 import { BaseDAOClass } from "@/dao/base-dao";
+import type { SqlParams } from "@/types/utils";
 
 /**
  * DAO for the file_processing_chunks table (chunked upload / processing pipeline).
@@ -93,7 +94,7 @@ export class FileProcessingChunksDAO extends BaseDAOClass {
 		}
 	): Promise<void> {
 		const fields: string[] = [];
-		const values: unknown[] = [];
+		const values: SqlParams = [];
 
 		if (updates.status !== undefined) {
 			fields.push("status = ?");
@@ -151,7 +152,7 @@ export class FileProcessingChunksDAO extends BaseDAOClass {
       SELECT * FROM file_processing_chunks
       WHERE status = 'pending'
     `;
-		const params: unknown[] = [];
+		const params: SqlParams = [];
 
 		if (username) {
 			sql += " AND username = ?";

--- a/src/dao/index.ts
+++ b/src/dao/index.ts
@@ -13,6 +13,8 @@ export type {
 	CampaignCharacter,
 	CampaignContext,
 	CampaignResource,
+	CampaignResourceRow,
+	CampaignRow,
 	CampaignWithDetails,
 } from "./campaign-dao";
 // Campaign DAO

--- a/src/dao/message-history-dao.ts
+++ b/src/dao/message-history-dao.ts
@@ -1,3 +1,4 @@
+import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
 export interface ChatMessageRecord {
@@ -112,7 +113,7 @@ export class MessageHistoryDAO extends BaseDAOClass {
 	 */
 	async getMessages(options: GetMessagesOptions): Promise<ChatMessageRecord[]> {
 		const conditions: string[] = [];
-		const params: any[] = [];
+		const params: SqlParam[] = [];
 
 		// sessionId is optional - can query by campaignId or username alone
 		if (options.sessionId) {

--- a/src/dao/planning-task-dao.ts
+++ b/src/dao/planning-task-dao.ts
@@ -1,3 +1,4 @@
+import type { SqlParams } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
 export type PlanningTaskStatus =
@@ -53,7 +54,7 @@ export class PlanningTaskDAO extends BaseDAOClass {
       WHERE campaign_id = ?
     `;
 
-		const params: unknown[] = [campaignId];
+		const params: SqlParams = [campaignId];
 
 		if (status && status.length > 0) {
 			const placeholders = status.map(() => "?").join(", ");
@@ -165,7 +166,7 @@ export class PlanningTaskDAO extends BaseDAOClass {
 		}
 	): Promise<void> {
 		const fields: string[] = [];
-		const params: unknown[] = [];
+		const params: SqlParams = [];
 
 		if (updates.title !== undefined) {
 			fields.push("title = ?");

--- a/src/dao/rebuild-status-dao.ts
+++ b/src/dao/rebuild-status-dao.ts
@@ -1,3 +1,4 @@
+import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
 // Raw row structure for the `rebuild_status` table. Matches the D1 schema exactly.
@@ -92,7 +93,7 @@ export class RebuildStatusDAO extends BaseDAOClass {
 		updates: UpdateRebuildStatusInput
 	): Promise<void> {
 		const updatesList: string[] = [];
-		const params: any[] = [];
+		const params: SqlParam[] = [];
 
 		if (updates.status !== undefined) {
 			updatesList.push("status = ?");
@@ -172,7 +173,7 @@ export class RebuildStatusDAO extends BaseDAOClass {
 
 	async getActiveRebuilds(campaignId?: string): Promise<RebuildStatus[]> {
 		const conditions: string[] = ["status IN ('pending', 'in_progress')"];
-		const params: any[] = [];
+		const params: SqlParam[] = [];
 
 		if (campaignId) {
 			conditions.push("campaign_id = ?");
@@ -194,7 +195,7 @@ export class RebuildStatusDAO extends BaseDAOClass {
 		options: RebuildStatusQueryOptions = {}
 	): Promise<RebuildStatus[]> {
 		const conditions: string[] = ["campaign_id = ?"];
-		const params: any[] = [campaignId];
+		const params: SqlParam[] = [campaignId];
 
 		if (options.status) {
 			conditions.push("status = ?");

--- a/src/dao/session-digest-dao.ts
+++ b/src/dao/session-digest-dao.ts
@@ -7,6 +7,7 @@ import type {
 	UpdateSessionDigestInput,
 } from "@/types/session-digest";
 import { validateSessionDigestData } from "@/types/session-digest";
+import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
 export class SessionDigestDAO extends BaseDAOClass {
@@ -136,7 +137,7 @@ export class SessionDigestDAO extends BaseDAOClass {
 		status?: SessionDigestStatus
 	): Promise<SessionDigestWithData[]> {
 		const conditions: string[] = ["campaign_id = ?"];
-		const params: any[] = [campaignId];
+		const params: SqlParam[] = [campaignId];
 
 		if (status) {
 			conditions.push("status = ?");
@@ -195,7 +196,7 @@ export class SessionDigestDAO extends BaseDAOClass {
 		toDate?: string
 	): Promise<SessionDigestWithData[]> {
 		const conditions: string[] = ["campaign_id = ?"];
-		const params: any[] = [campaignId];
+		const params: SqlParam[] = [campaignId];
 
 		if (fromDate) {
 			conditions.push("session_date >= ?");
@@ -301,7 +302,7 @@ export class SessionDigestDAO extends BaseDAOClass {
 		input: UpdateSessionDigestInput
 	): Promise<void> {
 		const updates: string[] = [];
-		const params: any[] = [];
+		const params: SqlParam[] = [];
 
 		if (input.sessionDate !== undefined) {
 			updates.push("session_date = ?");
@@ -358,7 +359,7 @@ export class SessionDigestDAO extends BaseDAOClass {
 		reviewNotes?: string | null
 	): Promise<void> {
 		const updates: string[] = ["status = ?"];
-		const params: any[] = [status];
+		const params: SqlParam[] = [status];
 
 		if (reviewNotes !== undefined) {
 			updates.push("review_notes = ?");

--- a/src/dao/session-digest-template-dao.ts
+++ b/src/dao/session-digest-template-dao.ts
@@ -6,6 +6,7 @@ import type {
 	UpdateSessionDigestTemplateInput,
 } from "@/types/session-digest";
 import { validateSessionDigestData } from "@/types/session-digest";
+import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
 export class SessionDigestTemplateDAO extends BaseDAOClass {
@@ -94,7 +95,7 @@ export class SessionDigestTemplateDAO extends BaseDAOClass {
 		input: UpdateSessionDigestTemplateInput
 	): Promise<void> {
 		const updates: string[] = [];
-		const params: any[] = [];
+		const params: SqlParam[] = [];
 
 		if (input.name !== undefined) {
 			updates.push("name = ?");

--- a/src/dao/subscription-dao.ts
+++ b/src/dao/subscription-dao.ts
@@ -85,7 +85,7 @@ export class SubscriptionDAO extends BaseDAOClass {
 		if (!existing) return;
 
 		const updates: string[] = [];
-		const params: unknown[] = [];
+		const params: import("@/types/utils").SqlParams = [];
 
 		if (data.tier !== undefined) {
 			updates.push("tier = ?");

--- a/src/dao/telemetry-dao.ts
+++ b/src/dao/telemetry-dao.ts
@@ -6,6 +6,7 @@ import type {
 	TelemetryRecord,
 	TimeSeriesDataPoint,
 } from "@/types/telemetry";
+import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
 // Raw row structure matching the database schema
@@ -46,7 +47,7 @@ export class TelemetryDAO extends BaseDAOClass {
 		options: TelemetryQueryOptions = {}
 	): Promise<TelemetryRecord[]> {
 		const conditions: string[] = [];
-		const params: any[] = [];
+		const params: SqlParam[] = [];
 
 		if (options.campaignId) {
 			conditions.push("campaign_id = ?");
@@ -120,7 +121,7 @@ export class TelemetryDAO extends BaseDAOClass {
 		} = {}
 	): Promise<AggregatedMetrics | null> {
 		const conditions: string[] = ["metric_type = ?"];
-		const params: any[] = [metricType];
+		const params: SqlParam[] = [metricType];
 
 		if (options.campaignId) {
 			conditions.push("campaign_id = ?");
@@ -189,7 +190,7 @@ export class TelemetryDAO extends BaseDAOClass {
 		}
 	): Promise<TimeSeriesDataPoint[]> {
 		const conditions: string[] = ["metric_type = ?"];
-		const params: any[] = [metricType];
+		const params: SqlParam[] = [metricType];
 
 		if (options.campaignId) {
 			conditions.push("campaign_id = ?");

--- a/src/dao/world-state-changelog-dao.ts
+++ b/src/dao/world-state-changelog-dao.ts
@@ -1,3 +1,4 @@
+import type { SqlParam } from "@/types/utils";
 import type {
 	WorldStateChangelogEntry,
 	WorldStateChangelogPayload,
@@ -55,7 +56,7 @@ export class WorldStateChangelogDAO extends BaseDAOClass {
 		options: WorldStateChangelogQueryOptions = {}
 	): Promise<WorldStateChangelogEntry[]> {
 		const conditions: string[] = ["campaign_id = ?"];
-		const params: any[] = [campaignId];
+		const params: SqlParam[] = [campaignId];
 
 		if (options.campaignSessionId !== undefined) {
 			conditions.push("campaign_session_id = ?");

--- a/src/routes/library.ts
+++ b/src/routes/library.ts
@@ -226,7 +226,7 @@ export const handleDeleteFile = async (
 		}
 
 		// Delete from R2
-		await c.env.R2.delete(metadata.fileKey);
+		await c.env.R2.delete(metadata.file_key);
 
 		// Delete from D1
 		await c.env.DB.prepare(
@@ -262,9 +262,9 @@ export const handleGetFileDownload = async (
 
 		return c.json({
 			success: true,
-			fileKey: metadata.fileKey,
-			filename: metadata.filename,
-			fileSize: metadata.fileSize,
+			fileKey: metadata.file_key,
+			filename: metadata.file_name,
+			fileSize: metadata.file_size,
 		});
 	} catch (_error) {
 		return c.json({ error: "Failed to generate download URL" }, 500);

--- a/src/routes/rag.ts
+++ b/src/routes/rag.ts
@@ -124,11 +124,13 @@ export async function handleProcessFileForRag(c: ContextWithAuth) {
 						userAuth.username
 					);
 					if (fileRecord) {
-						await notifyFileUploadCompleteWithData(
-							c.env,
-							userAuth.username,
-							fileRecord
-						);
+						await notifyFileUploadCompleteWithData(c.env, userAuth.username, {
+							...fileRecord,
+							status: fileRecord.status ?? "uploaded",
+							tags: fileRecord.tags
+								? (JSON.parse(fileRecord.tags) as string[])
+								: [],
+						});
 					} else {
 					}
 					await notifyIndexingCompleted(c.env, userAuth.username, filename);
@@ -208,7 +210,10 @@ export async function handleTriggerIndexing(c: ContextWithAuth) {
 			FileDAO.STATUS.SYNCING,
 			FileDAO.STATUS.INDEXING,
 		];
-		if (inProgressStatuses.includes(file.status)) {
+		if (
+			file.status &&
+			(inProgressStatuses as readonly string[]).includes(file.status)
+		) {
 			return c.json(
 				{
 					success: false,

--- a/src/routes/upload-notifications.ts
+++ b/src/routes/upload-notifications.ts
@@ -34,13 +34,19 @@ export async function sendUploadCompleteNotifications(
 			status: fileRecord.status,
 		});
 
+		const fileData = {
+			...fileRecord,
+			status: fileRecord.status ?? "uploaded",
+			tags: fileRecord.tags ? (JSON.parse(fileRecord.tags) as string[]) : [],
+		};
+
 		// Send file updated notification
-		notifyFileUpdated(env, userId, fileRecord).catch((error) => {
+		notifyFileUpdated(env, userId, fileData).catch((error) => {
 			log.error("File updated notification failed", error);
 		});
 
 		// Send upload complete notification
-		notifyFileUploadCompleteWithData(env, userId, fileRecord).catch((error) => {
+		notifyFileUploadCompleteWithData(env, userId, fileData).catch((error) => {
 			log.error("Upload complete notification failed", error);
 		});
 	} else {

--- a/src/types/campaign.ts
+++ b/src/types/campaign.ts
@@ -2,6 +2,55 @@
 
 export type ResourceType = "file" | "character" | "note" | "image";
 
+/** Database row shape for campaigns table (snake_case) */
+export interface CampaignRow {
+	id: string;
+	name: string;
+	username: string;
+	description?: string;
+	campaignRagBasePath?: string;
+	metadata?: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+/** Database row shape for campaign_resources table (snake_case) */
+export interface CampaignResourceRow {
+	id: string;
+	campaign_id: string;
+	file_key: string;
+	file_name: string;
+	display_name?: string;
+	description?: string;
+	tags?: string;
+	status: string;
+	created_at: string;
+	updated_at?: string;
+}
+
+/** Map CampaignRow to camelCase (for consumers that need it) */
+export function mapCampaignRow(row: CampaignRow): {
+	id: string;
+	name: string;
+	username: string;
+	description?: string;
+	campaignRagBasePath?: string;
+	metadata?: string | null;
+	createdAt: string;
+	updatedAt: string;
+} {
+	return {
+		id: row.id,
+		name: row.name,
+		username: row.username,
+		description: row.description,
+		campaignRagBasePath: row.campaignRagBasePath,
+		metadata: row.metadata,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
 export interface CampaignResource {
 	type: ResourceType;
 	id: string;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -144,7 +144,7 @@ export interface ActionButton {
 /**
  * Table column configuration
  */
-export interface TableColumn<T = any> {
+export interface TableColumn<T = unknown> {
 	key: string;
 	label: string;
 	render?: (item: T) => ReactNode;
@@ -156,7 +156,7 @@ export interface TableColumn<T = any> {
 /**
  * Table configuration
  */
-export interface TableConfig<T = any> {
+export interface TableConfig<T = unknown> {
 	columns: TableColumn<T>[];
 	data: T[];
 	loading?: boolean;

--- a/src/types/shard.ts
+++ b/src/types/shard.ts
@@ -13,7 +13,9 @@ import type { StructuredEntityType } from "@/lib/entity/entity-types";
 export type ShardStatus = "staging" | "approved" | "rejected" | "deleted";
 
 /**
- * Shard metadata containing file and source information
+ * Shard metadata containing file and source information.
+ * The index signature [key: string]: unknown allows extensions (e.g. from AI extraction).
+ * Use Record<string, unknown> for arbitrary extras; known fields are typed above.
  */
 export interface ShardMetadata {
 	fileKey: string;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared type utilities for stricter typing across the codebase.
+ */
+
+/** SQL bind parameters for D1 (string, number, null, boolean). Use null, not undefined, for SQL NULL. */
+export type SqlParam = string | number | null | boolean;
+
+/** Params passed to query/execute; undefined is converted to null when binding. Mutable for building. */
+export type SqlParams = (SqlParam | undefined)[];
+
+/** Params accepted by base-dao (readonly for input) */
+export type SqlParamsInput = readonly (SqlParam | undefined)[];
+
+/** Extract DAO methods for mocking (pick only function properties) */
+export type DaoMethods<T> = Pick<
+	T,
+	Extract<
+		{
+			[K in keyof T]: T[K] extends (...args: never[]) => unknown ? K : never;
+		}[keyof T],
+		keyof T
+	>
+>;
+
+/** Discriminated API result (alternative to ApiResponse) */
+export type Result<T, E = string> =
+	| { ok: true; data: T }
+	| { ok: false; error: E };

--- a/tests/dao/campaign-dao.test.ts
+++ b/tests/dao/campaign-dao.test.ts
@@ -35,7 +35,7 @@ describe("CampaignDAO", () => {
 			"My Campaign",
 			"user1",
 			"A great game",
-			undefined
+			null
 		);
 		expect(mockStmt.run).toHaveBeenCalled();
 	});


### PR DESCRIPTION
- Add SqlParam, SqlParams, SqlParamsInput to src/types/utils.ts
- Update BaseDAOClass: typed params, undefined->null for D1, T=unknown default
- Replace params: any[] with SqlParam[] across all DAOs
- Add EntityDAORead interface; AssessmentDAO uses it instead of any
- Unify Campaign types: CampaignRow, CampaignResourceRow in types/campaign.ts
- Add EnvWithDb; type getDAOFactory(env: EnvWithDb | unknown)
- FileDAO: explicit return types, FileMetadata.status, Env for checkFileIndexingStatus
- Add DaoMethods, Result to utils; tighten common/shard types
- Fix library.ts snake_case; notification handlers for FileMetadata tags
- Update campaign-dao test for undefined->null param conversion

Made-with: Cursor