### PR TITLE
chore(e2e): apply Playwright audit – selectors, page objects, flakiness

### DIFF
--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -18,7 +18,7 @@ npm run test:coverage
 
 ### E2E tests (Playwright)
 
-End-to-end tests cover auth, campaign management, file upload, AI chat, and billing flows.
+End-to-end tests cover auth, campaign management, file upload, AI chat, and billing flows. Tests use a page object model (`tests/e2e/pages/`) and semantic selectors (`data-testid`, `getByRole`) for stability.
 
 ```bash
 # First time: install browsers
@@ -29,6 +29,9 @@ npm run test:e2e
 
 # UI mode for debugging
 npm run test:e2e:ui
+
+# Burn-in run (repeat each test 10x) to surface flakiness before merge
+npm run test:e2e:repeat
 ```
 
 ## Test data factories
@@ -202,6 +205,8 @@ These tests are designed to drive the implementation of campaign features:
 - **Auth**: Sign in with seeded user `e2e-test-user` (password: `e2e-test-password`)
 - **Chat**: Mocks `/api/agents/*` to avoid AI API costs
 - **CI**: Runs in GitHub Actions; Playwright report and test results uploaded on failure
+- **Page objects**: `tests/e2e/pages/` – AppShellPage, CreateCampaignModal, LoginPage, UploadModal
+- **Flakiness**: Tests that pass on retry are logged as `FLAKY` in the output
 
 ## Future Enhancements
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",
 		"test:e2e:headed": "playwright test --headed",
+		"test:e2e:repeat": "playwright test --repeat-each=10",
 		"e2e:server": "VITE_API_URL=http://localhost:8787 npm run build && E2E_SEED_USER=1 ./scripts/e2e-db-setup.sh && wrangler dev --config wrangler.local.jsonc --port 8787 --local",
 		"types": "wrangler types",
 		"format": "biome check --write .",

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -79,7 +79,10 @@ export function AppShell() {
 				}}
 			/>
 			<div className="h-dvh w-full p-0 sm:p-4 md:p-6 flex justify-center items-center bg-fixed">
-				<div className="h-full sm:h-[calc(100dvh-2rem)] md:h-[calc(100dvh-3rem)] w-full mx-auto max-w-[var(--width-container-xl)] flex flex-col shadow-2xl rounded-none sm:rounded-2xl relative border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-950 overflow-hidden">
+				<div
+					className="h-full sm:h-[calc(100dvh-2rem)] md:h-[calc(100dvh-3rem)] w-full mx-auto max-w-[var(--width-container-xl)] flex flex-col shadow-2xl rounded-none sm:rounded-2xl relative border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-950 overflow-hidden"
+					data-testid="app-main"
+				>
 					<AppHeader
 						onToggleSidebar={ctx.onToggleSidebar}
 						isSidebarOpen={ctx.isSidebarOpen}

--- a/src/components/billing/BillingPage.tsx
+++ b/src/components/billing/BillingPage.tsx
@@ -288,7 +288,10 @@ export function BillingPage({ onBack }: BillingPageProps) {
 	const isPaid = status.tier !== "free";
 
 	return (
-		<div className="min-h-screen p-6 bg-neutral-50 dark:bg-neutral-950">
+		<div
+			className="min-h-screen p-6 bg-neutral-50 dark:bg-neutral-950"
+			data-testid="billing-page"
+		>
 			<div className="max-w-2xl mx-auto">
 				<div className="flex items-center gap-4 mb-8">
 					{onBack && (

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,35 +1,27 @@
-import { expect, test } from "@playwright/test";
 import { E2E_PASSWORD, E2E_USERNAME, loginAsE2EUser } from "./helpers/auth";
+import { expect, test } from "./lib/test";
+import { AppShellPage } from "./pages/app-shell.page";
+import { LoginPage } from "./pages/login.page";
 
 test.describe("auth flow", () => {
 	test("sign in with seeded user", async ({ page }) => {
-		await page.goto("/");
-		await expect(
-			page.getByRole("button", { name: /sign in|sign up/i }).first()
-		).toBeVisible({ timeout: 10_000 });
+		const loginPage = new LoginPage(page);
+		const appShell = new AppShellPage(page);
 
-		await page
-			.getByRole("button", { name: /sign in/i })
-			.first()
-			.click();
-
-		await page.getByLabel(/username/i).fill(E2E_USERNAME);
-		await page.getByLabel(/^password/i).fill(E2E_PASSWORD);
-		await page.getByRole("button", { name: /sign in/i }).click();
+		await loginPage.goto();
+		await loginPage.openAuthButton.click();
+		await loginPage.login(E2E_USERNAME, E2E_PASSWORD);
 
 		await expect(
 			page.getByRole("button", { name: /sign in|sign up/i })
-		).not.toBeVisible({ timeout: 5000 });
+		).not.toBeVisible({ timeout: 10_000 });
 
-		await expect(
-			page.locator(".tour-campaign-selector, .tour-campaigns-section").first()
-		).toBeVisible({ timeout: 5000 });
+		await appShell.waitForReady();
 	});
 
 	test("auth helper sets JWT and app shows main UI", async ({ page }) => {
 		await loginAsE2EUser(page);
-		await expect(
-			page.locator(".tour-campaign-selector, .tour-campaigns-section").first()
-		).toBeVisible({ timeout: 10_000 });
+		const appShell = new AppShellPage(page);
+		await appShell.waitForReady();
 	});
 });

--- a/tests/e2e/billing.spec.ts
+++ b/tests/e2e/billing.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "@playwright/test";
 import { loginAsE2EUser } from "./helpers/auth";
+import { expect, test } from "./lib/test";
 
 test.describe("billing", () => {
 	test("billing page loads when authenticated", async ({ page }) => {
@@ -7,8 +7,8 @@ test.describe("billing", () => {
 
 		await page.goto("/billing");
 
-		await expect(
-			page.getByText(/billing|usage|plan|free|subscription/i).first()
-		).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByTestId("billing-page")).toBeVisible({
+			timeout: 10_000,
+		});
 	});
 });

--- a/tests/e2e/campaign.spec.ts
+++ b/tests/e2e/campaign.spec.ts
@@ -1,5 +1,8 @@
-import { expect, test } from "@playwright/test";
 import { loginAsE2EUser } from "./helpers/auth";
+import { uniqueCampaignName } from "./helpers/test-utils";
+import { expect, test } from "./lib/test";
+import { AppShellPage } from "./pages/app-shell.page";
+import { CreateCampaignModal } from "./pages/create-campaign-modal.page";
 
 test.describe("campaign management", () => {
 	test.beforeEach(async ({ page }) => {
@@ -7,54 +10,27 @@ test.describe("campaign management", () => {
 	});
 
 	test("create campaign", async ({ page }) => {
-		await expect(
-			page.locator(".tour-campaign-selector, .tour-campaigns-section").first()
-		).toBeVisible({ timeout: 10_000 });
+		const appShell = new AppShellPage(page);
+		const createModal = new CreateCampaignModal(page);
+		const campaignName = uniqueCampaignName("E2E Test Campaign");
 
-		await page
-			.getByRole("button", {
-				name: /create your first campaign|create campaign/i,
-			})
-			.first()
-			.click();
+		await appShell.waitForReady();
+		await appShell.createCampaignButton.click();
 
-		await page.getByLabel("Campaign name").fill("E2E Test Campaign");
-		await Promise.all([
-			page.waitForResponse(
-				(resp) =>
-					resp.url().includes("/api/campaigns") &&
-					resp.request().method() === "POST" &&
-					resp.status() === 201
-			),
-			page.getByTestId("create-campaign-submit").click(),
-		]);
+		await createModal.createCampaign(campaignName, { waitForApi: true });
 
 		await expect(
-			page.getByRole("button", { name: /E2E Test Campaign/ }).first()
+			page.getByRole("button", { name: new RegExp(campaignName) }).first()
 		).toBeVisible({ timeout: 10_000 });
 	});
 
 	test("edit campaign", async ({ page }) => {
-		await expect(page.locator(".tour-campaigns-section").first()).toBeVisible({
-			timeout: 10_000,
-		});
+		const appShell = new AppShellPage(page);
+		const createModal = new CreateCampaignModal(page);
 
-		await page
-			.getByRole("button", {
-				name: /create your first campaign|create campaign/i,
-			})
-			.first()
-			.click();
-		await page.getByLabel("Campaign name").fill("Original Name");
-		await Promise.all([
-			page.waitForResponse(
-				(resp) =>
-					resp.url().includes("/api/campaigns") &&
-					resp.request().method() === "POST" &&
-					resp.status() === 201
-			),
-			page.getByTestId("create-campaign-submit").click(),
-		]);
+		await appShell.waitForReady();
+		await appShell.createCampaignButton.click();
+		await createModal.createCampaign("Original Name", { waitForApi: true });
 
 		await page.getByRole("button", { name: "Done" }).click();
 		await expect(
@@ -66,35 +42,21 @@ test.describe("campaign management", () => {
 			.click();
 
 		await page.getByRole("button", { name: "Edit" }).click();
-		await page.getByLabel("Campaign name").fill("Edited Name");
+		await createModal.fillName("Edited Name");
 		await page.getByRole("button", { name: "Save" }).click();
 
 		await expect(
 			page.getByRole("button", { name: /Edited Name/ }).first()
-		).toBeVisible({ timeout: 5000 });
+		).toBeVisible({ timeout: 10_000 });
 	});
 
 	test("delete campaign", async ({ page }) => {
-		await expect(page.locator(".tour-campaigns-section").first()).toBeVisible({
-			timeout: 10_000,
-		});
+		const appShell = new AppShellPage(page);
+		const createModal = new CreateCampaignModal(page);
 
-		await page
-			.getByRole("button", {
-				name: /create your first campaign|create campaign/i,
-			})
-			.first()
-			.click();
-		await page.getByLabel("Campaign name").fill("To Delete");
-		await Promise.all([
-			page.waitForResponse(
-				(resp) =>
-					resp.url().includes("/api/campaigns") &&
-					resp.request().method() === "POST" &&
-					resp.status() === 201
-			),
-			page.getByTestId("create-campaign-submit").click(),
-		]);
+		await appShell.waitForReady();
+		await appShell.createCampaignButton.click();
+		await createModal.createCampaign("To Delete", { waitForApi: true });
 
 		await page.getByRole("button", { name: "Done" }).click();
 		await expect(

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -1,6 +1,7 @@
-import { expect, test } from "@playwright/test";
 import { loginAsE2EUser } from "./helpers/auth";
 import { createMockChatStreamBody } from "./helpers/mock-chat-stream";
+import { expect, test } from "./lib/test";
+import { AppShellPage } from "./pages/app-shell.page";
 
 const MOCK_RESPONSE = "Hello from E2E mock";
 
@@ -24,9 +25,8 @@ test.describe("AI chat", () => {
 			return route.continue();
 		});
 
-		await expect(
-			page.locator(".tour-campaign-selector, .tour-campaigns-section").first()
-		).toBeVisible({ timeout: 10_000 });
+		const appShell = new AppShellPage(page);
+		await appShell.waitForReady();
 
 		const textarea = page
 			.getByRole("textbox", { name: /message|prompt/i })

--- a/tests/e2e/fixtures/authenticated.fixture.ts
+++ b/tests/e2e/fixtures/authenticated.fixture.ts
@@ -1,0 +1,17 @@
+import { loginAsE2EUser } from "../helpers/auth";
+import { test as base, expect } from "../lib/test";
+import { AppShellPage } from "../pages/app-shell.page";
+
+type AuthFixtures = {
+	appShell: AppShellPage;
+};
+
+/** Extended test with authenticated app shell (loginAsE2EUser runs before each test). */
+export const test = base.extend<AuthFixtures>({
+	appShell: async ({ page }, use) => {
+		await loginAsE2EUser(page);
+		await use(new AppShellPage(page));
+	},
+});
+
+export { expect };

--- a/tests/e2e/helpers/test-utils.ts
+++ b/tests/e2e/helpers/test-utils.ts
@@ -1,0 +1,4 @@
+/** Generate a unique campaign name for E2E tests to avoid collisions when running in parallel. */
+export function uniqueCampaignName(prefix: string): string {
+	return `${prefix}-${Date.now()}`;
+}

--- a/tests/e2e/lib/test.ts
+++ b/tests/e2e/lib/test.ts
@@ -4,7 +4,7 @@ import { test as base, expect } from "@playwright/test";
  * Log when a test passes on retry (flaky test detection).
  * Helps identify tests that need stabilization.
  */
-base.afterEach(async (_fixtures, testInfo) => {
+base.afterEach(async ({ page: _ }, testInfo) => {
 	if (testInfo.retry > 0 && testInfo.status === "passed") {
 		console.warn(
 			`FLAKY: ${testInfo.titlePath.join(" > ")} passed on retry ${testInfo.retry}`

--- a/tests/e2e/lib/test.ts
+++ b/tests/e2e/lib/test.ts
@@ -1,0 +1,16 @@
+import { test as base, expect } from "@playwright/test";
+
+/**
+ * Log when a test passes on retry (flaky test detection).
+ * Helps identify tests that need stabilization.
+ */
+base.afterEach(async (_fixtures, testInfo) => {
+	if (testInfo.retry > 0 && testInfo.status === "passed") {
+		console.warn(
+			`FLAKY: ${testInfo.titlePath.join(" > ")} passed on retry ${testInfo.retry}`
+		);
+	}
+});
+
+export const test = base;
+export { expect };

--- a/tests/e2e/pages/app-shell.page.ts
+++ b/tests/e2e/pages/app-shell.page.ts
@@ -1,0 +1,22 @@
+import type { Page } from "@playwright/test";
+
+/** Page object for the main app shell (post-login UI with campaigns and chat). */
+export class AppShellPage {
+	constructor(readonly page: Page) {}
+
+	/** Wait for the main app UI to be visible after login. */
+	async waitForReady(timeout = 10_000): Promise<void> {
+		await this.page
+			.getByTestId("app-main")
+			.waitFor({ state: "visible", timeout });
+	}
+
+	/** Button to create a new campaign (Create campaign / Create your first campaign). */
+	get createCampaignButton() {
+		return this.page
+			.getByRole("button", {
+				name: /create your first campaign|create campaign/i,
+			})
+			.first();
+	}
+}

--- a/tests/e2e/pages/create-campaign-modal.page.ts
+++ b/tests/e2e/pages/create-campaign-modal.page.ts
@@ -1,0 +1,43 @@
+import type { Page } from "@playwright/test";
+
+/** Page object for the create campaign modal. */
+export class CreateCampaignModal {
+	constructor(readonly page: Page) {}
+
+	get campaignNameInput() {
+		return this.page.getByLabel("Campaign name");
+	}
+
+	get submitButton() {
+		return this.page.getByTestId("create-campaign-submit");
+	}
+
+	async fillName(name: string): Promise<void> {
+		await this.campaignNameInput.fill(name);
+	}
+
+	async submit(): Promise<void> {
+		await this.submitButton.click();
+	}
+
+	/** Fill name and submit, optionally waiting for the API response. */
+	async createCampaign(
+		name: string,
+		options?: { waitForApi?: boolean }
+	): Promise<void> {
+		await this.fillName(name);
+		if (options?.waitForApi) {
+			await Promise.all([
+				this.page.waitForResponse(
+					(resp) =>
+						resp.url().includes("/api/campaigns") &&
+						resp.request().method() === "POST" &&
+						resp.status() === 201
+				),
+				this.submit(),
+			]);
+		} else {
+			await this.submit();
+		}
+	}
+}

--- a/tests/e2e/pages/login.page.ts
+++ b/tests/e2e/pages/login.page.ts
@@ -1,0 +1,42 @@
+import type { Page } from "@playwright/test";
+
+/** Page object for the login form (auth modal or sign-in page). */
+export class LoginPage {
+	constructor(readonly page: Page) {}
+
+	/** Button to open the auth modal (Sign in / Sign up in header). */
+	get openAuthButton() {
+		return this.page.getByRole("button", { name: /sign in|sign up/i }).first();
+	}
+
+	/** Sign in button inside the auth modal. */
+	get submitButton() {
+		return this.page.getByRole("button", { name: /sign in/i });
+	}
+
+	get usernameInput() {
+		return this.page.getByLabel(/username/i);
+	}
+
+	get passwordInput() {
+		return this.page.getByLabel(/^password/i);
+	}
+
+	/** Wait for the sign in / sign up button to be visible (auth UI loaded). */
+	async waitForAuthUI(timeout = 10_000): Promise<void> {
+		await this.openAuthButton.waitFor({ state: "visible", timeout });
+	}
+
+	/** Fill credentials and sign in. Assumes auth modal is already open. */
+	async login(username: string, password: string): Promise<void> {
+		await this.usernameInput.fill(username);
+		await this.passwordInput.fill(password);
+		await this.submitButton.click();
+	}
+
+	/** Navigate to root and wait for auth UI. */
+	async goto(baseURL = "http://localhost:8787"): Promise<void> {
+		await this.page.goto(baseURL);
+		await this.waitForAuthUI();
+	}
+}

--- a/tests/e2e/pages/upload-modal.page.ts
+++ b/tests/e2e/pages/upload-modal.page.ts
@@ -1,0 +1,42 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Page object for the file upload modal. */
+export class UploadModal {
+	constructor(readonly page: Page) {}
+
+	get chooseFilesInput() {
+		return this.page.getByLabel("Choose files to upload");
+	}
+
+	get uploadButton() {
+		return this.page.getByRole("button", { name: /^Upload$/ });
+	}
+
+	get librarySectionButton() {
+		return this.page.getByRole("button", { name: /your resource library/i });
+	}
+
+	/** Upload a file and wait for the PUT request to complete. */
+	async uploadFile(filePath: string): Promise<void> {
+		await this.chooseFilesInput.setInputFiles(filePath);
+		await Promise.all([
+			this.page.waitForResponse(
+				(resp) =>
+					resp.url().includes("/api/upload/direct/") &&
+					resp.request().method() === "PUT" &&
+					resp.status() >= 200 &&
+					resp.status() < 400
+			),
+			this.uploadButton.click(),
+		]);
+	}
+
+	/** Path to the sample.txt fixture. */
+	static get sampleFilePath(): string {
+		return path.join(__dirname, "..", "fixtures", "sample.txt");
+	}
+}

--- a/tests/e2e/upload.spec.ts
+++ b/tests/e2e/upload.spec.ts
@@ -1,10 +1,7 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { expect, test } from "@playwright/test";
 import { loginAsE2EUser } from "./helpers/auth";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const samplePath = path.join(__dirname, "fixtures", "sample.txt");
+import { expect, test } from "./lib/test";
+import { AppShellPage } from "./pages/app-shell.page";
+import { UploadModal } from "./pages/upload-modal.page";
 
 test.describe("file upload", () => {
 	test.beforeEach(async ({ page }) => {
@@ -12,30 +9,17 @@ test.describe("file upload", () => {
 	});
 
 	test("upload small file and see it in library", async ({ page }) => {
-		await expect(
-			page.locator(".tour-campaign-selector, .tour-campaigns-section").first()
-		).toBeVisible({ timeout: 10_000 });
+		const appShell = new AppShellPage(page);
+		const uploadModal = new UploadModal(page);
 
+		await appShell.waitForReady();
 		await page.getByRole("button", { name: /build your library/i }).click();
 
-		const fileInput = page.getByLabel("Choose files to upload");
-		await fileInput.setInputFiles(samplePath);
-
-		// Wait specifically for the upload PUT to succeed (not an earlier GET /api/library/files)
-		await Promise.all([
-			page.waitForResponse(
-				(resp) =>
-					resp.url().includes("/api/upload/direct/") &&
-					resp.request().method() === "PUT" &&
-					resp.status() >= 200 &&
-					resp.status() < 400
-			),
-			page.getByRole("button", { name: /^Upload$/ }).click(),
-		]);
+		await uploadModal.uploadFile(UploadModal.sampleFilePath);
 
 		// Modal closes on success; file appears in sidebar library (collapsed by default).
 		// Expand the library section so the file list is visible.
-		await page.getByRole("button", { name: /your resource library/i }).click();
+		await uploadModal.librarySectionButton.click();
 
 		// Wait for FILE_UPLOAD.COMPLETED to trigger fetchResources and for the file to render
 		await expect(page.getByText("sample.txt")).toBeVisible({


### PR DESCRIPTION
Phase 1 – Selector fixes:
- Add data-testid="app-main" to AppShell, data-testid="billing-page" to BillingPage
- Replace CSS selectors (.tour-*) with getByTestId
- Standardize timeouts (10s UI, 20s uploads)

Phase 2 – Page objects:
- Add AppShellPage, CreateCampaignModal, LoginPage, UploadModal
- Add authenticated fixture
- Refactor specs to use page objects

Phase 3 – Flakiness hardening:
- Add uniqueCampaignName() for create campaign test
- Add lib/test with afterEach flaky-detection logging
- Add test:e2e:repeat script (--repeat-each=10)

Update TESTING_GUIDE with page objects and burn-in docs

Made-with: Cursor