### PR TITLE
feat: drag and drop on resources

### DIFF
--- a/src/components/app/AppModals.tsx
+++ b/src/components/app/AppModals.tsx
@@ -353,6 +353,7 @@ export function AppModals({
 				className="modal-size-lg"
 			>
 				<ResourceUpload
+					initialFiles={modalState.addResourceInitialFiles}
 					onValidationError={(title, message) =>
 						addLocalNotification(NOTIFICATION_TYPES.ERROR, title, message)
 					}

--- a/src/components/resource-side-panel/LibrarySection.tsx
+++ b/src/components/resource-side-panel/LibrarySection.tsx
@@ -1,5 +1,5 @@
 import { Plus } from "@phosphor-icons/react";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import libraryIcon from "@/assets/library.png";
 import { CollapsibleCard } from "@/components/collapsible/CollapsibleCard";
 import { ActionQueueUI } from "@/components/queue/ActionQueueUI";
@@ -12,13 +12,14 @@ import type { ResourceFileWithCampaigns } from "@/hooks/useResourceFiles";
 import { useResourceFiles } from "@/hooks/useResourceFiles";
 import { APP_EVENT_TYPE } from "@/lib/app-events";
 import { buildStagingFileKey } from "@/lib/file/file-utils";
+import { cn } from "@/lib/utils";
 import { AuthService, getStoredJwt } from "@/services/core/auth-service";
 import type { Campaign } from "@/types/campaign";
 
 interface LibrarySectionProps {
 	isOpen: boolean;
 	onToggle: () => void;
-	onAddToLibrary: () => void;
+	onAddToLibrary: (initialFiles?: File[]) => void;
 	onAddToCampaign?: (file: ResourceFileWithCampaigns) => void;
 	onEditFile?: (file: ResourceFileWithCampaigns) => void;
 	campaigns?: Campaign[];
@@ -166,83 +167,133 @@ export function LibrarySection({
 		return [...queuedEntries, ...files];
 	}, [files, uploadQueue?.queue]);
 
+	const fileDragDepthRef = useRef(0);
+	const [isFileDragOver, setIsFileDragOver] = useState(false);
+
+	const handleLibraryDragEnter = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		if (!Array.from(e.dataTransfer.types).includes("Files")) return;
+		fileDragDepthRef.current += 1;
+		setIsFileDragOver(true);
+	}, []);
+
+	const handleLibraryDragLeave = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		fileDragDepthRef.current = Math.max(0, fileDragDepthRef.current - 1);
+		if (fileDragDepthRef.current === 0) {
+			setIsFileDragOver(false);
+		}
+	}, []);
+
+	const handleLibraryDragOver = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		if (Array.from(e.dataTransfer.types).includes("Files")) {
+			e.dataTransfer.dropEffect = "copy";
+		}
+	}, []);
+
+	const handleLibraryDrop = useCallback(
+		(e: React.DragEvent) => {
+			e.preventDefault();
+			fileDragDepthRef.current = 0;
+			setIsFileDragOver(false);
+			const files = Array.from(e.dataTransfer.files);
+			if (files.length === 0) return;
+			onAddToLibrary(files);
+		},
+		[onAddToLibrary]
+	);
+
 	return (
-		<CollapsibleCard
-			header={
-				<>
-					<img
-						src={libraryIcon}
-						alt="Library"
-						className="w-8 h-8"
-						width={32}
-						height={32}
-					/>
-					<span className="font-medium text-sm">Your resource library</span>
-				</>
-			}
-			headerSupplement={
-				processingCount > 0 ? (
-					<span
-						className="text-xs px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
-						title={`${processingCount} file${processingCount === 1 ? "" : "s"} preparing`}
-					>
-						{processingCount} preparing
-					</span>
-				) : undefined
-			}
-			isOpen={isOpen}
-			onToggle={onToggle}
-			tourClassName="tour-library-section"
-			className="border-t border-neutral-200 dark:border-neutral-700"
+		<section
+			aria-label="Your resource library"
+			className={cn(
+				"rounded-lg transition-shadow",
+				isFileDragOver &&
+					"ring-2 ring-blue-500/40 dark:ring-blue-400/35 ring-offset-2 ring-offset-neutral-50 dark:ring-offset-neutral-900"
+			)}
+			onDragEnter={handleLibraryDragEnter}
+			onDragLeave={handleLibraryDragLeave}
+			onDragOver={handleLibraryDragOver}
+			onDrop={handleLibraryDrop}
 		>
-			<div className="flex flex-col">
-				<div className="flex-shrink-0 p-2">
-					<button
-						type="button"
-						onClick={onAddToLibrary}
-						className="w-full px-2 py-1.5 bg-neutral-200 dark:bg-neutral-700 text-blue-600 dark:text-blue-400 rounded hover:bg-neutral-300 dark:hover:bg-neutral-600 transition-colors flex items-center justify-center gap-2 text-sm"
-					>
-						<Plus size={14} />
-						Add to library
-					</button>
-				</div>
-				<div className="border-t border-neutral-200 dark:border-neutral-700 flex flex-col">
-					<div className="max-h-64 overflow-y-auto">
-						<ResourceList
-							files={displayFiles}
-							setFiles={setFiles}
-							loading={loading}
-							error={error}
-							setError={setError}
-							setLoading={setLoading}
-							fetchResources={fetchResources}
-							onAddToCampaign={onAddToCampaign}
-							onEditFile={onEditFile}
-							onOpenAddToLibrary={onAddToLibrary}
-							campaigns={campaigns}
-							campaignAdditionProgress={campaignAdditionProgress}
-							_isAddingToCampaigns={isAddingToCampaigns}
+			<CollapsibleCard
+				header={
+					<>
+						<img
+							src={libraryIcon}
+							alt="Library"
+							className="w-8 h-8"
+							width={32}
+							height={32}
 						/>
+						<span className="font-medium text-sm">Your resource library</span>
+					</>
+				}
+				headerSupplement={
+					processingCount > 0 ? (
+						<span
+							className="text-xs px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
+							title={`${processingCount} file${processingCount === 1 ? "" : "s"} preparing`}
+						>
+							{processingCount} preparing
+						</span>
+					) : undefined
+				}
+				isOpen={isOpen}
+				onToggle={onToggle}
+				tourClassName="tour-library-section"
+				className="border-t border-neutral-200 dark:border-neutral-700"
+			>
+				<div className="flex flex-col">
+					<div className="flex-shrink-0 p-2">
+						<button
+							type="button"
+							onClick={() => onAddToLibrary()}
+							className="w-full px-2 py-1.5 bg-neutral-200 dark:bg-neutral-700 text-blue-600 dark:text-blue-400 rounded hover:bg-neutral-300 dark:hover:bg-neutral-600 transition-colors flex items-center justify-center gap-2 text-sm"
+						>
+							<Plus size={14} />
+							Add to library
+						</button>
 					</div>
-					<div className="flex-shrink-0">
-						<StorageTracker />
-						{uploadQueue && uploadQueue.queuedCount > 0 && (
-							<div className="px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 border-t border-neutral-200 dark:border-neutral-700">
-								{uploadQueue.queuedCount} file
-								{uploadQueue.queuedCount === 1 ? "" : "s"} queued – retrying
-								when capacity is available
-							</div>
-						)}
-						<ActionQueueUI />
-						{addLocalNotification && onShowUsageLimits && (
-							<RateLimitIndicator
-								addLocalNotification={addLocalNotification}
-								onShowUsageLimits={onShowUsageLimits}
+					<div className="border-t border-neutral-200 dark:border-neutral-700 flex flex-col">
+						<div className="max-h-64 overflow-y-auto">
+							<ResourceList
+								files={displayFiles}
+								setFiles={setFiles}
+								loading={loading}
+								error={error}
+								setError={setError}
+								setLoading={setLoading}
+								fetchResources={fetchResources}
+								onAddToCampaign={onAddToCampaign}
+								onEditFile={onEditFile}
+								onOpenAddToLibrary={onAddToLibrary}
+								campaigns={campaigns}
+								campaignAdditionProgress={campaignAdditionProgress}
+								_isAddingToCampaigns={isAddingToCampaigns}
 							/>
-						)}
+						</div>
+						<div className="flex-shrink-0">
+							<StorageTracker />
+							{uploadQueue && uploadQueue.queuedCount > 0 && (
+								<div className="px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 border-t border-neutral-200 dark:border-neutral-700">
+									{uploadQueue.queuedCount} file
+									{uploadQueue.queuedCount === 1 ? "" : "s"} queued – retrying
+									when capacity is available
+								</div>
+							)}
+							<ActionQueueUI />
+							{addLocalNotification && onShowUsageLimits && (
+								<RateLimitIndicator
+									addLocalNotification={addLocalNotification}
+									onShowUsageLimits={onShowUsageLimits}
+								/>
+							)}
+						</div>
 					</div>
 				</div>
-			</div>
-		</CollapsibleCard>
+			</CollapsibleCard>
+		</section>
 	);
 }

--- a/src/components/resource-side-panel/ResourceSidePanel.tsx
+++ b/src/components/resource-side-panel/ResourceSidePanel.tsx
@@ -21,7 +21,7 @@ interface ResourceSidePanelProps {
 	onFileUploadTriggered?: () => void;
 	onCreateCampaign?: () => void;
 	onCampaignClick?: (campaign: Campaign) => void;
-	onAddResource?: () => void;
+	onAddResource?: (initialFiles?: File[]) => void;
 	onAddToCampaign?: (file: ResourceFileWithCampaigns) => void;
 	onEditFile?: (file: ResourceFileWithCampaigns) => void;
 	campaignAdditionProgress?: Record<string, number>;

--- a/src/components/upload/ResourceUpload.tsx
+++ b/src/components/upload/ResourceUpload.tsx
@@ -1,5 +1,5 @@
 import { Plus } from "@phosphor-icons/react";
-import { useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { UPLOAD_CONFIG } from "@/app-constants";
 import { FormButton } from "@/components/button/FormButton";
 import { ProcessingProgressBar } from "@/components/progress/ProcessingProgressBar";
@@ -35,6 +35,45 @@ export type OnUploadLimitReached = (
 /** Callback for validation errors (file size, unsupported type); use for toast/inline feedback */
 export type OnValidationError = (title: string, message: string) => void;
 
+/** Shared validation for picker, drag-and-drop, and initial files from the sidebar */
+export function validateResourceUploadFiles(
+	files: File[],
+	onValidationError?: OnValidationError
+): File[] {
+	const allowedExtensions =
+		/\.(pdf|txt|doc|docx|md|mdx|json|jpg|jpeg|png|webp)$/i;
+	const typeValidFiles = files.filter((file) => {
+		const byMime =
+			file.type === "application/pdf" ||
+			file.type === "text/plain" ||
+			file.type === "text/markdown" ||
+			file.type === "text/x-markdown" ||
+			file.type === "application/msword" ||
+			file.type ===
+				"application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+			file.type === "application/json" ||
+			file.type === "image/jpeg" ||
+			file.type === "image/jpg" ||
+			file.type === "image/png" ||
+			file.type === "image/webp";
+		const byExt = allowedExtensions.test(file.name);
+		return byMime || byExt;
+	});
+
+	return typeValidFiles.filter((file) => {
+		if (file.size > UPLOAD_CONFIG.MAX_FILE_SIZE) {
+			const maxSizeMB = UPLOAD_CONFIG.MAX_FILE_SIZE / (1024 * 1024);
+			const fileSizeMB = file.size / (1024 * 1024);
+			onValidationError?.(
+				"File too large",
+				`"${file.name}" is too large (${fileSizeMB.toFixed(2)}MB). Maximum file size is ${maxSizeMB}MB.`
+			);
+			return false;
+		}
+		return true;
+	});
+}
+
 interface ResourceUploadProps {
 	onUpload: (
 		file: File,
@@ -58,6 +97,8 @@ interface ResourceUploadProps {
 	onCreateCampaign?: () => void;
 	showCampaignSelection?: boolean;
 	onUploadLimitReached?: OnUploadLimitReached;
+	/** When set (e.g. from sidebar drag-and-drop), applied into the picker; cleared when the modal closes */
+	initialFiles?: File[] | null;
 }
 
 export const ResourceUpload = ({
@@ -76,12 +117,37 @@ export const ResourceUpload = ({
 	onCreateCampaign,
 	showCampaignSelection = false,
 	onUploadLimitReached,
+	initialFiles = null,
 }: ResourceUploadProps) => {
 	const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
 	const [_isValid, setIsValid] = useState(false);
 	const [uploadSuccess, setUploadSuccess] = useState(false);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const fileInputId = useId();
+	const onValidationErrorRef = useRef(onValidationError);
+	onValidationErrorRef.current = onValidationError;
+
+	useEffect(() => {
+		if (initialFiles == null || initialFiles.length === 0) return;
+
+		const notify = onValidationErrorRef.current;
+		const validFiles = validateResourceUploadFiles([...initialFiles], notify);
+		if (initialFiles.length > 0 && validFiles.length === 0) {
+			notify?.(
+				"Unsupported file type",
+				"Allowed: PDF, TXT, DOC, DOCX, MD, MDX, JSON, JPG, JPEG, PNG, WEBP."
+			);
+		}
+		if (validFiles.length > 0) {
+			setSelectedFiles(validFiles);
+			setIsValid(true);
+			setUploadSuccess(false);
+		} else {
+			setSelectedFiles([]);
+			setIsValid(false);
+			setUploadSuccess(false);
+		}
+	}, [initialFiles]);
 
 	// Show progress bar if upload is in progress
 	if (uploadProgress) {
@@ -92,46 +158,8 @@ export const ResourceUpload = ({
 		);
 	}
 
-	// Helper function to validate and filter files
-	const validateAndFilterFiles = (files: File[]): File[] => {
-		// Filter by file type (must match RAG-supported types: FileExtractionService + file-upload-security ALLOWED_EXTENSIONS)
-		const allowedExtensions =
-			/\.(pdf|txt|doc|docx|md|mdx|json|jpg|jpeg|png|webp)$/i;
-		const typeValidFiles = files.filter((file) => {
-			const byMime =
-				file.type === "application/pdf" ||
-				file.type === "text/plain" ||
-				file.type === "text/markdown" ||
-				file.type === "text/x-markdown" ||
-				file.type === "application/msword" ||
-				file.type ===
-					"application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
-				file.type === "application/json" ||
-				file.type === "image/jpeg" ||
-				file.type === "image/jpg" ||
-				file.type === "image/png" ||
-				file.type === "image/webp";
-			// Fallback: some browsers use generic MIME for .md/.mdx/.json or images
-			const byExt = allowedExtensions.test(file.name);
-			return byMime || byExt;
-		});
-
-		// Filter by file size (use app constant; large files use multipart and are processed in chunks)
-		const validFiles = typeValidFiles.filter((file) => {
-			if (file.size > UPLOAD_CONFIG.MAX_FILE_SIZE) {
-				const maxSizeMB = UPLOAD_CONFIG.MAX_FILE_SIZE / (1024 * 1024);
-				const fileSizeMB = file.size / (1024 * 1024);
-				onValidationError?.(
-					"File too large",
-					`"${file.name}" is too large (${fileSizeMB.toFixed(2)}MB). Maximum file size is ${maxSizeMB}MB.`
-				);
-				return false;
-			}
-			return true;
-		});
-
-		return validFiles;
-	};
+	const validateAndFilterFiles = (files: File[]): File[] =>
+		validateResourceUploadFiles(files, onValidationError);
 
 	// Helper function to set selected files state
 	const setSelectedFilesState = (validFiles: File[]) => {

--- a/src/contexts/AppShellContext.tsx
+++ b/src/contexts/AppShellContext.tsx
@@ -74,7 +74,7 @@ export interface AppShellContextValue {
 	addLocalNotification: (type: string, title: string, message: string) => void;
 
 	// Resource / file
-	onAddResource: () => void;
+	onAddResource: (initialFiles?: File[]) => void;
 	onAddToCampaign: (file: ResourceFileWithCampaigns) => void;
 	addFileToCampaigns: ReturnType<
 		typeof useAppOrchestration
@@ -330,6 +330,17 @@ export function AppShellProvider({ children }: AppShellProviderProps) {
 		[setTriggerFileUpload]
 	);
 
+	const onAddResource = useCallback(
+		(initialFiles?: File[]) => {
+			if (initialFiles?.length) {
+				modalState.handleAddResourceWithDroppedFiles(initialFiles);
+			} else {
+				modalState.handleAddResource();
+			}
+		},
+		[modalState.handleAddResource, modalState.handleAddResourceWithDroppedFiles]
+	);
+
 	// biome-ignore lint/correctness/useExhaustiveDependencies: invisibleUserContentsRef.current intentionally excluded; invisibleUserContentsVersion triggers updates when ref changes
 	const value = useMemo<AppShellContextValue>(
 		() => ({
@@ -356,7 +367,7 @@ export function AppShellProvider({ children }: AppShellProviderProps) {
 			dismissNotification,
 			clearAllNotifications,
 			addLocalNotification,
-			onAddResource: modalState.handleAddResource,
+			onAddResource,
 			onAddToCampaign: modalState.handleAddToCampaign,
 			addFileToCampaigns,
 			onEditFile: modalState.handleEditFile,
@@ -430,7 +441,7 @@ export function AppShellProvider({ children }: AppShellProviderProps) {
 			dismissNotification,
 			clearAllNotifications,
 			addLocalNotification,
-			modalState.handleAddResource,
+			onAddResource,
 			modalState.handleAddToCampaign,
 			addFileToCampaigns,
 			modalState.handleEditFile,

--- a/src/hooks/useModalState.ts
+++ b/src/hooks/useModalState.ts
@@ -23,6 +23,9 @@ export function useModalState() {
 	const [isCampaignDetailsModalOpen, setIsCampaignDetailsModalOpen] =
 		useState(false);
 	const [isAddResourceModalOpen, setIsAddResourceModalOpen] = useState(false);
+	const [addResourceInitialFiles, setAddResourceInitialFiles] = useState<
+		File[] | null
+	>(null);
 	const [isAddToCampaignModalOpen, setIsAddToCampaignModalOpen] =
 		useState(false);
 	const [isEditFileModalOpen, setIsEditFileModalOpen] = useState(false);
@@ -80,11 +83,18 @@ export function useModalState() {
 	}, []);
 
 	const handleAddResource = useCallback(() => {
+		setAddResourceInitialFiles(null);
+		setIsAddResourceModalOpen(true);
+	}, []);
+
+	const handleAddResourceWithDroppedFiles = useCallback((files: File[]) => {
+		setAddResourceInitialFiles(Array.from(files));
 		setIsAddResourceModalOpen(true);
 	}, []);
 
 	const handleAddResourceClose = useCallback(() => {
 		setIsAddResourceModalOpen(false);
+		setAddResourceInitialFiles(null);
 		setSelectedCampaigns([]);
 	}, []);
 
@@ -182,6 +192,7 @@ export function useModalState() {
 		isCampaignDetailsModalOpen,
 		isAddResourceModalOpen,
 		setIsAddResourceModalOpen,
+		addResourceInitialFiles,
 		isAddToCampaignModalOpen,
 		isEditFileModalOpen,
 		isAdminDashboardModalOpen,
@@ -223,6 +234,7 @@ export function useModalState() {
 		handleCampaignClick,
 		handleCampaignDetailsClose,
 		handleAddResource,
+		handleAddResourceWithDroppedFiles,
 		handleAddResourceClose,
 		handleAddToCampaign,
 		handleAddToCampaignClose,

--- a/tests/hooks/useModalState.test.ts
+++ b/tests/hooks/useModalState.test.ts
@@ -50,6 +50,23 @@ describe("useModalState", () => {
 		expect(result.current.isAddResourceModalOpen).toBe(true);
 	});
 
+	it("handleAddResourceWithDroppedFiles opens modal and sets initial files", () => {
+		const { result } = renderHook(() => useModalState());
+		const file = new File(["x"], "note.md", { type: "text/markdown" });
+		act(() => result.current.handleAddResourceWithDroppedFiles([file]));
+		expect(result.current.isAddResourceModalOpen).toBe(true);
+		expect(result.current.addResourceInitialFiles).toEqual([file]);
+	});
+
+	it("handleAddResource clears staged initial files", () => {
+		const { result } = renderHook(() => useModalState());
+		const file = new File(["x"], "note.md", { type: "text/markdown" });
+		act(() => result.current.handleAddResourceWithDroppedFiles([file]));
+		act(() => result.current.handleAddResource());
+		expect(result.current.addResourceInitialFiles).toBeNull();
+		expect(result.current.isAddResourceModalOpen).toBe(true);
+	});
+
 	it("handleAddResourceClose clears selected campaigns", () => {
 		const { result } = renderHook(() => useModalState());
 		act(() => result.current.handleAddResource());
@@ -57,6 +74,7 @@ describe("useModalState", () => {
 		act(() => result.current.handleAddResourceClose());
 		expect(result.current.isAddResourceModalOpen).toBe(false);
 		expect(result.current.selectedCampaigns).toEqual([]);
+		expect(result.current.addResourceInitialFiles).toBeNull();
 	});
 
 	it("handleAdminDashboardOpen and handleAdminDashboardClose", () => {


### PR DESCRIPTION
# PR: Library sidebar drag-and-drop opens Add resource with files

## Title suggestion

`feat: open Add resource from library drag-and-drop with files preloaded`

## Summary

Dropping supported files onto **Your resource library** in the sidebar (expanded or collapsed) opens the **Add resource** modal and loads those files into the upload picker, using the same validation as the in-modal flow.

## Motivation

Fewer steps when adding files from the OS file manager: users do not need to click **Add to library** and drop again inside the modal.

## Changes (by area)

| Area | Change |
|------|--------|
| `LibrarySection` | `<section>` drop target with drag enter/leave/over/drop, depth counter to reduce highlight flicker, blue ring while dragging files |
| `useModalState` | `addResourceInitialFiles`, `handleAddResourceWithDroppedFiles`; clear staged files on normal open and on close |
| `AppShellContext` | `onAddResource(initialFiles?: File[])` dispatches to dropped-file vs empty open |
| `ResourceSidePanel` | Prop type accepts optional `File[]` |
| `AppModals` | Passes `initialFiles` into `ResourceUpload` |
| `ResourceUpload` | `initialFiles` effect (before `uploadProgress` early return); exported `validateResourceUploadFiles`; ref for validation callback |

## How to test manually

1. Collapse **Your resource library**, drag a `.pdf` onto the header row, release → modal opens with file listed.
2. Expand the section, drag a valid file onto the file list area → same.
3. Drag an unsupported type → modal opens; expect unsupported-type feedback and empty selection (same rules as modal drop zone).
4. Click **Add to library** without drag → modal opens empty.
5. Open via drag, close without uploading, open again via button → empty modal.

## Automated tests

- `tests/hooks/useModalState.test.ts` — staged files, clear on normal open, clear on close

---

## Code review

### What works well

1. **Single validation path** — `validateResourceUploadFiles` keeps sidebar → modal behavior aligned with the picker and avoids silent divergence from server-allowed types.

2. **Modal lifecycle** — Staging `File[]` in `useModalState` and clearing it in `handleAddResource`, `handleAddResourceClose`, and the dropped-files path avoids leaking stale blobs across opens. `Modal` returns `null` when closed, so `ResourceUpload` remounts and local selection resets naturally.

3. **Rules of hooks** — The `initialFiles` `useEffect` sits **before** the `uploadProgress` early return, so hook order is stable when switching into the progress UI.

4. **`onValidationError` ref** — Parent often passes an inline notifier; using a ref prevents the initial-files effect from re-firing every render and wiping in-progress selection.

5. **Drag UX** — Depth counting on `dragenter` / `dragleave` is a standard way to avoid flicker when moving across nested nodes.

6. **Semantics** — Using `<section aria-label="Your resource library">` satisfies linting better than a naked interactive `div`.

### Suggestions (non-blocking)

1. **Drag exit edge case** — If the pointer leaves the window mid-drag, some browsers do not always emit a balanced `dragleave` sequence; `isFileDragOver` could rarely stick `true` until the next drag. Low impact; a `window` `dragleave` or `drop` listener could reset depth if this shows up in QA.

2. **Partial drops** — A multi-file drop with mix of valid and invalid files keeps only valid ones (same as existing modal drop). Users are not told which names were dropped but rejected; acceptable parity, but a future toast like “2 of 3 files added” would improve clarity.

3. **Keyboard / AT** — Drag-and-drop is pointer-centric; **Add to library** remains the accessible path. Optional follow-up: short hint text (e.g. in help or empty state) that files can be dropped on the library section.

4. **`onAddResource` dependency array** — `useCallback` depends on `modalState.handleAddResource` and `modalState.handleAddResourceWithDroppedFiles`. If `modalState` is ever recreated each render without stable handlers, this callback would churn; worth confirming `useModalState` (or orchestration) keeps those references stable (current implementation uses `useCallback` with empty deps — good).

### Security / correctness

- Client-side checks mirror existing upload UI; **authoritative validation remains on the server**, which is appropriate.

### Verdict

**Approve** — Implementation is coherent, test-backed for modal state, and consistent with existing upload validation. Optional polish items above are incremental, not merge blockers.
