### PR TITLE
Derive user LLM rate limits from Anthropic org budget and concurrency

### DIFF
--- a/docs/LIMITS.md
+++ b/docs/LIMITS.md
@@ -31,13 +31,13 @@ Purchased one-off credits add directly to your daily and hourly token limits. If
 
 ## Subscription tiers
 
-Defined in `SUBSCRIPTION_TIERS` in `src/app-constants.ts`:
+**TPH / QPH / TPD / QPD** are computed in `src/config/anthropic-org-rate-budget.ts` from Anthropic org limits (Console) and `expectedConcurrentActiveUsers`, then merged into `SUBSCRIPTION_TIERS` in `src/app-constants.ts`. Other columns are static in `SUBSCRIPTION_TIERS`.
 
-| Tier | Max campaigns | Max files | Storage | TPH | QPH | TPD | QPD | Trial tokens | Resources/campaign/hour | Retries/file/day | Retries/file/month |
-|------|---------------|-----------|---------|-----|-----|-----|-----|--------------|-------------------------|------------------|--------------------|
-| Free | 1 | 5 | 25 MB | 120k | 300 | 10k | 50 | 150k (one-time) | 5 | 2 | 6 |
-| Basic | 5 | 25 | 1 GB | 600k | 600 | 500k | 500 | — | 20 | 3 | 15 |
-| Pro | 999,999 | 100 | 5 GB | 1.2M | 1,200 | 1M | 1,000 | — | 50 | 5 | 50 |
+| Tier | Max campaigns | Max files | Storage | TPH / QPH / TPD / QPD | Trial tokens | Resources/campaign/hour | Retries/file/day | Retries/file/month |
+|------|---------------|-----------|---------|------------------------|--------------|-------------------------|------------------|--------------------|
+| Free | 1 | 5 | 25 MB | Derived (fraction of Basic) | 150k (one-time) | 5 | 2 | 6 |
+| Basic | 5 | 25 | 1 GB | Derived (org share ÷ concurrent users) | — | 20 | 3 | 15 |
+| Pro | 999,999 | 100 | 5 GB | Derived (2× Basic rates) | — | 50 | 5 | 50 |
 
 - **TPH** = tokens per hour  
 - **QPH** = queries per hour  
@@ -56,14 +56,14 @@ Defined in `SUBSCRIPTION_TIERS` in `src/app-constants.ts`:
 
 ## Fallback rate limits
 
-Non-admin users, when tier limits are unavailable (e.g. in usage modals), use `RATE_LIMITS` as fallbacks:
+Non-admin users, when tier limits are unavailable (e.g. in usage modals), use `RATE_LIMITS` as fallbacks (matches **Basic** tier derived values):
 
 | Limit | Value |
 |-------|-------|
-| TPH | 600,000 |
-| QPH | 600 |
-| TPD | 500,000 |
-| QPD | 500 |
+| TPH | Same as Basic `tph` from org budget |
+| QPH | Same as Basic `qph` |
+| TPD | Same as Basic `tpd` |
+| QPD | Same as Basic `qpd` |
 | Resources per campaign per hour | 20 |
 
 ## Where limits are enforced

--- a/src/app-constants.ts
+++ b/src/app-constants.ts
@@ -3,6 +3,8 @@
  * This file contains all shared constants used throughout the application
  */
 
+import { deriveSubscriptionTierRates } from "@/config/anthropic-org-rate-budget";
+
 // Re-export from shared-config.ts for convenience
 export {
 	API_CONFIG,
@@ -324,15 +326,17 @@ export function getGenerationModelForProvider(
 		: MODEL_CONFIG.OPENAI[tier];
 }
 
+/** Per-tier tph/qph/tpd/qpd derived from Anthropic org limits; see `src/config/anthropic-org-rate-budget.ts`. */
+const DERIVED_SUBSCRIPTION_RATES = deriveSubscriptionTierRates();
+
 // Rate limits for non-admin users (admin users bypass all limits).
-// Fallback when tier limits unavailable (e.g. UsageLimitsModal). Tuning per deployment: adjust
-// SUBSCRIPTION_TIERS tph/qph/tpd/qpd and resourcesPerCampaignPerHour (see LLMRateLimitService).
+// Fallback when tier limits unavailable (e.g. UsageLimitsModal). Aligns with Basic tier from org budget.
 export const RATE_LIMITS = {
-	NON_ADMIN_TPH: 600_000, // 10k/min * 60 = tokens per hour
-	NON_ADMIN_QPH: 600, // 10/min * 60 = queries per hour (Basic tier fallback)
-	NON_ADMIN_TPD: 500_000,
-	NON_ADMIN_QPD: 500,
-	RESOURCES_PER_CAMPAIGN_PER_HOUR: 20, // Basic tier fallback
+	NON_ADMIN_TPH: DERIVED_SUBSCRIPTION_RATES.basic.tph,
+	NON_ADMIN_QPH: DERIVED_SUBSCRIPTION_RATES.basic.qph,
+	NON_ADMIN_TPD: DERIVED_SUBSCRIPTION_RATES.basic.tpd,
+	NON_ADMIN_QPD: DERIVED_SUBSCRIPTION_RATES.basic.qpd,
+	RESOURCES_PER_CAMPAIGN_PER_HOUR: 20, // Basic tier static cap (see SUBSCRIPTION_TIERS.basic)
 } as const;
 
 export type SubscriptionTier = "free" | "basic" | "pro";
@@ -362,10 +366,7 @@ export const SUBSCRIPTION_TIERS: Record<SubscriptionTier, TierLimits> = {
 		maxCampaigns: 1,
 		maxFiles: 5,
 		storageBytes: 25 * 1024 * 1024, // 25MB
-		tph: 120_000,
-		qph: 300,
-		tpd: 10_000,
-		qpd: 50,
+		...DERIVED_SUBSCRIPTION_RATES.free,
 		lifetimeTokens: 150_000, // One-time trial capacity; no monthly reset
 		retriesPerFilePerDay: 2,
 		retriesPerFilePerMonth: 6,
@@ -375,10 +376,7 @@ export const SUBSCRIPTION_TIERS: Record<SubscriptionTier, TierLimits> = {
 		maxCampaigns: 5,
 		maxFiles: 25,
 		storageBytes: 1 * 1024 * 1024 * 1024, // 1GB
-		tph: 600_000, // was 10k/min * 60
-		qph: 600, // 10/min * 60 = queries per hour
-		tpd: 500_000,
-		qpd: 500,
+		...DERIVED_SUBSCRIPTION_RATES.basic,
 		retriesPerFilePerDay: 3,
 		retriesPerFilePerMonth: 15,
 		resourcesPerCampaignPerHour: 20,
@@ -387,10 +385,7 @@ export const SUBSCRIPTION_TIERS: Record<SubscriptionTier, TierLimits> = {
 		maxCampaigns: 999_999, // effectively unlimited
 		maxFiles: 100,
 		storageBytes: 5 * 1024 * 1024 * 1024, // 5GB
-		tph: 1_200_000, // was 20k/min * 60
-		qph: 1_200, // 20/min * 60 = queries per hour
-		tpd: 1_000_000,
-		qpd: 1_000,
+		...DERIVED_SUBSCRIPTION_RATES.pro,
 		retriesPerFilePerDay: 5,
 		retriesPerFilePerMonth: 50,
 		resourcesPerCampaignPerHour: 50,

--- a/src/config/anthropic-org-rate-budget.ts
+++ b/src/config/anthropic-org-rate-budget.ts
@@ -1,0 +1,119 @@
+/**
+ * Anthropic API org capacity → LoreSmith per-user rate limits.
+ *
+ * Update `ANTHROPIC_ORG_LIMITS` when your Console “Limits” page changes (tier, model rows).
+ * Tune `ORG_RATE_BUDGET_ASSUMPTIONS` for expected peak concurrency and safety margin.
+ *
+ * Derived limits split **input** token budget (ITPM) and **request** budget (RPM) across
+ * `expectedConcurrentActiveUsers`. Basic tier receives that share; Pro is 2× Basic (historic
+ * product ratio); Free uses fixed fractions of Basic for trial pacing.
+ *
+ * Non-rate fields (campaign/file caps, storage, retries, resources/hour) stay in `app-constants.ts`.
+ */
+
+/** Values from Anthropic Console → Organization → Limits (example: Tier 4). */
+export const ANTHROPIC_ORG_LIMITS = {
+	/** Sonnet / Opus row (same RPM & token ceilings in Console). */
+	primary: {
+		requestsPerMinute: 4_000,
+		inputTokensPerMinute: 2_000_000,
+		outputTokensPerMinute: 400_000,
+	},
+	opus: {
+		requestsPerMinute: 4_000,
+		inputTokensPerMinute: 2_000_000,
+		outputTokensPerMinute: 400_000,
+	},
+	/** Haiku row — informational; enforcement below uses `primary` unless you switch. */
+	haiku: {
+		requestsPerMinute: 4_000,
+		inputTokensPerMinute: 4_000_000,
+		outputTokensPerMinute: 800_000,
+	},
+	batchRequestsPerMinute: 4_000,
+} as const;
+
+/**
+ * Which org row drives **input token** and **request** budgets for `deriveSubscriptionTierRates`.
+ * Change to `"haiku"` if your app is dominated by Haiku and you want to size from that column.
+ */
+export const ORG_LIMIT_ROW_FOR_ENFORCEMENT: "primary" | "haiku" = "primary";
+
+export const ORG_RATE_BUDGET_ASSUMPTIONS = {
+	/**
+	 * Expected **simultaneously active** users (chat + indexing + background jobs attributed to users).
+	 * Higher N → smaller per-user share of org TPM/RPM.
+	 */
+	expectedConcurrentActiveUsers: 20,
+
+	/**
+	 * Fraction of org capacity reserved for burst, retries, admin, and non-user traffic (0–1).
+	 * e.g. 0.85 leaves 15% headroom below Anthropic’s hard ceiling.
+	 */
+	headroom: 0.85,
+} as const;
+
+export interface TierRateLimits {
+	tph: number;
+	qph: number;
+	tpd: number;
+	qpd: number;
+}
+
+function pickOrgRow() {
+	return ORG_LIMIT_ROW_FOR_ENFORCEMENT === "haiku"
+		? ANTHROPIC_ORG_LIMITS.haiku
+		: ANTHROPIC_ORG_LIMITS.primary;
+}
+
+/**
+ * Computes per-tier hourly/daily token and query caps from org limits and concurrency assumptions.
+ * Basic = fair share of org RPM/ITPM; Pro = 2× Basic; Free = trial-style fractions of Basic.
+ */
+export function deriveSubscriptionTierRates(): {
+	free: TierRateLimits;
+	basic: TierRateLimits;
+	pro: TierRateLimits;
+} {
+	const row = pickOrgRow();
+	const n = Math.max(
+		1,
+		Math.floor(ORG_RATE_BUDGET_ASSUMPTIONS.expectedConcurrentActiveUsers)
+	);
+	const headroom = ORG_RATE_BUDGET_ASSUMPTIONS.headroom;
+
+	const inputTokensPerHourOrg = row.inputTokensPerMinute * 60;
+	const requestsPerHourOrg = row.requestsPerMinute * 60;
+
+	const baseTph = Math.floor((inputTokensPerHourOrg * headroom) / n);
+	const baseQph = Math.floor((requestsPerHourOrg * headroom) / n);
+
+	/** Historic Basic ratio: daily cap was 5/6 of “one hour at max tph” for tokens and queries. */
+	const tpdBasic = Math.floor(baseTph * (500_000 / 600_000));
+	const qpdBasic = Math.floor(baseQph * (500 / 600));
+
+	const basic: TierRateLimits = {
+		tph: baseTph,
+		qph: baseQph,
+		tpd: tpdBasic,
+		qpd: qpdBasic,
+	};
+
+	/** Historic Free vs Basic: tph 20%, qph 50%; tpd/qpd small fractions of Basic daily caps. */
+	const free: TierRateLimits = {
+		tph: Math.floor(baseTph * 0.2),
+		qph: Math.floor(baseQph * 0.5),
+		tpd: Math.max(1_000, Math.floor(tpdBasic * 0.02)),
+		qpd: Math.max(10, Math.floor(qpdBasic * 0.1)),
+	};
+
+	/** Historic Pro = 2× Basic on all four rate limits. */
+	const pro: TierRateLimits = {
+		tph: baseTph * 2,
+		qph: baseQph * 2,
+		tpd: tpdBasic * 2,
+		qpd: qpdBasic * 2,
+	};
+
+	return { free, basic, pro };
+}

--- a/tests/config/anthropic-org-rate-budget.test.ts
+++ b/tests/config/anthropic-org-rate-budget.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { deriveSubscriptionTierRates } from "@/config/anthropic-org-rate-budget";
+
+describe("deriveSubscriptionTierRates", () => {
+	it("keeps Pro at 2× Basic on rate limits", () => {
+		const { free, basic, pro } = deriveSubscriptionTierRates();
+		expect(pro.tph).toBe(basic.tph * 2);
+		expect(pro.qph).toBe(basic.qph * 2);
+		expect(pro.tpd).toBe(basic.tpd * 2);
+		expect(pro.qpd).toBe(basic.qpd * 2);
+		expect(free.tph).toBeLessThan(basic.tph);
+		expect(free.qph).toBeLessThan(basic.qph);
+	});
+
+	it("produces positive limits", () => {
+		const { basic } = deriveSubscriptionTierRates();
+		expect(basic.tph).toBeGreaterThan(0);
+		expect(basic.qph).toBeGreaterThan(0);
+		expect(basic.tpd).toBeGreaterThan(0);
+		expect(basic.qpd).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
Add anthropic-org-rate-budget.ts with Console-style org caps, headroom, and expected concurrent users; compute Basic/Free/Pro tph/qph/tpd/qpd and wire SUBSCRIPTION_TIERS and RATE_LIMITS. Document derived limits in LIMITS.md and add unit tests for tier ratios.

Made-with: Cursor