### PR TITLE
fix(ci): invoke wrangler via npx in D1 bootstrap scripts

### DIFF
--- a/scripts/d1-bootstrap.sh
+++ b/scripts/d1-bootstrap.sh
@@ -25,11 +25,12 @@ fi
 
 echo "Running D1 bootstrap for $ENV ($DB_NAME)..."
 
+# npx: CI runs this script directly; node_modules/.bin is not on PATH unless via npm.
 # Main schema (tables, indexes, view)
-wrangler d1 execute "$DB_NAME" --config "$CONFIG" --remote --file="$SCRIPT_DIR/d1-bootstrap.sql"
+npx wrangler d1 execute "$DB_NAME" --config "$CONFIG" --remote --file="$SCRIPT_DIR/d1-bootstrap.sql"
 
 # Triggers (run via --command to avoid D1 semicolon-splitting issues)
-wrangler d1 execute "$DB_NAME" --config "$CONFIG" --remote --command="CREATE TRIGGER IF NOT EXISTS update_shard_registry_timestamp AFTER UPDATE ON shard_registry FOR EACH ROW BEGIN UPDATE shard_registry SET updated_at = datetime('now') WHERE shard_id = new.shard_id; END"
-wrangler d1 execute "$DB_NAME" --config "$CONFIG" --remote --command="CREATE TRIGGER IF NOT EXISTS trigger_entity_relationships_updated_at AFTER UPDATE ON entity_relationships FOR EACH ROW BEGIN UPDATE entity_relationships SET updated_at = current_timestamp WHERE id = new.id; END"
+npx wrangler d1 execute "$DB_NAME" --config "$CONFIG" --remote --command="CREATE TRIGGER IF NOT EXISTS update_shard_registry_timestamp AFTER UPDATE ON shard_registry FOR EACH ROW BEGIN UPDATE shard_registry SET updated_at = datetime('now') WHERE shard_id = new.shard_id; END"
+npx wrangler d1 execute "$DB_NAME" --config "$CONFIG" --remote --command="CREATE TRIGGER IF NOT EXISTS trigger_entity_relationships_updated_at AFTER UPDATE ON entity_relationships FOR EACH ROW BEGIN UPDATE entity_relationships SET updated_at = current_timestamp WHERE id = new.id; END"
 
 echo "Bootstrap complete. Run 'npm run migrate:dev' (or migrate:prod) to apply incremental migrations."

--- a/scripts/e2e-db-setup.sh
+++ b/scripts/e2e-db-setup.sh
@@ -11,13 +11,13 @@ DB_NAME="loresmith-db-dev"
 CONFIG="wrangler.local.jsonc"
 
 echo "[e2e-db] Running D1 bootstrap (local)..."
-wrangler d1 execute "$DB_NAME" --config "$CONFIG" --local \
+npx wrangler d1 execute "$DB_NAME" --config "$CONFIG" --local \
   --file="$SCRIPT_DIR/d1-bootstrap.sql"
 
 echo "[e2e-db] Running D1 migrations (local)..."
 for f in migrations/*.sql; do
   [ -f "$f" ] || continue
-  wrangler d1 execute "$DB_NAME" --config "$CONFIG" --local \
+  npx wrangler d1 execute "$DB_NAME" --config "$CONFIG" --local \
     --file="$f" || true
 done
 
@@ -26,7 +26,7 @@ if [ "$E2E_SEED_USER" = "1" ]; then
   E2E_SEED_USER=1 npx tsx scripts/seed-e2e-user.ts
 
   echo "[e2e-db] Cleaning E2E user data for fresh test state..."
-  wrangler d1 execute "$DB_NAME" --config "$CONFIG" --local \
+  npx wrangler d1 execute "$DB_NAME" --config "$CONFIG" --local \
     --file="$SCRIPT_DIR/e2e-cleanup.sql"
 fi
 


### PR DESCRIPTION
Deploy runs d1-bootstrap.sh outside npm scripts, so bare wrangler was not on PATH. Use npx wrangler consistently with e2e-db-setup for local D1.

Made-with: Cursor