### PR TITLE
ci(deploy): document Cloudflare secrets and set env per job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,29 +4,35 @@ on:
   push:
     branches: [main]
 
-# Required for deploy:
-#   CLOUDFLARE_API_TOKEN — repository secret; API token with Workers + D1 (and bindings you use)
-#   CLOUDFLARE_ACCOUNT_ID — repository secret or variable (account ID from Cloudflare dashboard)
-# Optional: environment-scoped secrets with the same names.
-env:
-  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
-
+# Cloudflare credentials (wrangler deploy / D1 migrations):
+#
+# 1) Repository secrets (typical): Settings → Secrets and variables → Actions
+#    - CLOUDFLARE_API_TOKEN   (Create API Token: Workers, D1, etc.)
+#    - CLOUDFLARE_ACCOUNT_ID  (can be a Variables → Actions variable instead)
+#
+# 2) If you store these only on a GitHub Environment, add to each job below:
+#      environment: <environment-name>
+#    so `secrets.*` resolves. Workflow-level secrets are NOT visible without it.
+#
+# 3) Fork PRs: secrets are not available; deploy only runs on push to main on this repo.
 jobs:
   deploy-dev:
     name: Deploy to staging (loresmith-ai-dev)
     runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Verify Cloudflare credentials
         run: |
           if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
-            echo "::error title=Missing secret::CLOUDFLARE_API_TOKEN is not set. Add it under Repository secrets (or the deploy environment). See https://developers.cloudflare.com/fundamentals/api/get-started/create-token/"
+            echo "::error title=Missing secret::CLOUDFLARE_API_TOKEN is empty. Add repository secret CLOUDFLARE_API_TOKEN (Actions secrets), or add \`environment: <name>\` to this job if the token lives only in a GitHub Environment. Token docs: https://developers.cloudflare.com/fundamentals/api/get-started/create-token/"
             exit 1
           fi
           if [ -z "${CLOUDFLARE_ACCOUNT_ID}" ]; then
-            echo "::error title=Missing config::CLOUDFLARE_ACCOUNT_ID is not set. Add repository secret or variable CLOUDFLARE_ACCOUNT_ID."
+            echo "::error title=Missing config::CLOUDFLARE_ACCOUNT_ID is empty. Add secret or Variables → Actions variable CLOUDFLARE_ACCOUNT_ID, or use an Environment with \`environment:\` on this job."
             exit 1
           fi
 
@@ -54,17 +60,20 @@ jobs:
     name: Deploy to production (loresmith-ai)
     runs-on: ubuntu-latest
     needs: deploy-dev
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Verify Cloudflare credentials
         run: |
           if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
-            echo "::error title=Missing secret::CLOUDFLARE_API_TOKEN is not set. Add it under Repository secrets."
+            echo "::error title=Missing secret::CLOUDFLARE_API_TOKEN is empty. Add repository secret CLOUDFLARE_API_TOKEN, or \`environment:\` on this job if the token is only on a GitHub Environment."
             exit 1
           fi
           if [ -z "${CLOUDFLARE_ACCOUNT_ID}" ]; then
-            echo "::error title=Missing config::CLOUDFLARE_ACCOUNT_ID is not set. Add repository secret or variable CLOUDFLARE_ACCOUNT_ID."
+            echo "::error title=Missing config::CLOUDFLARE_ACCOUNT_ID is empty. Add secret or Actions variable CLOUDFLARE_ACCOUNT_ID, or use an Environment with \`environment:\` on this job."
             exit 1
           fi
 


### PR DESCRIPTION
Clarify repository vs GitHub Environment secrets in workflow comments. Move CLOUDFLARE_* env onto each deploy job and improve credential check errors.

Made-with: Cursor