### PR TITLE
fix(entity-extraction): preserve PROGRESS across rate limits and stuc…

### DIFF
--- a/src/dao/entity-extraction-queue-dao.ts
+++ b/src/dao/entity-extraction-queue-dao.ts
@@ -1,3 +1,4 @@
+import { queueMessageWithProgress } from "@/lib/entity-extraction-progress";
 import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
 
@@ -460,6 +461,11 @@ export class EntityExtractionQueueDAO extends BaseDAOClass {
 		id: number,
 		errorMessage: string
 	): Promise<void> {
+		const row = await this.getQueueItemById(id);
+		const message = queueMessageWithProgress(
+			row?.queue_message ?? null,
+			errorMessage
+		);
 		const sql = `
       UPDATE entity_extraction_queue
       SET status = 'pending',
@@ -468,6 +474,6 @@ export class EntityExtractionQueueDAO extends BaseDAOClass {
           updated_at = CURRENT_TIMESTAMP
       WHERE id = ?
     `;
-		await this.execute(sql, [errorMessage, id]);
+		await this.execute(sql, [message, id]);
 	}
 }

--- a/src/lib/entity-extraction-progress.ts
+++ b/src/lib/entity-extraction-progress.ts
@@ -1,15 +1,18 @@
+/** First PROGRESS line wins (progress may be prefixed before error/rate-limit text). */
+const PROGRESS_IN_MESSAGE = /PROGRESS:(\d+)\/(\d+)/;
+
 /**
- * Parses a `PROGRESS:processed/total` checkpoint string from `queue_message`
+ * Parses a `PROGRESS:processed/total` checkpoint from `queue_message`
  * on `entity_extraction_queue` (also used for failures and rate-limit notes).
  * `processed` is cumulative chunks finished for the resource (resume cursor / bar),
  * not “chunks done in the current worker invocation only”.
- * Same pattern as `parseProgressMarker` in `entity-extraction-queue-service.ts`.
+ * Matches the first `PROGRESS:a/b` in the string so the line can sit before other text.
  */
 export function parseEntityExtractionProgress(
 	value: string | null | undefined
 ): { processed: number; total: number } | null {
 	if (!value) return null;
-	const match = /^PROGRESS:(\d+)\/(\d+)$/.exec(value.trim());
+	const match = PROGRESS_IN_MESSAGE.exec(value);
 	if (!match) return null;
 	const processed = Number.parseInt(match[1], 10);
 	const total = Number.parseInt(match[2], 10);
@@ -22,6 +25,21 @@ export function parseEntityExtractionProgress(
 		return null;
 	}
 	return { processed, total };
+}
+
+/**
+ * Keep resume + UI progress when appending a rate-limit or timeout message.
+ */
+export function queueMessageWithProgress(
+	previousQueueMessage: string | null | undefined,
+	detail: string
+): string {
+	const prev = parseEntityExtractionProgress(previousQueueMessage);
+	const body = detail.trim();
+	if (!prev) return body;
+	const line = `PROGRESS:${prev.processed}/${prev.total}`;
+	if (!body) return line;
+	return `${line}\n${body}`;
 }
 
 /** Integer percent indexed (processed chunks / total chunks), capped at 100. */

--- a/src/services/campaign/entity-extraction-queue-service.ts
+++ b/src/services/campaign/entity-extraction-queue-service.ts
@@ -8,6 +8,10 @@ import {
 	type EntityExtractionQueueItem,
 } from "@/dao/entity-extraction-queue-dao";
 import { TelemetryDAO } from "@/dao/telemetry-dao";
+import {
+	parseEntityExtractionProgress,
+	queueMessageWithProgress,
+} from "@/lib/entity-extraction-progress";
 import { getEnvVar } from "@/lib/env-utils";
 import { createLogger } from "@/lib/logger";
 import type { Env } from "@/middleware/auth";
@@ -86,19 +90,16 @@ function isAuthenticationError(error: unknown): boolean {
 	);
 }
 
-function parseProgressMarker(
-	value: string | null | undefined
-): { processedChunks: number; totalChunks: number } | null {
-	if (!value) return null;
-	const match = value.match(/^PROGRESS:(\d+)\/(\d+)$/);
-	if (!match) return null;
-	const processedChunks = Number.parseInt(match[1], 10);
-	const totalChunks = Number.parseInt(match[2], 10);
-	if (!Number.isFinite(processedChunks) || !Number.isFinite(totalChunks)) {
-		return null;
-	}
-	if (processedChunks < 0 || totalChunks <= 0) return null;
-	return { processedChunks, totalChunks };
+async function buildRateLimitQueueMessage(
+	queueDAO: EntityExtractionQueueDAO,
+	item: EntityExtractionQueueItem,
+	errorMessage: string
+): Promise<string> {
+	const latest = await queueDAO.getQueueItemById(item.id);
+	return queueMessageWithProgress(
+		latest?.queue_message ?? item.queue_message,
+		errorMessage
+	);
 }
 
 export class EntityExtractionQueueService {
@@ -231,8 +232,8 @@ export class EntityExtractionQueueService {
 					);
 				}
 
-				const progress = parseProgressMarker(item.queue_message);
-				const resumeFromChunk = progress?.processedChunks ?? 0;
+				const progress = parseEntityExtractionProgress(item.queue_message);
+				const resumeFromChunk = progress?.processed ?? 0;
 
 				// Process entity extraction window (checkpointed so cron CPU limits can resume)
 				const result = await stageEntitiesFromResource({
@@ -268,7 +269,7 @@ export class EntityExtractionQueueService {
 
 				if (result.completed === false) {
 					const nextChunk = result.nextChunkIndex ?? resumeFromChunk;
-					const totalChunks = result.totalChunks ?? progress?.totalChunks ?? 0;
+					const totalChunks = result.totalChunks ?? progress?.total ?? 0;
 					await queueDAO.markAsPending(
 						item.id,
 						totalChunks > 0
@@ -357,7 +358,7 @@ export class EntityExtractionQueueService {
 							item.id,
 							currentRetryCount,
 							nextRetryAt,
-							errorMessage
+							await buildRateLimitQueueMessage(queueDAO, item, errorMessage)
 						);
 					}
 				} else {
@@ -381,7 +382,7 @@ export class EntityExtractionQueueService {
 							item.id,
 							currentRetryCount,
 							nextRetryAt,
-							errorMessage
+							await buildRateLimitQueueMessage(queueDAO, item, errorMessage)
 						);
 					}
 				}

--- a/tests/lib/entity-extraction-progress.test.ts
+++ b/tests/lib/entity-extraction-progress.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+	entityExtractionProgressPercent,
+	parseEntityExtractionProgress,
+	queueMessageWithProgress,
+} from "@/lib/entity-extraction-progress";
+
+describe("parseEntityExtractionProgress", () => {
+	it("parses a bare PROGRESS line", () => {
+		expect(parseEntityExtractionProgress("PROGRESS:9/59")).toEqual({
+			processed: 9,
+			total: 59,
+		});
+	});
+
+	it("reads the first PROGRESS when prefixed before error text", () => {
+		expect(
+			parseEntityExtractionProgress(
+				"PROGRESS:12/59\n429 Too Many Requests — retry later"
+			)
+		).toEqual({ processed: 12, total: 59 });
+	});
+
+	it("returns null when missing", () => {
+		expect(parseEntityExtractionProgress(null)).toBeNull();
+		expect(parseEntityExtractionProgress("Rate limited")).toBeNull();
+	});
+});
+
+describe("entityExtractionProgressPercent", () => {
+	it("uses embedded PROGRESS", () => {
+		expect(
+			entityExtractionProgressPercent("PROGRESS:12/59\nsome trailing detail")
+		).toBe(20);
+	});
+});
+
+describe("queueMessageWithProgress", () => {
+	it("prefixes PROGRESS when previous message had it", () => {
+		expect(
+			queueMessageWithProgress("PROGRESS:12/59", "429 Too Many Requests")
+		).toBe("PROGRESS:12/59\n429 Too Many Requests");
+	});
+
+	it("extracts PROGRESS from a prior combined message", () => {
+		expect(
+			queueMessageWithProgress("PROGRESS:12/59\nold error", "new error")
+		).toBe("PROGRESS:12/59\nnew error");
+	});
+
+	it("returns detail only when no prior PROGRESS", () => {
+		expect(queueMessageWithProgress(null, "oops")).toBe("oops");
+	});
+});


### PR DESCRIPTION
…k resets

Wiping queue_message on rate_limited or processing timeout dropped PROGRESS, so resume fell back to chunk 0 and the UI jumped backward.

- Parse first PROGRESS:a/b anywhere in queue_message
- Prefix rate-limit messages with last known PROGRESS; re-fetch row before write
- resetStuckProcessingItem merges progress from current row
- Add unit tests for progress parsing and queueMessageWithProgress

Made-with: Cursor