### PR TITLE
perf(entity-extraction): raise throughput caps for ~10 active users

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -1133,7 +1133,7 @@ export async function handleCleanupStuckEntityExtraction(c: ContextWithAuth) {
 	const log = getRequestLogger(c);
 	try {
 		const userAuth = (c as any).userAuth;
-		const timeoutMinutes = parseInt(c.req.query("timeoutMinutes") || "10", 10);
+		const timeoutMinutes = parseInt(c.req.query("timeoutMinutes") || "60", 10);
 
 		if (!userAuth) {
 			return c.json({ error: "Authentication required" }, 401);

--- a/src/services/campaign/entity-extraction-queue-service.ts
+++ b/src/services/campaign/entity-extraction-queue-service.ts
@@ -154,7 +154,7 @@ export class EntityExtractionQueueService {
 		// First, check for and reset any stuck processing items for this user
 		// (This handles cases where a job got stuck before the scheduled cleanup ran)
 		if (username) {
-			const stuckItems = await queueDAO.getStuckProcessingItems(10);
+			const stuckItems = await queueDAO.getStuckProcessingItems(60);
 			const userStuckItems = stuckItems.filter(
 				(item) => item.username === username
 			);
@@ -446,7 +446,7 @@ export class EntityExtractionQueueService {
 	 */
 	static async cleanupStuckProcessingItems(
 		env: Env,
-		timeoutMinutes: number = 10
+		timeoutMinutes: number = 60
 	): Promise<{ reset: number; items: EntityExtractionQueueItem[] }> {
 		try {
 			const queueDAO = new EntityExtractionQueueDAO(env.DB);

--- a/src/services/campaign/entity-extraction-queue-service.ts
+++ b/src/services/campaign/entity-extraction-queue-service.ts
@@ -33,7 +33,12 @@ const MAX_RETRIES = 5;
 const INITIAL_BACKOFF_MS = 2000; // 2 seconds
 const MAX_BACKOFF_MS = 300000; // 5 minutes
 const RATE_LIMIT_BACKOFF_MULTIPLIER = 2;
-const MAX_CHUNKS_PER_EXTRACTION_RUN = 3;
+
+/** Chunks processed per queue job invocation (bounded for Worker CPU / LLM cost). Tuned for ~10 concurrent active users. */
+const MAX_CHUNKS_PER_EXTRACTION_RUN = 12;
+
+/** Queue items run per cron tick across all users (each item runs up to MAX_CHUNKS_PER_EXTRACTION_RUN chunks). Tuned for ~10 concurrent active users. */
+const MAX_JOBS_PER_SCHEDULED_RUN = 10;
 
 /**
  * Calculate exponential backoff delay for rate limits
@@ -141,7 +146,7 @@ export class EntityExtractionQueueService {
 	static async processQueue(
 		env: Env,
 		username?: string,
-		maxItems: number = 10
+		maxItems: number = 15
 	): Promise<{ processed: number; failed: number }> {
 		const queueDAO = new EntityExtractionQueueDAO(env.DB);
 		const daoFactory = getDAOFactory(env);
@@ -398,7 +403,6 @@ export class EntityExtractionQueueService {
 	static async processPendingQueueItems(env: Env): Promise<void> {
 		try {
 			const queueDAO = new EntityExtractionQueueDAO(env.DB);
-			const MAX_JOBS_PER_SCHEDULED_RUN = 2;
 
 			// First, clean up stuck processing items
 			await EntityExtractionQueueService.cleanupStuckProcessingItems(env);

--- a/src/services/campaign/entity-staging-service.ts
+++ b/src/services/campaign/entity-staging-service.ts
@@ -414,8 +414,9 @@ export async function stageEntitiesFromResource(
 		const allExtractedEntities: Map<string, ExtractedEntity> = new Map();
 		let jsonRepairCount = 0;
 
-		const CHUNK_CONCURRENCY = 3;
-		const CHUNK_START_INTERVAL_MS = 1000; // Min interval between chunk starts to respect provider TPM
+		// Parallel chunk extraction; tuned for ~10 concurrent active users (lower TPM contention than ~100-user caps).
+		const CHUNK_CONCURRENCY = 5;
+		const CHUNK_START_INTERVAL_MS = 500; // Min interval between chunk starts to respect provider TPM
 		const MAX_CHUNK_RETRIES = 3; // Maximum retry attempts per chunk (rate limits only)
 		const INITIAL_RETRY_DELAY_MS = 2000; // Initial delay for retries (2 seconds)
 		const MAX_RETRY_DELAY_MS = 30000; // Maximum delay for retries (30 seconds)


### PR DESCRIPTION
Increase chunks per run (12), scheduled jobs per cron tick (10), and default processQueue batch (15). Raise chunk concurrency to 5 and halve start spacing to 500ms. Document tuning assumption in comments.

Made-with: Cursor