### PR TITLE
fix(d1): chunk changelog IN clauses to avoid SQL variable limit

### DIFF
--- a/src/dao/world-state-changelog-dao.ts
+++ b/src/dao/world-state-changelog-dao.ts
@@ -25,6 +25,9 @@ export interface WorldStateChangelogQueryOptions {
 }
 
 export class WorldStateChangelogDAO extends BaseDAOClass {
+	/** SQLite/D1 bound-variable limit per statement is ~999; keep IN() batches small. */
+	private static readonly IN_CLAUSE_CHUNK_SIZE = 90;
+
 	async createEntry(input: CreateWorldStateChangelogInput): Promise<void> {
 		const sql = `
       INSERT INTO world_state_changelog (
@@ -110,14 +113,23 @@ export class WorldStateChangelogDAO extends BaseDAOClass {
 	async markEntriesApplied(ids: string[]): Promise<void> {
 		if (!ids.length) return;
 
-		const placeholders = ids.map(() => "?").join(", ");
-		const sql = `
+		for (
+			let i = 0;
+			i < ids.length;
+			i += WorldStateChangelogDAO.IN_CLAUSE_CHUNK_SIZE
+		) {
+			const chunk = ids.slice(
+				i,
+				i + WorldStateChangelogDAO.IN_CLAUSE_CHUNK_SIZE
+			);
+			const placeholders = chunk.map(() => "?").join(", ");
+			const sql = `
       UPDATE world_state_changelog
       SET applied_to_graph = TRUE
       WHERE id IN (${placeholders})
     `;
-
-		await this.execute(sql, ids);
+			await this.execute(sql, chunk);
+		}
 	}
 
 	/**
@@ -140,13 +152,22 @@ export class WorldStateChangelogDAO extends BaseDAOClass {
 	async deleteEntries(ids: string[]): Promise<void> {
 		if (!ids.length) return;
 
-		const placeholders = ids.map(() => "?").join(", ");
-		const sql = `
+		for (
+			let i = 0;
+			i < ids.length;
+			i += WorldStateChangelogDAO.IN_CLAUSE_CHUNK_SIZE
+		) {
+			const chunk = ids.slice(
+				i,
+				i + WorldStateChangelogDAO.IN_CLAUSE_CHUNK_SIZE
+			);
+			const placeholders = chunk.map(() => "?").join(", ");
+			const sql = `
       DELETE FROM world_state_changelog
       WHERE id IN (${placeholders})
     `;
-
-		await this.execute(sql, ids);
+			await this.execute(sql, chunk);
+		}
 	}
 
 	private mapRecord(

--- a/tests/dao/world-state-changelog-dao.test.ts
+++ b/tests/dao/world-state-changelog-dao.test.ts
@@ -121,6 +121,15 @@ describe("WorldStateChangelogDAO", () => {
 			expect.stringContaining("UPDATE world_state_changelog")
 		);
 		expect(mockStatement.bind).toHaveBeenCalledWith("entry-1", "entry-2");
-		expect(mockStatement.run).toHaveBeenCalled();
+		expect(mockStatement.run).toHaveBeenCalledTimes(1);
+	});
+
+	it("chunks markEntriesApplied so large IN lists stay under D1 bind limits", async () => {
+		const ids = Array.from({ length: 95 }, (_, i) => `entry-${i}`);
+		await dao.markEntriesApplied(ids);
+
+		expect(mockStatement.run).toHaveBeenCalledTimes(2);
+		expect(mockStatement.bind).toHaveBeenNthCalledWith(1, ...ids.slice(0, 90));
+		expect(mockStatement.bind).toHaveBeenNthCalledWith(2, ...ids.slice(90));
 	});
 });


### PR DESCRIPTION
Rebuild completion called markEntriesApplied/deleteEntries with every unapplied changelog id in one statement, exceeding SQLite bind limits (~999) and failing with D1_ERROR too many SQL variables. Batch updates and deletes in chunks of 90; add test for chunked applies.

Made-with: Cursor