### PR TITLE
fix(d1): honor 100 bind-parameter limit across graph-related DAOs

### DIFF
--- a/src/dao/community-dao.ts
+++ b/src/dao/community-dao.ts
@@ -1,11 +1,11 @@
 import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
+import { D1_IN_LIST_CHUNK_SIZE, d1MultiRowValuesChunkSize } from "./d1-limits";
 
-// D1 has a relatively small SQL parameter ceiling; keep IN() batches conservative.
-const D1_IN_CLAUSE_BATCH_SIZE = 90;
+const D1_IN_CLAUSE_BATCH_SIZE = D1_IN_LIST_CHUNK_SIZE;
 
-/** Each community_entities row uses 2 bound parameters; SQLite limits ~999 vars per statement. */
-const COMMUNITY_ENTITIES_INSERT_CHUNK_SIZE = 400;
+/** Each `community_entities` row is `(?, ?)`; D1 allows max 100 binds per statement. */
+const COMMUNITY_ENTITIES_INSERT_CHUNK_SIZE = d1MultiRowValuesChunkSize(2);
 
 // Raw row shape returned directly from D1 queries against the `communities` table.
 export interface CommunityRecord {

--- a/src/dao/d1-limits.ts
+++ b/src/dao/d1-limits.ts
@@ -1,0 +1,20 @@
+/**
+ * Cloudflare D1 limits (bound parameters per single SQL statement).
+ * @see https://developers.cloudflare.com/d1/platform/limits/
+ */
+export const D1_MAX_BOUND_PARAMETERS_PER_QUERY = 100;
+
+/** Safe size for `WHERE col IN (?,?,…)` when that list is the only large bind group. */
+export const D1_IN_LIST_CHUNK_SIZE = 90;
+
+/**
+ * Max rows per `INSERT … VALUES (?,?),…` when each tuple has `bindsPerRow` placeholders.
+ * Stays under {@link D1_MAX_BOUND_PARAMETERS_PER_QUERY} with a small margin.
+ */
+export function d1MultiRowValuesChunkSize(bindsPerRow: number): number {
+	if (bindsPerRow < 1) return 1;
+	return Math.max(
+		1,
+		Math.floor(D1_MAX_BOUND_PARAMETERS_PER_QUERY / bindsPerRow) - 1
+	);
+}

--- a/src/dao/entity-dao.ts
+++ b/src/dao/entity-dao.ts
@@ -6,6 +6,7 @@ import { RelationshipUpsertError } from "@/lib/errors";
 import { incrementCampaignCacheVersion } from "@/services/search/entity-search-cache-service";
 import type { SqlParam, SqlParams } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
+import { D1_IN_LIST_CHUNK_SIZE } from "./d1-limits";
 
 /** D1 platform limit: max 100 bound params per query. We use 2×N (from + to IN), so N ≤ 49. */
 const RELATIONSHIPS_BATCH_SIZE = 49;
@@ -350,13 +351,20 @@ export class EntityDAO extends BaseDAOClass {
 
 		// Invalidate entity search cache for affected campaigns
 		const entityIds = updates.map((u) => u.entityId);
-		const placeholders = entityIds.map(() => "?").join(", ");
-		const rows = await this.queryAll<{ campaign_id: string }>(
-			`SELECT DISTINCT campaign_id FROM entities WHERE id IN (${placeholders})`,
-			entityIds
-		);
-		for (const row of rows) {
-			await incrementCampaignCacheVersion(this.db, row.campaign_id);
+		const campaignsInvalidated = new Set<string>();
+		for (let i = 0; i < entityIds.length; i += D1_IN_LIST_CHUNK_SIZE) {
+			const chunk = entityIds.slice(i, i + D1_IN_LIST_CHUNK_SIZE);
+			const placeholders = chunk.map(() => "?").join(", ");
+			const rows = await this.queryAll<{ campaign_id: string }>(
+				`SELECT DISTINCT campaign_id FROM entities WHERE id IN (${placeholders})`,
+				chunk
+			);
+			for (const row of rows) {
+				if (!campaignsInvalidated.has(row.campaign_id)) {
+					campaignsInvalidated.add(row.campaign_id);
+					await incrementCampaignCacheVersion(this.db, row.campaign_id);
+				}
+			}
 		}
 	}
 
@@ -372,10 +380,21 @@ export class EntityDAO extends BaseDAOClass {
 		if (entityIds.length === 0) {
 			return [];
 		}
-		const placeholders = entityIds.map(() => "?").join(", ");
-		const sql = `SELECT * FROM entities WHERE id IN (${placeholders})`;
-		const records = await this.queryAll<EntityRecord>(sql, entityIds);
-		return records.map((record) => this.mapEntityRecord(record));
+		const byId = new Map<string, EntityRecord>();
+		for (let i = 0; i < entityIds.length; i += D1_IN_LIST_CHUNK_SIZE) {
+			const chunk = entityIds.slice(i, i + D1_IN_LIST_CHUNK_SIZE);
+			const placeholders = chunk.map(() => "?").join(", ");
+			const sql = `SELECT * FROM entities WHERE id IN (${placeholders})`;
+			const records = await this.queryAll<EntityRecord>(sql, chunk);
+			for (const record of records) {
+				if (!byId.has(record.id)) {
+					byId.set(record.id, record);
+				}
+			}
+		}
+		return Array.from(byId.values()).map((record) =>
+			this.mapEntityRecord(record)
+		);
 	}
 
 	async listEntitiesByCampaign(

--- a/src/dao/entity-importance-dao.ts
+++ b/src/dao/entity-importance-dao.ts
@@ -1,5 +1,6 @@
 import type { SqlParam } from "@/types/utils";
 import { BaseDAOClass } from "./base-dao";
+import { D1_IN_LIST_CHUNK_SIZE } from "./d1-limits";
 
 // Raw row structure for the `entity_importance` table. Matches the D1 schema
 // exactly and is primarily used internally before normalization.
@@ -134,14 +135,22 @@ export class EntityImportanceDAO extends BaseDAOClass {
 			return [];
 		}
 
-		const placeholders = entityIds.map(() => "?").join(", ");
-		const sql = `
+		const byId = new Map<string, EntityImportanceRecord>();
+		for (let i = 0; i < entityIds.length; i += D1_IN_LIST_CHUNK_SIZE) {
+			const chunk = entityIds.slice(i, i + D1_IN_LIST_CHUNK_SIZE);
+			const placeholders = chunk.map(() => "?").join(", ");
+			const sql = `
       SELECT * FROM entity_importance
       WHERE entity_id IN (${placeholders})
     `;
-
-		const records = await this.queryAll<EntityImportanceRecord>(sql, entityIds);
-		return records.map((record) => this.mapRecord(record));
+			const records = await this.queryAll<EntityImportanceRecord>(sql, chunk);
+			for (const record of records) {
+				if (!byId.has(record.entity_id)) {
+					byId.set(record.entity_id, record);
+				}
+			}
+		}
+		return Array.from(byId.values()).map((record) => this.mapRecord(record));
 	}
 
 	async getImportanceForCampaign(

--- a/src/dao/world-state-changelog-dao.ts
+++ b/src/dao/world-state-changelog-dao.ts
@@ -5,6 +5,7 @@ import type {
 	WorldStateChangelogRecord,
 } from "@/types/world-state";
 import { BaseDAOClass } from "./base-dao";
+import { D1_IN_LIST_CHUNK_SIZE } from "./d1-limits";
 
 export interface CreateWorldStateChangelogInput {
 	id: string;
@@ -25,9 +26,6 @@ export interface WorldStateChangelogQueryOptions {
 }
 
 export class WorldStateChangelogDAO extends BaseDAOClass {
-	/** SQLite/D1 bound-variable limit per statement is ~999; keep IN() batches small. */
-	private static readonly IN_CLAUSE_CHUNK_SIZE = 90;
-
 	async createEntry(input: CreateWorldStateChangelogInput): Promise<void> {
 		const sql = `
       INSERT INTO world_state_changelog (
@@ -113,15 +111,8 @@ export class WorldStateChangelogDAO extends BaseDAOClass {
 	async markEntriesApplied(ids: string[]): Promise<void> {
 		if (!ids.length) return;
 
-		for (
-			let i = 0;
-			i < ids.length;
-			i += WorldStateChangelogDAO.IN_CLAUSE_CHUNK_SIZE
-		) {
-			const chunk = ids.slice(
-				i,
-				i + WorldStateChangelogDAO.IN_CLAUSE_CHUNK_SIZE
-			);
+		for (let i = 0; i < ids.length; i += D1_IN_LIST_CHUNK_SIZE) {
+			const chunk = ids.slice(i, i + D1_IN_LIST_CHUNK_SIZE);
 			const placeholders = chunk.map(() => "?").join(", ");
 			const sql = `
       UPDATE world_state_changelog
@@ -152,15 +143,8 @@ export class WorldStateChangelogDAO extends BaseDAOClass {
 	async deleteEntries(ids: string[]): Promise<void> {
 		if (!ids.length) return;
 
-		for (
-			let i = 0;
-			i < ids.length;
-			i += WorldStateChangelogDAO.IN_CLAUSE_CHUNK_SIZE
-		) {
-			const chunk = ids.slice(
-				i,
-				i + WorldStateChangelogDAO.IN_CLAUSE_CHUNK_SIZE
-			);
+		for (let i = 0; i < ids.length; i += D1_IN_LIST_CHUNK_SIZE) {
+			const chunk = ids.slice(i, i + D1_IN_LIST_CHUNK_SIZE);
 			const placeholders = chunk.map(() => "?").join(", ");
 			const sql = `
       DELETE FROM world_state_changelog

--- a/tests/dao/d1-limits.test.ts
+++ b/tests/dao/d1-limits.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import {
+	D1_IN_LIST_CHUNK_SIZE,
+	D1_MAX_BOUND_PARAMETERS_PER_QUERY,
+	d1MultiRowValuesChunkSize,
+} from "@/dao/d1-limits";
+
+describe("d1-limits", () => {
+	it("documents D1 max binds and safe IN chunk", () => {
+		expect(D1_MAX_BOUND_PARAMETERS_PER_QUERY).toBe(100);
+		expect(D1_IN_LIST_CHUNK_SIZE).toBeLessThanOrEqual(100);
+	});
+
+	it("sizes multi-row VALUES chunks for two columns under D1 cap", () => {
+		expect(d1MultiRowValuesChunkSize(2)).toBe(49);
+	});
+});

--- a/tests/dao/entity-dao.test.ts
+++ b/tests/dao/entity-dao.test.ts
@@ -232,5 +232,39 @@ describe("EntityDAO", () => {
 			);
 			expect(mockStmt.bind).toHaveBeenCalledWith("e1");
 		});
+
+		it("chunks id lists so each query stays under D1 bind limits", async () => {
+			expect.hasAssertions();
+
+			const mkRow = (id: string): EntityRecord => ({
+				id,
+				campaign_id: "c1",
+				entity_type: "npc",
+				name: id,
+				content: null,
+				metadata: null,
+				confidence: null,
+				source_type: null,
+				source_id: null,
+				embedding_id: null,
+				created_at: "2024-01-01T00:00:00Z",
+				updated_at: "2024-01-01T00:00:00Z",
+			});
+
+			const ids = Array.from({ length: 95 }, (_, i) => `e-${i}`);
+			let call = 0;
+			mockStmt.all.mockImplementation(async () => {
+				call += 1;
+				if (call === 1) {
+					return { results: ids.slice(0, 90).map(mkRow) };
+				}
+				return { results: ids.slice(90).map(mkRow) };
+			});
+
+			const result = await dao.getEntitiesByIds(ids);
+
+			expect(mockDB.prepare).toHaveBeenCalledTimes(2);
+			expect(result).toHaveLength(95);
+		});
 	});
 });


### PR DESCRIPTION
Cloudflare D1 caps bound parameters at 100 per statement (not 999). community_entities bulk INSERT used 400 rows × 2 binds, which always exceeded the cap during community sync after detection.

- Add d1-limits helpers and shared IN-list chunk size (90)
- Chunk getEntitiesByIds, updateEntitiesBatch cache invalidation, and getImportanceByEntityIds
- Reduce community_entities VALUES batches via d1MultiRowValuesChunkSize(2)

Made-with: Cursor