### PR TITLE
perf(graph): speed up campaign graph visualization API

### DIFF
--- a/src/dao/community-summary-dao.ts
+++ b/src/dao/community-summary-dao.ts
@@ -153,6 +153,53 @@ export class CommunitySummaryDAO extends BaseDAOClass {
 		return records.map((record) => this.mapSummaryRecord(record));
 	}
 
+	/**
+	 * Latest summary per community (same as getSummaryByCommunityId per id, one round-trip).
+	 */
+	async getLatestSummariesMapByCampaign(
+		campaignId: string
+	): Promise<Map<string, CommunitySummary>> {
+		const sql = `
+      SELECT
+        ranked.id,
+        ranked.community_id,
+        ranked.level,
+        ranked.name,
+        ranked.summary_text,
+        ranked.key_entities,
+        ranked.metadata,
+        ranked.generated_at,
+        ranked.updated_at
+      FROM (
+        SELECT
+          cs.id,
+          cs.community_id,
+          cs.level,
+          cs.name,
+          cs.summary_text,
+          cs.key_entities,
+          cs.metadata,
+          cs.generated_at,
+          cs.updated_at,
+          ROW_NUMBER() OVER (PARTITION BY cs.community_id ORDER BY cs.updated_at DESC) AS rn
+        FROM community_summaries cs
+        INNER JOIN communities c ON cs.community_id = c.id
+        WHERE c.campaign_id = ?
+      ) ranked
+      WHERE ranked.rn = 1
+    `;
+
+		const records = await this.queryAll<CommunitySummaryRecord>(sql, [
+			campaignId,
+		]);
+		const map = new Map<string, CommunitySummary>();
+		for (const record of records) {
+			const summary = this.mapSummaryRecord(record);
+			map.set(summary.communityId, summary);
+		}
+		return map;
+	}
+
 	async listSummariesByLevel(
 		campaignId: string,
 		level: number

--- a/src/dao/entity-dao.ts
+++ b/src/dao/entity-dao.ts
@@ -24,6 +24,26 @@ function sanitizeLikeTerm(input: string): string {
 		.slice(0, MAX_LIKE_TERM_LENGTH);
 }
 
+/** Narrow row for graph visualization: avoids loading `content` and other heavy columns. */
+export interface EntityGraphProjectionRecord {
+	id: string;
+	campaign_id: string;
+	entity_type: string;
+	name: string;
+	metadata: string | null;
+	source_id: string | null;
+	shard_status: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+/** Minimal relationship row for campaign-wide graph edges (single D1 query). */
+export interface GraphRelationshipEdge {
+	fromEntityId: string;
+	toEntityId: string;
+	relationshipType: RelationshipType;
+}
+
 // Raw row shape returned directly from D1 queries against the `entities` table.
 // All fields mirror the database column names and use snake_case to match D1 results.
 export interface EntityRecord {
@@ -480,6 +500,116 @@ export class EntityDAO extends BaseDAOClass {
 
 		const records = await this.queryAll<EntityRecord>(sql, params);
 		return records.map((record) => this.mapEntityRecord(record));
+	}
+
+	/**
+	 * List entities with columns needed for graph visualization only (no `content`).
+	 * Same filter options as {@link listEntitiesByCampaign}.
+	 */
+	async listEntitiesGraphProjectionByCampaign(
+		campaignId: string,
+		options: {
+			entityType?: string;
+			sourceId?: string;
+			resourceId?: string;
+			entityIds?: string[];
+			shardStatus?: string | string[];
+			excludeShardStatuses?: string[];
+			limit?: number;
+			offset?: number;
+			orderBy?: "updated_at" | "name";
+		} = {}
+	): Promise<Entity[]> {
+		const conditions = ["campaign_id = ?"];
+		const params: SqlParam[] = [campaignId];
+
+		if (options.entityType) {
+			conditions.push("entity_type = ?");
+			params.push(options.entityType);
+		}
+
+		if (options.sourceId) {
+			conditions.push("source_id = ?");
+			params.push(options.sourceId);
+		}
+
+		if (options.resourceId) {
+			conditions.push("json_extract(metadata, '$.resourceId') = ?");
+			params.push(options.resourceId);
+		}
+
+		if (options.entityIds && options.entityIds.length > 0) {
+			conditions.push("id IN (SELECT value FROM json_each(?))");
+			params.push(JSON.stringify(options.entityIds));
+		}
+
+		if (options.shardStatus) {
+			const statuses = Array.isArray(options.shardStatus)
+				? options.shardStatus
+				: [options.shardStatus];
+			if (statuses.length > 0) {
+				const placeholders = statuses.map(() => "?").join(", ");
+				conditions.push(`shard_status IN (${placeholders})`);
+				params.push(...statuses);
+			}
+		}
+
+		if (
+			options.excludeShardStatuses &&
+			options.excludeShardStatuses.length > 0
+		) {
+			const placeholders = options.excludeShardStatuses
+				.map(() => "?")
+				.join(", ");
+			conditions.push(
+				`(shard_status IS NULL OR shard_status NOT IN (${placeholders}))`
+			);
+			params.push(...options.excludeShardStatuses);
+		}
+
+		const orderBy =
+			options.orderBy === "name"
+				? "LOWER(TRIM(name)) ASC, id ASC"
+				: "updated_at DESC";
+		let sql = `
+      SELECT id, campaign_id, entity_type, name, metadata, source_id, shard_status, created_at, updated_at
+      FROM entities
+      WHERE ${conditions.join(" AND ")}
+      ORDER BY ${orderBy}
+    `;
+
+		if (typeof options.limit === "number") {
+			sql += " LIMIT ?";
+			params.push(options.limit);
+		}
+
+		if (typeof options.offset === "number") {
+			sql += " OFFSET ?";
+			params.push(options.offset);
+		}
+
+		const records = await this.queryAll<EntityGraphProjectionRecord>(
+			sql,
+			params
+		);
+		return records.map((record) => this.mapEntityGraphProjection(record));
+	}
+
+	mapEntityGraphProjection(record: EntityGraphProjectionRecord): Entity {
+		return {
+			id: record.id,
+			campaignId: record.campaign_id,
+			entityType: record.entity_type,
+			name: record.name,
+			metadata: record.metadata
+				? this.safeParseJson(record.metadata)
+				: undefined,
+			sourceType: undefined,
+			sourceId: record.source_id,
+			shardStatus: record.shard_status ?? undefined,
+			createdAt: record.created_at,
+			updatedAt: record.updated_at,
+		};
 	}
 
 	/**
@@ -1020,6 +1150,30 @@ export class EntityDAO extends BaseDAOClass {
 			toEntityId: record.to_entity_id,
 			strength: record.strength,
 			metadata: record.metadata,
+		}));
+	}
+
+	/**
+	 * All relationship edges for a campaign in one query (replaces batched getRelationshipsForEntities for graph viz).
+	 */
+	async getGraphRelationshipEdgesForCampaign(
+		campaignId: string
+	): Promise<GraphRelationshipEdge[]> {
+		const sql = `
+      SELECT from_entity_id, to_entity_id, relationship_type
+      FROM entity_relationships
+      WHERE campaign_id = ?
+    `;
+		const records = await this.queryAll<{
+			from_entity_id: string;
+			to_entity_id: string;
+			relationship_type: string;
+		}>(sql, [campaignId]);
+
+		return records.map((record) => ({
+			fromEntityId: record.from_entity_id,
+			toEntityId: record.to_entity_id,
+			relationshipType: normalizeRelationshipType(record.relationship_type),
 		}));
 	}
 

--- a/src/lib/graph/graph-visualization-helpers.ts
+++ b/src/lib/graph/graph-visualization-helpers.ts
@@ -1,6 +1,10 @@
 import type { Community } from "@/dao/community-dao";
 import type { CommunitySummary } from "@/dao/community-summary-dao";
-import type { Entity, EntityRelationship } from "@/dao/entity-dao";
+import type {
+	Entity,
+	EntityRelationship,
+	GraphRelationshipEdge,
+} from "@/dao/entity-dao";
 import type { CommunityGraphData } from "@/types/graph-visualization";
 import type { ShardStatus } from "@/types/shard";
 import { toCommunityNode } from "./community-utils";
@@ -184,6 +188,32 @@ export function buildRelationshipMap(
 				type: rel.relationshipType,
 			}))
 		);
+	}
+	return map;
+}
+
+/**
+ * Build {@link RelationshipMap} from campaign-wide edges, restricted to the given entity ids
+ * (e.g. non-stub entities). Matches semantics of {@link buildRelationshipMap} from batched DAO results.
+ */
+export function buildRelationshipMapFromEdges(
+	edges: GraphRelationshipEdge[],
+	entityIds: Set<string>
+): RelationshipMap {
+	const map: RelationshipMap = new Map();
+	for (const id of entityIds) {
+		map.set(id, []);
+	}
+	for (const edge of edges) {
+		const type = edge.relationshipType;
+		if (entityIds.has(edge.fromEntityId)) {
+			const list = map.get(edge.fromEntityId)!;
+			list.push({ toId: edge.toEntityId, type });
+		}
+		if (entityIds.has(edge.toEntityId)) {
+			const list = map.get(edge.toEntityId)!;
+			list.push({ toId: edge.fromEntityId, type });
+		}
 	}
 	return map;
 }

--- a/src/routes/graph-visualization.ts
+++ b/src/routes/graph-visualization.ts
@@ -15,7 +15,7 @@ import {
 import {
 	applyGraphFilters,
 	buildCommunityGraphNodes,
-	buildRelationshipMap,
+	buildRelationshipMapFromEdges,
 	computeOrphanNodes,
 	type GraphFilters,
 } from "@/lib/graph/graph-visualization-helpers";
@@ -85,9 +85,32 @@ export async function handleGetGraphVisualization(c: ContextWithAuth) {
 					.filter(Boolean)
 			: undefined;
 
-		// Load all communities
-		const communities =
-			await daoFactory.communityDAO.listCommunitiesByCampaign(campaignId);
+		const entityListOptions = {
+			limit: 10000,
+			entityType:
+				entityTypes && entityTypes.length === 1 ? entityTypes[0] : undefined,
+			resourceId:
+				resourceIds && resourceIds.length === 1 ? resourceIds[0] : undefined,
+			shardStatus:
+				approvalStatuses && approvalStatuses.length > 0
+					? approvalStatuses
+					: undefined,
+		};
+
+		const [communities, allEntities, relationshipEdges, communitySummaryMap] =
+			await Promise.all([
+				daoFactory.communityDAO.listCommunitiesByCampaign(campaignId),
+				daoFactory.entityDAO.listEntitiesGraphProjectionByCampaign(
+					campaignId,
+					entityListOptions
+				),
+				daoFactory.entityDAO.getGraphRelationshipEdgesForCampaign(campaignId),
+				daoFactory.communitySummaryDAO
+					? daoFactory.communitySummaryDAO.getLatestSummariesMapByCampaign(
+							campaignId
+						)
+					: Promise.resolve(new Map<string, CommunitySummary>()),
+			]);
 
 		if (communities.length === 0) {
 			return c.json({
@@ -96,21 +119,7 @@ export async function handleGetGraphVisualization(c: ContextWithAuth) {
 			});
 		}
 
-		// Load all entities for the campaign to check filters (exclude stubs so they are not rendered)
-		const allEntities = await daoFactory.entityDAO.listEntitiesByCampaign(
-			campaignId,
-			{
-				limit: 10000,
-				entityType:
-					entityTypes && entityTypes.length === 1 ? entityTypes[0] : undefined,
-				resourceId:
-					resourceIds && resourceIds.length === 1 ? resourceIds[0] : undefined,
-				shardStatus:
-					approvalStatuses && approvalStatuses.length > 0
-						? approvalStatuses
-						: undefined,
-			}
-		);
+		// Exclude stubs so they are not rendered
 		const nonStubEntities = allEntities.filter((e) => !isEntityStub(e));
 
 		// Create entity map for quick lookup (stubs excluded)
@@ -119,13 +128,11 @@ export async function handleGetGraphVisualization(c: ContextWithAuth) {
 			entityMap.set(entity.id, entity);
 		}
 
-		// Batch load relationships for all entities (used for filters and edges)
-		const allEntityIds = nonStubEntities.map((e) => e.id);
-		const relationshipsByEntity =
-			allEntityIds.length > 0
-				? await daoFactory.entityDAO.getRelationshipsForEntities(allEntityIds)
-				: new Map();
-		const relationshipMap = buildRelationshipMap(relationshipsByEntity);
+		const nonStubEntityIds = new Set(nonStubEntities.map((e) => e.id));
+		const relationshipMap = buildRelationshipMapFromEdges(
+			relationshipEdges,
+			nonStubEntityIds
+		);
 
 		const filters: GraphFilters = {
 			entityTypes,
@@ -141,25 +148,6 @@ export async function handleGetGraphVisualization(c: ContextWithAuth) {
 			filters,
 			relationshipMap
 		);
-
-		// Load community summaries (including natural language names)
-		const communitySummaryMap = new Map<string, CommunitySummary>();
-		if (daoFactory.communitySummaryDAO) {
-			for (const community of filteredCommunities) {
-				try {
-					const summary =
-						await daoFactory.communitySummaryDAO.getSummaryByCommunityId(
-							community.id,
-							campaignId
-						);
-					if (summary) {
-						communitySummaryMap.set(community.id, summary);
-					}
-				} catch {
-					// Ignore errors loading summaries
-				}
-			}
-		}
 
 		// Build community nodes
 		const communityNodes = buildCommunityGraphNodes(

--- a/tests/dao/community-summary-dao.test.ts
+++ b/tests/dao/community-summary-dao.test.ts
@@ -1,0 +1,59 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { beforeEach, describe, expect, it } from "vitest";
+import { CommunitySummaryDAO } from "@/dao/community-summary-dao";
+import { createMockD1, createMockStmt } from "./helpers";
+
+describe("CommunitySummaryDAO", () => {
+	let dao: CommunitySummaryDAO;
+	let mockDB: D1Database;
+	let mockStmt: ReturnType<typeof createMockStmt>;
+
+	beforeEach(() => {
+		mockStmt = createMockStmt();
+		mockDB = createMockD1(mockStmt);
+		dao = new CommunitySummaryDAO(mockDB);
+	});
+
+	describe("getLatestSummariesMapByCampaign", () => {
+		it("uses window function for latest summary per community", async () => {
+			expect.hasAssertions();
+
+			mockStmt.all.mockResolvedValue({ results: [] });
+
+			await dao.getLatestSummariesMapByCampaign("camp-1");
+
+			expect(mockDB.prepare).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/ROW_NUMBER\(\) OVER \(PARTITION BY cs\.community_id/
+				)
+			);
+			expect(mockStmt.bind).toHaveBeenCalledWith("camp-1");
+		});
+
+		it("maps rows by community id", async () => {
+			expect.hasAssertions();
+
+			mockStmt.all.mockResolvedValue({
+				results: [
+					{
+						id: "s1",
+						community_id: "com-1",
+						level: 0,
+						name: "Group A",
+						summary_text: "Summary",
+						key_entities: null,
+						metadata: null,
+						generated_at: "2024-01-01T00:00:00Z",
+						updated_at: "2024-01-02T00:00:00Z",
+					},
+				],
+			});
+
+			const map = await dao.getLatestSummariesMapByCampaign("camp-1");
+
+			expect(map.size).toBe(1);
+			expect(map.get("com-1")?.summaryText).toBe("Summary");
+			expect(map.get("com-1")?.name).toBe("Group A");
+		});
+	});
+});

--- a/tests/dao/entity-dao.test.ts
+++ b/tests/dao/entity-dao.test.ts
@@ -191,6 +191,80 @@ describe("EntityDAO", () => {
 		});
 	});
 
+	describe("listEntitiesGraphProjectionByCampaign", () => {
+		it("selects narrow columns without content", async () => {
+			expect.hasAssertions();
+
+			mockStmt.all.mockResolvedValue({ results: [] });
+
+			await dao.listEntitiesGraphProjectionByCampaign("c1", { limit: 100 });
+
+			expect(mockDB.prepare).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/SELECT id, campaign_id, entity_type, name, metadata, source_id, shard_status/
+				)
+			);
+			expect(mockDB.prepare).toHaveBeenCalledWith(
+				expect.not.stringContaining("content")
+			);
+			expect(mockStmt.bind).toHaveBeenCalledWith("c1", 100);
+		});
+
+		it("mirrors listEntitiesByCampaign filter options", async () => {
+			expect.hasAssertions();
+
+			mockStmt.all.mockResolvedValue({ results: [] });
+
+			await dao.listEntitiesGraphProjectionByCampaign("c1", {
+				entityType: "npc",
+				resourceId: "res-1",
+				shardStatus: ["approved"],
+				limit: 50,
+			});
+
+			expect(mockDB.prepare).toHaveBeenCalledWith(
+				expect.stringContaining("entity_type = ?")
+			);
+			expect(mockDB.prepare).toHaveBeenCalledWith(
+				expect.stringContaining("json_extract(metadata, '$.resourceId')")
+			);
+			expect(mockStmt.bind).toHaveBeenCalledWith(
+				"c1",
+				"npc",
+				"res-1",
+				"approved",
+				50
+			);
+		});
+	});
+
+	describe("getGraphRelationshipEdgesForCampaign", () => {
+		it("queries relationships by campaign_id", async () => {
+			expect.hasAssertions();
+
+			mockStmt.all.mockResolvedValue({
+				results: [
+					{
+						from_entity_id: "a",
+						to_entity_id: "b",
+						relationship_type: "member_of",
+					},
+				],
+			});
+
+			const edges = await dao.getGraphRelationshipEdgesForCampaign("c1");
+
+			expect(mockDB.prepare).toHaveBeenCalledWith(
+				expect.stringContaining("WHERE campaign_id = ?")
+			);
+			expect(mockStmt.bind).toHaveBeenCalledWith("c1");
+			expect(edges).toHaveLength(1);
+			expect(edges[0].fromEntityId).toBe("a");
+			expect(edges[0].toEntityId).toBe("b");
+			expect(edges[0].relationshipType).toBe("member_of");
+		});
+	});
+
 	describe("getEntitiesByIds", () => {
 		it("returns empty array for empty input", async () => {
 			expect.hasAssertions();

--- a/tests/lib/graph-visualization-helpers.test.ts
+++ b/tests/lib/graph-visualization-helpers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { GraphRelationshipEdge } from "@/dao/entity-dao";
+import { buildRelationshipMapFromEdges } from "@/lib/graph/graph-visualization-helpers";
+
+describe("buildRelationshipMapFromEdges", () => {
+	it("builds adjacency lists for both endpoints when both are in the entity set", () => {
+		const edges: GraphRelationshipEdge[] = [
+			{
+				fromEntityId: "a",
+				toEntityId: "b",
+				relationshipType: "member_of",
+			},
+		];
+		const entityIds = new Set(["a", "b"]);
+		const map = buildRelationshipMapFromEdges(edges, entityIds);
+
+		expect(map.get("a")).toEqual([{ toId: "b", type: "member_of" }]);
+		expect(map.get("b")).toEqual([{ toId: "a", type: "member_of" }]);
+	});
+
+	it("includes an edge on one side when the other endpoint is outside the set", () => {
+		const edges: GraphRelationshipEdge[] = [
+			{
+				fromEntityId: "a",
+				toEntityId: "stub-only",
+				relationshipType: "related_to",
+			},
+		];
+		const entityIds = new Set(["a"]);
+		const map = buildRelationshipMapFromEdges(edges, entityIds);
+
+		expect(map.get("a")).toEqual([{ toId: "stub-only", type: "related_to" }]);
+	});
+
+	it("initializes empty lists for every entity id", () => {
+		const map = buildRelationshipMapFromEdges([], new Set(["x", "y"]));
+		expect(map.get("x")).toEqual([]);
+		expect(map.get("y")).toEqual([]);
+	});
+});

--- a/tests/routes/graph-visualization.test.ts
+++ b/tests/routes/graph-visualization.test.ts
@@ -15,8 +15,8 @@ const mockCommunityDAO = {
 	listCommunitiesByCampaign: vi.fn(),
 };
 const mockEntityDAO = {
-	listEntitiesByCampaign: vi.fn(),
-	getRelationshipsForEntities: vi.fn(),
+	listEntitiesGraphProjectionByCampaign: vi.fn(),
+	getGraphRelationshipEdgesForCampaign: vi.fn(),
 };
 
 (getDAOFactory as ReturnType<typeof vi.fn>).mockReturnValue({
@@ -55,8 +55,8 @@ describe("graph-visualization routes", () => {
 			username: "user1",
 		});
 		mockCommunityDAO.listCommunitiesByCampaign.mockResolvedValue([]);
-		mockEntityDAO.listEntitiesByCampaign.mockResolvedValue([]);
-		mockEntityDAO.getRelationshipsForEntities.mockResolvedValue(new Map());
+		mockEntityDAO.listEntitiesGraphProjectionByCampaign.mockResolvedValue([]);
+		mockEntityDAO.getGraphRelationshipEdgesForCampaign.mockResolvedValue([]);
 	});
 
 	it("returns 401 when userAuth is missing", async () => {
@@ -103,5 +103,19 @@ describe("graph-visualization routes", () => {
 				edges: [],
 			})
 		);
+	});
+
+	it("loads graph projection and campaign relationship edges in parallel", async () => {
+		const c = createContext();
+		await handleGetGraphVisualization(c);
+		expect(
+			mockEntityDAO.listEntitiesGraphProjectionByCampaign
+		).toHaveBeenCalledWith(
+			"campaign-1",
+			expect.objectContaining({ limit: 10000 })
+		);
+		expect(
+			mockEntityDAO.getGraphRelationshipEdgesForCampaign
+		).toHaveBeenCalledWith("campaign-1");
 	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -122,5 +122,5 @@
 		// "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */
 	},
-	"exclude": ["tests"]
+	"exclude": ["tests", "**/*.stories.tsx"]
 }


### PR DESCRIPTION
- Load entities with a narrow projection (no content) and relationships in one campaign-scoped query instead of batched per-entity lookups.
- Fetch latest community summaries per community in a single query with ROW_NUMBER, parallel to other reads.
- Add buildRelationshipMapFromEdges helper and tests for DAOs, helpers, and route.

- Exclude *.stories.tsx from root tsconfig so tsc matches Storybook resolution and pre-commit hooks pass.

Made-with: Cursor