### PR TITLE
feat(library): client-side search for resource list

### DIFF
--- a/src/components/resource-side-panel/LibrarySection.tsx
+++ b/src/components/resource-side-panel/LibrarySection.tsx
@@ -1,5 +1,12 @@
-import { Plus } from "@phosphor-icons/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { MagnifyingGlass, Plus } from "@phosphor-icons/react";
+import {
+	useCallback,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import libraryIcon from "@/assets/library.png";
 import { CollapsibleCard } from "@/components/collapsible/CollapsibleCard";
 import { ActionQueueUI } from "@/components/queue/ActionQueueUI";
@@ -169,6 +176,8 @@ export function LibrarySection({
 
 	const fileDragDepthRef = useRef(0);
 	const [isFileDragOver, setIsFileDragOver] = useState(false);
+	const [librarySearchQuery, setLibrarySearchQuery] = useState("");
+	const librarySearchInputId = useId();
 
 	const handleLibraryDragEnter = useCallback((e: React.DragEvent) => {
 		e.preventDefault();
@@ -246,7 +255,7 @@ export function LibrarySection({
 				className="border-t border-neutral-200 dark:border-neutral-700"
 			>
 				<div className="flex flex-col">
-					<div className="flex-shrink-0 p-2">
+					<div className="flex-shrink-0 p-2 space-y-2">
 						<button
 							type="button"
 							onClick={() => onAddToLibrary()}
@@ -255,6 +264,24 @@ export function LibrarySection({
 							<Plus size={14} />
 							Add to library
 						</button>
+						<div className="relative">
+							<label htmlFor={librarySearchInputId} className="sr-only">
+								Search library
+							</label>
+							<MagnifyingGlass
+								className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-neutral-500 dark:text-neutral-400"
+								aria-hidden
+							/>
+							<input
+								id={librarySearchInputId}
+								type="search"
+								value={librarySearchQuery}
+								onChange={(e) => setLibrarySearchQuery(e.target.value)}
+								placeholder="Search library"
+								autoComplete="off"
+								className="w-full rounded-md border border-neutral-300 bg-neutral-100 py-1.5 pl-8 pr-2 text-sm text-neutral-900 shadow-sm placeholder:text-neutral-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus-visible:ring-neutral-500"
+							/>
+						</div>
 					</div>
 					<div className="border-t border-neutral-200 dark:border-neutral-700 flex flex-col">
 						<div className="max-h-64 overflow-y-auto">
@@ -272,6 +299,7 @@ export function LibrarySection({
 								campaigns={campaigns}
 								campaignAdditionProgress={campaignAdditionProgress}
 								_isAddingToCampaigns={isAddingToCampaigns}
+								searchQuery={librarySearchQuery}
 							/>
 						</div>
 						<div className="flex-shrink-0">

--- a/src/components/upload/ResourceList.tsx
+++ b/src/components/upload/ResourceList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { MEMORY_LIMIT_COPY } from "@/app-constants";
 import { Button } from "@/components/button/Button";
 import { FileDAO } from "@/dao";
@@ -8,6 +8,7 @@ import type { ResourceFileWithCampaigns } from "@/hooks/useResourceFiles";
 import { useRetryLimitStatus } from "@/hooks/useRetryLimitStatus";
 import { APP_EVENT_TYPE } from "@/lib/app-events";
 import { logger } from "@/lib/logger";
+import { matchesResourceSearch } from "@/lib/resource-tags";
 import {
 	authenticatedFetchWithExpiration,
 	getStoredJwt,
@@ -31,6 +32,8 @@ interface ResourceListProps {
 	campaigns?: Campaign[];
 	campaignAdditionProgress?: Record<string, number>;
 	_isAddingToCampaigns?: boolean;
+	/** Client-side filter for sidebar library search */
+	searchQuery?: string;
 }
 
 /**
@@ -51,6 +54,7 @@ export function ResourceList({
 	campaigns = [],
 	campaignAdditionProgress = {},
 	_isAddingToCampaigns = false,
+	searchQuery = "",
 }: ResourceListProps) {
 	const handleDeleteFile = useCallback(
 		async (fileKey: string) => {
@@ -81,6 +85,11 @@ export function ResourceList({
 		Record<string, number>
 	>({});
 	const authReady = useAuthReady();
+
+	const visibleFiles = useMemo(() => {
+		if (!searchQuery.trim()) return files;
+		return files.filter((f) => matchesResourceSearch(f, searchQuery));
+	}, [files, searchQuery]);
 
 	// File event handling - manages progress state internally and via prop setter
 	useResourceFileEvents({
@@ -301,10 +310,20 @@ export function ResourceList({
 		);
 	}
 
+	if (visibleFiles.length === 0 && searchQuery.trim()) {
+		return (
+			<div className="text-center py-8 px-2">
+				<p className="text-sm text-muted-foreground">
+					No resources match your search
+				</p>
+			</div>
+		);
+	}
+
 	return (
 		<div className="h-full overflow-y-auto">
 			<div className="space-y-3">
-				{files.map((file) => (
+				{visibleFiles.map((file) => (
 					<ResourceFileItem
 						key={file.file_key}
 						file={file}

--- a/src/hooks/useResourceFileEvents.ts
+++ b/src/hooks/useResourceFileEvents.ts
@@ -3,6 +3,7 @@ import { FileDAO } from "@/dao";
 import { APP_EVENT_TYPE } from "@/lib/app-events";
 import type { FileUploadEvent } from "@/lib/event-bus";
 import { EVENT_TYPES, useEventBus } from "@/lib/event-bus";
+import { parseTags } from "@/lib/resource-tags";
 import {
 	AuthService,
 	authenticatedFetchWithExpiration,
@@ -23,29 +24,6 @@ interface UseResourceFileEventsOptions {
 interface UseResourceFileEventsReturn {
 	progressByFileKey: Record<string, number>;
 	refreshAllFileStatuses: () => Promise<void>;
-}
-
-/**
- * Helper to safely parse tags from JSON string or return as-is
- */
-function parseTags(tags: string | string[] | undefined): string[] {
-	if (!tags) return [];
-	if (Array.isArray(tags)) return tags;
-	if (typeof tags === "string") {
-		try {
-			const parsed = JSON.parse(tags);
-			if (Array.isArray(parsed)) {
-				return parsed;
-			}
-		} catch {
-			// Not valid JSON, treat as comma-separated string
-			return tags
-				.split(",")
-				.map((t) => t.trim())
-				.filter((t) => t.length > 0);
-		}
-	}
-	return [];
 }
 
 /**

--- a/src/hooks/useResourceFiles.ts
+++ b/src/hooks/useResourceFiles.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { ERROR_MESSAGES } from "@/app-constants";
 import { FileDAO } from "@/dao";
+import { parseTags } from "@/lib/resource-tags";
 import {
 	authenticatedFetchWithExpiration,
 	getStoredJwt,
@@ -116,27 +117,6 @@ export function useResourceFiles(
 						}
 					}
 				}
-
-				// Helper to safely parse tags from JSON string or return as-is
-				const parseTags = (tags: string | string[] | undefined): string[] => {
-					if (!tags) return [];
-					if (Array.isArray(tags)) return tags;
-					if (typeof tags === "string") {
-						try {
-							const parsed = JSON.parse(tags);
-							if (Array.isArray(parsed)) {
-								return parsed;
-							}
-						} catch {
-							// Not valid JSON, treat as comma-separated string
-							return tags
-								.split(",")
-								.map((t) => t.trim())
-								.filter((t) => t.length > 0);
-						}
-					}
-					return [];
-				};
 
 				// Map files with campaigns and parse tags from JSON strings
 				const filesWithCampaigns: ResourceFileWithCampaigns[] =

--- a/src/lib/resource-tags.ts
+++ b/src/lib/resource-tags.ts
@@ -1,0 +1,57 @@
+import { getDisplayName } from "@/lib/display-name-utils";
+
+/**
+ * Safely parse tags from JSON string, array, or comma-separated text.
+ */
+export function parseTags(tags: string | string[] | undefined): string[] {
+	if (!tags) return [];
+	if (Array.isArray(tags)) return tags;
+	if (typeof tags === "string") {
+		try {
+			const parsed = JSON.parse(tags);
+			if (Array.isArray(parsed)) {
+				return parsed;
+			}
+		} catch {
+			return tags
+				.split(",")
+				.map((t) => t.trim())
+				.filter((t) => t.length > 0);
+		}
+	}
+	return [];
+}
+
+export type ResourceSearchableFile = {
+	display_name?: string;
+	file_name?: string;
+	name?: string;
+	description?: string;
+	tags?: string[] | string;
+};
+
+/**
+ * Combined searchable text for client-side library search (display name, filename, description, tags).
+ */
+export function getResourceSearchHaystack(
+	file: ResourceSearchableFile
+): string {
+	const parts = [
+		getDisplayName(file),
+		file.file_name ?? "",
+		file.description ?? "",
+		...parseTags(file.tags),
+	];
+	return parts.join(" ");
+}
+
+export function matchesResourceSearch(
+	file: ResourceSearchableFile,
+	query: string
+): boolean {
+	const q = query.trim();
+	if (!q) return true;
+	return getResourceSearchHaystack(file)
+		.toLowerCase()
+		.includes(q.toLowerCase());
+}

--- a/tests/lib/resource-tags.test.ts
+++ b/tests/lib/resource-tags.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+	getResourceSearchHaystack,
+	matchesResourceSearch,
+	parseTags,
+} from "@/lib/resource-tags";
+
+describe("parseTags", () => {
+	it("parses JSON array string", () => {
+		expect(parseTags('["a","b"]')).toEqual(["a", "b"]);
+	});
+
+	it("parses comma-separated string when not JSON", () => {
+		expect(parseTags("foo, bar")).toEqual(["foo", "bar"]);
+	});
+
+	it("returns array as-is", () => {
+		expect(parseTags(["x", "y"])).toEqual(["x", "y"]);
+	});
+
+	it("returns empty for undefined", () => {
+		expect(parseTags(undefined)).toEqual([]);
+	});
+});
+
+describe("getResourceSearchHaystack", () => {
+	it("includes display_name, file_name, description, and tags", () => {
+		const haystack = getResourceSearchHaystack({
+			display_name: "Shown",
+			file_name: "hidden.pdf",
+			description: "About dragons",
+			tags: '["lore"]',
+		});
+		expect(haystack).toContain("Shown");
+		expect(haystack).toContain("hidden.pdf");
+		expect(haystack).toContain("About dragons");
+		expect(haystack).toContain("lore");
+	});
+});
+
+describe("matchesResourceSearch", () => {
+	it("matches on display_name", () => {
+		expect(
+			matchesResourceSearch(
+				{ display_name: "Spellbook", file_name: "x.pdf" },
+				"spell"
+			)
+		).toBe(true);
+	});
+
+	it("matches on file_name when display differs", () => {
+		expect(
+			matchesResourceSearch(
+				{ display_name: "Custom", file_name: "original-name.pdf" },
+				"original"
+			)
+		).toBe(true);
+	});
+
+	it("matches on description", () => {
+		expect(
+			matchesResourceSearch(
+				{ file_name: "a.pdf", description: "Session zero notes" },
+				"session"
+			)
+		).toBe(true);
+	});
+
+	it("matches on JSON tags string", () => {
+		expect(
+			matchesResourceSearch(
+				{ file_name: "a.pdf", tags: '["maps","npcs"]' },
+				"npcs"
+			)
+		).toBe(true);
+	});
+
+	it("matches on comma-separated tags", () => {
+		expect(
+			matchesResourceSearch({ file_name: "a.pdf", tags: "foo, bar baz" }, "bar")
+		).toBe(true);
+	});
+
+	it("returns true for whitespace-only query (shows full list)", () => {
+		expect(matchesResourceSearch({ file_name: "secret.pdf" }, "   ")).toBe(
+			true
+		);
+	});
+
+	it("returns false when nothing matches", () => {
+		expect(
+			matchesResourceSearch(
+				{ file_name: "alpha.pdf", description: "beta" },
+				"gamma"
+			)
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
Add search field under Add to library with substring matching on display name, filename, description, and tags. Centralize parseTags in resource-tags lib; filter visible rows in ResourceList while keeping full list for events. Include unit tests for search helpers.

Made-with: Cursor