### PR TITLE
feat(ui): show entity chunk progress in library, not campaign links

### DIFF
--- a/src/components/resource-side-panel/CampaignDetailsModal.tsx
+++ b/src/components/resource-side-panel/CampaignDetailsModal.tsx
@@ -19,7 +19,6 @@ import { useRetryLimitStatus } from "@/hooks/useRetryLimitStatus";
 import { useSessionDigests } from "@/hooks/useSessionDigests";
 import { APP_EVENT_TYPE } from "@/lib/app-events";
 import { getDisplayName } from "@/lib/display-name-utils";
-import { parseEntityExtractionProgress } from "@/lib/entity-extraction-progress";
 import { API_CONFIG } from "@/shared-config";
 import type { Campaign, CampaignResource } from "@/types/campaign";
 import type {
@@ -100,9 +99,6 @@ export function CampaignDetailsModal({
 	const [processingResources, setProcessingResources] = useState<Set<string>>(
 		new Set()
 	);
-	/** Chunk progress from queue `queue_message` PROGRESS:a/b; keyed by resource id */
-	const [extractionProgressByResourceId, setExtractionProgressByResourceId] =
-		useState<Record<string, { processed: number; total: number } | null>>({});
 	// Track expanded resources
 	const [expandedResources, setExpandedResources] = useState<Set<string>>(
 		new Set()
@@ -328,21 +324,8 @@ export function CampaignDetailsModal({
 							next.delete(resourceId);
 							return next;
 						});
-						setExtractionProgressByResourceId((prev) => {
-							const next = { ...prev };
-							delete next[resourceId];
-							return next;
-						});
 						return;
 					}
-
-					const progress = parseEntityExtractionProgress(
-						data.queueMessage ?? null
-					);
-					setExtractionProgressByResourceId((prev) => ({
-						...prev,
-						[resourceId]: progress,
-					}));
 
 					// If in queue and processing, add to processing set
 					if (
@@ -394,11 +377,6 @@ export function CampaignDetailsModal({
 				setProcessingResources((prev) => {
 					const next = new Set(prev);
 					next.delete(resourceId);
-					return next;
-				});
-				setExtractionProgressByResourceId((prev) => {
-					const next = { ...prev };
-					delete next[resourceId];
 					return next;
 				});
 			}
@@ -489,7 +467,6 @@ export function CampaignDetailsModal({
 			// Reset initial status check tracking when campaign changes
 			initialStatusCheckedRef.current.clear();
 			setProcessingResources(new Set());
-			setExtractionProgressByResourceId({});
 			if (isOpen && activeTab === "digests") {
 				fetchSessionDigests.execute(campaign.campaignId);
 			}
@@ -805,9 +782,6 @@ export function CampaignDetailsModal({
 									expandedResources={expandedResources}
 									onExpandedChange={setExpandedResources}
 									processingResources={processingResources}
-									extractionProgressByResourceId={
-										extractionProgressByResourceId
-									}
 									retryingResourceId={retryingResourceId}
 									onRetry={handleRetryEntityExtraction}
 									canRetryEntityExtraction={isOwner}

--- a/src/components/resource-side-panel/CampaignResourcesTab.tsx
+++ b/src/components/resource-side-panel/CampaignResourcesTab.tsx
@@ -8,13 +8,7 @@ import {
 import { Button } from "@/components/button/Button";
 import { Tooltip } from "@/components/tooltip/Tooltip";
 import { getDisplayName } from "@/lib/display-name-utils";
-import { chunkProgressPercent } from "@/lib/entity-extraction-progress";
 import type { CampaignResource } from "@/types/campaign";
-
-export interface EntityExtractionChunkProgress {
-	processed: number;
-	total: number;
-}
 
 interface CampaignResourcesTabProps {
 	resources: CampaignResource[];
@@ -23,11 +17,6 @@ interface CampaignResourcesTabProps {
 	expandedResources: Set<string>;
 	onExpandedChange: (next: Set<string>) => void;
 	processingResources: Set<string>;
-	/** Parsed PROGRESS:a/b from entity extraction queue when polling */
-	extractionProgressByResourceId?: Record<
-		string,
-		EntityExtractionChunkProgress | null
-	>;
 	retryingResourceId: string | null;
 	onRetry: (resourceId: string) => void;
 	canRetryEntityExtraction?: boolean;
@@ -48,7 +37,6 @@ export function CampaignResourcesTab({
 	expandedResources,
 	onExpandedChange,
 	processingResources,
-	extractionProgressByResourceId = {},
 	retryingResourceId,
 	onRetry,
 	canRetryEntityExtraction = true,
@@ -142,46 +130,6 @@ export function CampaignResourcesTab({
 											)}
 										</button>
 									</div>
-
-									{processingResources.has(resource.id) && (
-										<div className="mt-2 w-full">
-											{(() => {
-												const prog =
-													extractionProgressByResourceId[resource.id];
-												const pct = prog
-													? chunkProgressPercent(prog.processed, prog.total)
-													: null;
-												if (pct !== null && prog) {
-													return (
-														<>
-															<div
-																className="h-1.5 w-full rounded-full bg-neutral-200 dark:bg-neutral-700 overflow-hidden"
-																role="progressbar"
-																aria-valuenow={pct}
-																aria-valuemin={0}
-																aria-valuemax={100}
-																aria-label={`Indexing ${pct} percent`}
-															>
-																<div
-																	className="h-full rounded-full bg-purple-500/90 dark:bg-purple-400/80 transition-[width] duration-300"
-																	style={{ width: `${pct}%` }}
-																/>
-															</div>
-															<p className="text-xs text-neutral-600 dark:text-neutral-400 mt-1 tabular-nums">
-																{pct}% indexed ({prog.processed} of {prog.total}{" "}
-																chunks)
-															</p>
-														</>
-													);
-												}
-												return (
-													<p className="text-xs text-neutral-600 dark:text-neutral-400">
-														Indexing…
-													</p>
-												);
-											})()}
-										</div>
-									)}
 
 									{isExpanded && (
 										<div className="overflow-y-auto transition-opacity transition-[max-height] duration-300 ease-in-out max-h-96 opacity-100">

--- a/src/components/upload/LibraryEntityIndexingProgress.tsx
+++ b/src/components/upload/LibraryEntityIndexingProgress.tsx
@@ -1,0 +1,54 @@
+import {
+	chunkProgressPercent,
+	parseEntityExtractionProgress,
+} from "@/lib/entity-extraction-progress";
+
+interface LibraryEntityIndexingProgressProps {
+	/** `library_entity_discovery.queue_message` from GET /library/files */
+	queueMessage?: string | null;
+	/** `library_entity_discovery.status` */
+	status?: string;
+}
+
+/**
+ * Chunk-level entity discovery progress for a library file (PROGRESS:a/b in queue_message).
+ */
+export function LibraryEntityIndexingProgress({
+	queueMessage,
+	status,
+}: LibraryEntityIndexingProgressProps) {
+	const inFlight = status === "pending" || status === "processing";
+	if (!inFlight) return null;
+
+	const prog = parseEntityExtractionProgress(queueMessage ?? null);
+	const pct = prog ? chunkProgressPercent(prog.processed, prog.total) : null;
+
+	return (
+		<div className="mt-2 w-full">
+			{pct !== null && prog ? (
+				<>
+					<div
+						className="h-1.5 w-full rounded-full bg-neutral-200 dark:bg-neutral-700 overflow-hidden"
+						role="progressbar"
+						aria-valuenow={pct}
+						aria-valuemin={0}
+						aria-valuemax={100}
+						aria-label={`Indexing progress ${pct} percent`}
+					>
+						<div
+							className="h-full rounded-full bg-primary transition-[width] duration-300"
+							style={{ width: `${pct}%` }}
+						/>
+					</div>
+					<p className="text-xs text-neutral-600 dark:text-neutral-400 mt-1 tabular-nums">
+						{pct}% indexed ({prog.processed} of {prog.total} chunks)
+					</p>
+				</>
+			) : (
+				<p className="text-xs text-neutral-600 dark:text-neutral-400">
+					Indexing entities…
+				</p>
+			)}
+		</div>
+	);
+}

--- a/src/components/upload/ResourceFileItem.tsx
+++ b/src/components/upload/ResourceFileItem.tsx
@@ -6,6 +6,7 @@ import { getDisplayName } from "@/lib/display-name-utils";
 import { cn } from "@/lib/utils";
 import { AuthService } from "@/services/core/auth-service";
 import type { Campaign } from "@/types/campaign";
+import { LibraryEntityIndexingProgress } from "./LibraryEntityIndexingProgress";
 import { ResourceFileDetails } from "./ResourceFileDetails";
 
 interface ResourceFileItemProps {
@@ -137,6 +138,10 @@ export function ResourceFileItem({
 									Visual inspiration
 								</p>
 							) : null}
+							<LibraryEntityIndexingProgress
+								queueMessage={file.library_entity_discovery_queue_message}
+								status={file.library_entity_discovery_status}
+							/>
 						</div>
 						{AuthService.getUsernameFromStoredJwt() && (
 							<FileStatusIndicator

--- a/src/components/upload/ResourceList.tsx
+++ b/src/components/upload/ResourceList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { MEMORY_LIMIT_COPY } from "@/app-constants";
 import { Button } from "@/components/button/Button";
 import { FileDAO } from "@/dao";
@@ -90,6 +90,24 @@ export function ResourceList({
 		if (!searchQuery.trim()) return files;
 		return files.filter((f) => matchesResourceSearch(f, searchQuery));
 	}, [files, searchQuery]);
+
+	const needsLibraryDiscoveryPoll = useMemo(
+		() =>
+			files.some(
+				(f) =>
+					f.library_entity_discovery_status === "pending" ||
+					f.library_entity_discovery_status === "processing"
+			),
+		[files]
+	);
+
+	useEffect(() => {
+		if (!needsLibraryDiscoveryPoll) return;
+		const id = window.setInterval(() => {
+			void fetchResources();
+		}, 20000);
+		return () => window.clearInterval(id);
+	}, [needsLibraryDiscoveryPoll, fetchResources]);
 
 	// File event handling - manages progress state internally and via prop setter
 	useResourceFileEvents({


### PR DESCRIPTION
Library files surface PROGRESS from library_entity_discovery on each ResourceFileItem; poll the file list every 20s while discovery runs. Remove campaign linked-resources chunk bar and related modal state now that indexing is driven from the library.

Made-with: Cursor