### PR TITLE
Gate add-to-campaign on library entity discovery and skip duplicate e…

### DIFF
--- a/src/components/upload/FileStatusIndicator.tsx
+++ b/src/components/upload/FileStatusIndicator.tsx
@@ -13,6 +13,7 @@ import {
 	estimateProcessingTime,
 	formatProcessingTime,
 } from "@/lib/file/processing-time-estimator";
+import { isLibraryEntityDiscoveryInFlight } from "@/lib/library-entity-pipeline";
 
 interface FileStatusIndicatorProps {
 	className?: string;
@@ -29,6 +30,8 @@ interface FileStatusIndicatorProps {
 	retryLimitDisabled?: boolean;
 	/** Tooltip text when retry is disabled due to limit */
 	retryLimitTooltip?: string;
+	/** When RAG is `completed` but library entity discovery is still running, show as processing */
+	libraryEntityDiscoveryStatus?: string | null;
 }
 
 export function FileStatusIndicator({
@@ -44,6 +47,7 @@ export function FileStatusIndicator({
 	onRetry,
 	retryLimitDisabled = false,
 	retryLimitTooltip,
+	libraryEntityDiscoveryStatus,
 }: FileStatusIndicatorProps) {
 	// No local error timeout; rely on SSE-driven updates and server state
 
@@ -152,8 +156,13 @@ export function FileStatusIndicator({
 	// Get current status - use initialStatus if it exists in statusConfig, otherwise default to PROCESSING
 	let currentStatus: keyof typeof statusConfig;
 
-	// Check if initialStatus is a valid key in statusConfig
-	if (initialStatus && initialStatus in statusConfig) {
+	// RAG can be "completed" while library entity + shard discovery is still running
+	if (
+		initialStatus === FILE_UPLOAD_STATUS.COMPLETED &&
+		isLibraryEntityDiscoveryInFlight(libraryEntityDiscoveryStatus)
+	) {
+		currentStatus = FILE_UPLOAD_STATUS.PROCESSING;
+	} else if (initialStatus && initialStatus in statusConfig) {
 		currentStatus = initialStatus as keyof typeof statusConfig;
 	} else if (initialStatus === "failed") {
 		// Handle legacy "failed" status

--- a/src/components/upload/ResourceFileDetails.tsx
+++ b/src/components/upload/ResourceFileDetails.tsx
@@ -4,6 +4,10 @@ import { Button } from "@/components/button/Button";
 import { Tooltip } from "@/components/tooltip/Tooltip";
 import { FileDAO } from "@/dao";
 import type { ResourceFileWithCampaigns } from "@/hooks/useResourceFiles";
+import {
+	isFileReadyForCampaignAdd,
+	isLibraryEntityDiscoveryInFlight,
+} from "@/lib/library-entity-pipeline";
 import type { Campaign } from "@/types/campaign";
 
 const LIBRARY_DISCOVERY_LABEL: Record<string, string> = {
@@ -42,6 +46,7 @@ export function ResourceFileDetails({
 	retryLimitDisabled = false,
 	retryLimitTooltip,
 }: ResourceFileDetailsProps) {
+	const canAddToCampaign = isFileReadyForCampaignAdd(file);
 	const [isDeleting, setIsDeleting] = useState(false);
 	const handleRetryIndexing = async () => {
 		await onRetryIndexing(file.file_key);
@@ -271,11 +276,15 @@ export function ResourceFileDetails({
 						variant="secondary"
 						size="sm"
 						className="w-full !text-purple-600 dark:!text-purple-400 hover:!text-purple-700 dark:hover:!text-purple-300 border-purple-200 dark:border-purple-700 hover:border-purple-300 dark:hover:border-purple-600"
-						disabled={file.status !== FileDAO.STATUS.COMPLETED}
+						disabled={!canAddToCampaign}
 					>
-						{file.status === FileDAO.STATUS.COMPLETED
+						{canAddToCampaign
 							? "Add to campaign"
-							: "File Not Ready"}
+							: isLibraryEntityDiscoveryInFlight(
+										file.library_entity_discovery_status
+									)
+								? "Indexing entities…"
+								: "File not ready"}
 					</Button>
 				)}
 				<Button

--- a/src/components/upload/ResourceFileItem.tsx
+++ b/src/components/upload/ResourceFileItem.tsx
@@ -3,6 +3,7 @@ import { FileStatusIndicator } from "@/components/upload/FileStatusIndicator";
 import { FileDAO } from "@/dao";
 import type { ResourceFileWithCampaigns } from "@/hooks/useResourceFiles";
 import { getDisplayName } from "@/lib/display-name-utils";
+import { isLibraryEntityDiscoveryInFlight } from "@/lib/library-entity-pipeline";
 import { cn } from "@/lib/utils";
 import { AuthService } from "@/services/core/auth-service";
 import type { Campaign } from "@/types/campaign";
@@ -49,6 +50,14 @@ export function ResourceFileItem({
 		file.file_name || file.display_name || ""
 	);
 
+	const libraryDiscoveryInFlight = isLibraryEntityDiscoveryInFlight(
+		file.library_entity_discovery_status
+	);
+	const statusForDisplayProgress =
+		file.status === FileDAO.STATUS.COMPLETED && libraryDiscoveryInFlight
+			? FileDAO.STATUS.INDEXING
+			: file.status;
+
 	const progressPercentage = (() => {
 		// Check for campaign addition progress first
 		if (typeof campaignProgress === "number") {
@@ -61,7 +70,7 @@ export function ResourceFileItem({
 		}
 
 		// Progress based on status
-		switch (file.status) {
+		switch (statusForDisplayProgress) {
 			case FileDAO.STATUS.UPLOADING:
 				return 20;
 			case FileDAO.STATUS.UPLOADED:
@@ -147,6 +156,9 @@ export function ResourceFileItem({
 							<FileStatusIndicator
 								tenant={AuthService.getUsernameFromStoredJwt()!}
 								initialStatus={file.status}
+								libraryEntityDiscoveryStatus={
+									file.library_entity_discovery_status
+								}
 								fileKey={file.file_key}
 								fileName={file.file_name}
 								fileSize={file.file_size}

--- a/src/hooks/useCampaignAddition.ts
+++ b/src/hooks/useCampaignAddition.ts
@@ -273,6 +273,31 @@ export function useCampaignAddition(
 								// Fall through to throw
 							}
 						}
+						if (response.status === 409) {
+							try {
+								const errBody = JSON.parse(errorText) as {
+									code?: string;
+									error?: string;
+								};
+								if (errBody.code === "LIBRARY_DISCOVERY_IN_PROGRESS") {
+									addLocalNotification(
+										NOTIFICATION_TYPES.ERROR,
+										"File not ready",
+										errBody.error ??
+											"Entity indexing is still in progress. Try again when the library shows ready."
+									);
+									setCampaignAdditionProgress((prev) => {
+										const next = { ...prev };
+										delete next[fileKey];
+										return next;
+									});
+									setIsAddingToCampaigns(false);
+									return;
+								}
+							} catch {
+								// fall through
+							}
+						}
 						const { parseErrorResponse, formatErrorForNotification } =
 							await import("@/lib/error-parsing");
 						const parsedError = parseErrorResponse(errorText, response.status);

--- a/src/hooks/useResourceFiles.ts
+++ b/src/hooks/useResourceFiles.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { ERROR_MESSAGES } from "@/app-constants";
 import { FileDAO } from "@/dao";
+import { isLibraryEntityDiscoveryInFlight } from "@/lib/library-entity-pipeline";
 import { parseTags } from "@/lib/resource-tags";
 import {
 	authenticatedFetchWithExpiration,
@@ -187,7 +188,13 @@ export function useResourceFiles(
 	}, [fetchResourceCampaigns, campaigns]);
 
 	const processingCount = useMemo(
-		() => files.filter((f) => PROCESSING_STATUSES.has(f.status)).length,
+		() =>
+			files.filter(
+				(f) =>
+					PROCESSING_STATUSES.has(f.status) ||
+					(f.status === FileDAO.STATUS.COMPLETED &&
+						isLibraryEntityDiscoveryInFlight(f.library_entity_discovery_status))
+			).length,
 		[files]
 	);
 

--- a/src/lib/library-entity-pipeline.ts
+++ b/src/lib/library-entity-pipeline.ts
@@ -1,0 +1,23 @@
+/**
+ * Library entity discovery runs after RAG completes. These helpers align UI and API
+ * so "ready" and "add to campaign" wait until discovery is not in flight.
+ */
+export function isLibraryEntityDiscoveryInFlight(
+	status: string | null | undefined
+): boolean {
+	return status === "pending" || status === "processing";
+}
+
+/**
+ * RAG is done and, when the library-entity table reports status, it is not pending/processing.
+ */
+export function isFileReadyForCampaignAdd(file: {
+	status: string;
+	library_entity_discovery_status?: string | null;
+}): boolean {
+	if (file.status !== "completed") return false;
+	if (isLibraryEntityDiscoveryInFlight(file.library_entity_discovery_status)) {
+		return false;
+	}
+	return true;
+}

--- a/src/routes/campaign-resource-proposals.ts
+++ b/src/routes/campaign-resource-proposals.ts
@@ -1,6 +1,8 @@
 import type { Context } from "hono";
 import { CAMPAIGN_ROLES } from "@/constants/campaign-roles";
+import { FileDAO } from "@/dao";
 import { getDAOFactory } from "@/dao/dao-factory";
+import { LibraryEntityDAO } from "@/dao/library-entity-dao";
 import {
 	addResourceToCampaign,
 	checkResourceExists,
@@ -9,6 +11,7 @@ import {
 	getExtension,
 	validateR2ObjectAndGetStream,
 } from "@/lib/file/file-upload-security";
+import { isLibraryEntityDiscoveryInFlight } from "@/lib/library-entity-pipeline";
 import { getRequestLogger } from "@/lib/logger";
 import {
 	notifyProposalApproved,
@@ -285,6 +288,38 @@ export async function handleApproveResourceProposal(c: ContextWithAuth) {
 				},
 				429
 			);
+		}
+
+		const fileRecord = await daoFactory.fileDAO.getFileForRag(
+			proposal.file_key,
+			userAuth.username
+		);
+		if (!fileRecord) {
+			return c.json({ error: "File not found in library" }, 404);
+		}
+		if (fileRecord.status !== FileDAO.STATUS.COMPLETED) {
+			return c.json(
+				{
+					error: "File is not yet indexed",
+					status: fileRecord.status,
+				},
+				400
+			);
+		}
+		const libEntityDao = new LibraryEntityDAO(c.env.DB);
+		if (await libEntityDao.isSchemaReady()) {
+			const discovery = await libEntityDao.getDiscovery(proposal.file_key);
+			if (discovery && isLibraryEntityDiscoveryInFlight(discovery.status)) {
+				return c.json(
+					{
+						error:
+							"Entity indexing is still in progress. Try again when the library shows ready.",
+						code: "LIBRARY_DISCOVERY_IN_PROGRESS",
+						libraryEntityDiscoveryStatus: discovery.status,
+					},
+					409
+				);
+			}
 		}
 
 		const resourceId = crypto.randomUUID();

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -4,6 +4,7 @@ import { CAMPAIGN_ROLES } from "@/constants/campaign-roles";
 import { FileDAO } from "@/dao";
 import { getDAOFactory } from "@/dao/dao-factory";
 import { EntityExtractionQueueDAO } from "@/dao/entity-extraction-queue-dao";
+import { LibraryEntityDAO } from "@/dao/library-entity-dao";
 import {
 	buildBulkDeletionResponse,
 	buildCampaignCreationResponse,
@@ -26,6 +27,7 @@ import {
 	getExtension,
 	validateR2ObjectAndGetStream,
 } from "@/lib/file/file-upload-security";
+import { isLibraryEntityDiscoveryInFlight } from "@/lib/library-entity-pipeline";
 import { getRequestLogger } from "@/lib/logger";
 import {
 	getBlockedExtensionsDescription,
@@ -684,6 +686,22 @@ export async function handleAddResourceToCampaign(c: ContextWithAuth) {
 				},
 				400
 			);
+		}
+
+		const libEntityDao = new LibraryEntityDAO(c.env.DB);
+		if (await libEntityDao.isSchemaReady()) {
+			const discovery = await libEntityDao.getDiscovery(id);
+			if (discovery && isLibraryEntityDiscoveryInFlight(discovery.status)) {
+				return c.json(
+					{
+						error:
+							"Entity indexing is still in progress. Try again when the library shows ready.",
+						code: "LIBRARY_DISCOVERY_IN_PROGRESS",
+						libraryEntityDiscoveryStatus: discovery.status,
+					},
+					409
+				);
+			}
 		}
 
 		log.debug(

--- a/src/services/campaign/entity-extraction-queue-service.ts
+++ b/src/services/campaign/entity-extraction-queue-service.ts
@@ -17,6 +17,7 @@ import { createLogger } from "@/lib/logger";
 import type { Env } from "@/middleware/auth";
 import { TelemetryService } from "@/services/telemetry/telemetry-service";
 import { stageEntitiesFromResource } from "./entity-staging-service";
+import { tryCopyLibraryEntitiesToCampaign } from "./library-entity-copy-to-campaign-service";
 
 export interface EntityExtractionJobOptions {
 	env: Env;
@@ -182,10 +183,6 @@ export class EntityExtractionQueueService {
 
 		for (const item of queueItems) {
 			try {
-				// Mark as processing
-				await queueDAO.markAsProcessing(item.id);
-				const runStartedAt = Date.now();
-
 				// Get campaign details
 				const campaign =
 					await daoFactory.campaignDAO.getCampaignByIdWithMapping(
@@ -210,6 +207,32 @@ export class EntityExtractionQueueService {
 						`Resource not found: ${item.resource_id} in campaign ${item.campaign_id}`
 					);
 				}
+
+				// If library discovery finished after this was queued, copy and skip duplicate LLM extraction
+				if (item.file_key) {
+					const copied = await tryCopyLibraryEntitiesToCampaign({
+						env,
+						username: item.username,
+						campaignId: item.campaign_id,
+						campaignName: campaign.name,
+						resourceId: item.resource_id,
+						fileKey: item.file_key,
+						fileName: resource.file_name ?? item.resource_name,
+						attribution:
+							item.proposed_by != null
+								? { proposedBy: item.proposed_by, approvedBy: item.username }
+								: undefined,
+					});
+					if (copied) {
+						await queueDAO.markAsCompleted(item.id);
+						processed++;
+						continue;
+					}
+				}
+
+				// Mark as processing
+				await queueDAO.markAsProcessing(item.id);
+				const runStartedAt = Date.now();
 
 				const providerKeyEnvVar =
 					MODEL_CONFIG.PROVIDER.DEFAULT === "anthropic"


### PR DESCRIPTION
…xtraction

- Add library-entity-pipeline helpers; show processing until discovery completes
- Disable add-to-campaign in UI; return 409 from add and proposal approve
- Count post-RAG discovery in processing; handle 409 in useCampaignAddition
- Entity extraction queue: try copy from library before LLM when possible

Made-with: Cursor