### PR TITLE
Add verbose LLM token spend logging with intents.

### DIFF
--- a/.vars.example
+++ b/.vars.example
@@ -26,6 +26,11 @@
 # OpenAI API Key (optional - users can provide their own in production)
 # OPENAI_API_KEY=sk-your-openai-api-key-here
 
+# When set to 1/true/yes/on (case-insensitive), emit structured `llm_token_spend` logs
+# with intent/source for debugging token usage (see LORESMITH_VERBOSE_LLM_USAGE in code).
+# Production sets `LORESMITH_VERBOSE_LLM_USAGE` in wrangler.jsonc `vars`; override locally if needed.
+# LORESMITH_VERBOSE_LLM_USAGE=1
+
 # CORS allowed origins for production
 CORS_ALLOWED_ORIGINS=https://yourdomain.com
 

--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -13,6 +13,11 @@ import { getStatusMessageForTool } from "@/lib/agent-status-messages";
 import { getEnvVar } from "@/lib/env-utils";
 import { buildExplainabilityFromSteps } from "@/lib/explainability-builder";
 import { normalizeMessageHistoryScope } from "@/lib/get-message-history-query";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
+import {
+	isVerboseLlmSpendEnabled,
+	logVerboseLlmSpend,
+} from "@/lib/llm-usage-verbose-log";
 import { createLogger } from "@/lib/logger";
 import { messageHistoryInjectionFlags } from "@/lib/message-history-injection";
 import { getAgentRoleContext } from "@/lib/prompts/agent-role-context";
@@ -37,6 +42,20 @@ import {
 	MESSAGE_HISTORY_REFERENCE_RULE,
 	MESSAGE_HISTORY_RESEARCH_RULE,
 } from "./system-prompts";
+
+function parseUsernameFromClientJwt(clientJwt: string | null): string | null {
+	if (!clientJwt) return null;
+	try {
+		const part = clientJwt.split(".")[1] || "";
+		let base64 = part.replace(/-/g, "+").replace(/_/g, "/");
+		const pad = base64.length % 4;
+		if (pad) base64 += "=".repeat(4 - pad);
+		const jwtPayload = JSON.parse(atob(base64)) as { username?: string };
+		return typeof jwtPayload.username === "string" ? jwtPayload.username : null;
+	} catch {
+		return null;
+	}
+}
 
 interface Env {
 	Chat: DurableObjectNamespace;
@@ -455,6 +474,12 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 				{ hasLastUserMessage: !!lastUserMessage }
 			);
 		}
+
+		const usageBillingUserData = lastUserMessage?.data as
+			| { isHelpRequest?: boolean }
+			| undefined;
+		const isHelpRequestForUsage = usageBillingUserData?.isHelpRequest === true;
+
 		if (!selectedCampaignId) {
 			// Fallback: use the most recent campaignId found in message metadata
 			// (including client marker system messages) so tools can use the
@@ -842,18 +867,9 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 					durationMs: Date.now() - turnStartedAt,
 				});
 				// Record LLM usage for rate limiting (chat consumes quota)
-				const lastUserData = lastUserMessage?.data as
-					| { isHelpRequest?: boolean }
-					| undefined;
-				const isHelpRequest = lastUserData?.isHelpRequest === true;
-				if (clientJwt && !isHelpRequest) {
+				if (clientJwt && !isHelpRequestForUsage) {
 					try {
-						const part = clientJwt.split(".")[1] || "";
-						let base64 = part.replace(/-/g, "+").replace(/_/g, "/");
-						const pad = base64.length % 4;
-						if (pad) base64 += "=".repeat(4 - pad);
-						const jwtPayload = JSON.parse(atob(base64));
-						const username = jwtPayload.username;
+						const username = parseUsernameFromClientJwt(clientJwt);
 						const usage = (args?.totalUsage ?? args?.usage) as
 							| {
 									totalTokens?: number;
@@ -861,16 +877,57 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 									completionTokens?: number;
 							  }
 							| undefined;
-						if (username && usage) {
-							const tokens =
-								usage.totalTokens ??
-								(usage.promptTokens ?? 0) + (usage.completionTokens ?? 0);
-							if (tokens > 0 && this.env?.DB) {
-								const rateLimitService = getLLMRateLimitService(
-									this.env as Parameters<typeof getLLMRateLimitService>[0]
-								);
-								await rateLimitService.recordUsage(username, tokens, 1);
+						const tokens = usage
+							? (usage.totalTokens ??
+								(usage.promptTokens ?? 0) + (usage.completionTokens ?? 0))
+							: 0;
+						const envRecord = this.env as Record<string, unknown> | undefined;
+						const verbose = isVerboseLlmSpendEnabled(envRecord);
+
+						if (username && tokens > 0 && this.env?.DB) {
+							const rateLimitService = getLLMRateLimitService(
+								this.env as Parameters<typeof getLLMRateLimitService>[0]
+							);
+							await rateLimitService.recordUsage(
+								username,
+								tokens,
+								1,
+								undefined,
+								{
+									intent: LLM_SPEND_INTENT.user_prompt,
+									source: "base_agent:onChatMessage",
+									agent: this.constructor.name,
+									promptTokens: usage?.promptTokens,
+									completionTokens: usage?.completionTokens,
+									totalTokens: usage?.totalTokens,
+								}
+							);
+						} else if (verbose && username) {
+							const extras: Record<string, unknown> = {
+								finishReason: args?.finishReason ?? null,
+								agent: this.constructor.name,
+							};
+							if (usage) {
+								extras.promptTokens = usage.promptTokens;
+								extras.completionTokens = usage.completionTokens;
+								extras.totalTokens = usage.totalTokens;
+							} else {
+								extras.usageUnavailable = true;
 							}
+							if (tokens > 0 && !this.env?.DB) {
+								extras.d1Unavailable = true;
+							}
+							if (tokens === 0) {
+								extras.zeroTokenFinish = true;
+							}
+							logVerboseLlmSpend(envRecord, {
+								intent: LLM_SPEND_INTENT.user_prompt,
+								source: "base_agent:onChatMessage",
+								username,
+								tokens,
+								queryCount: 1,
+								extras,
+							});
 						}
 					} catch (err) {
 						log.warn("Failed to record LLM usage", err);
@@ -944,6 +1001,34 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 				);
 				if (error?.stack && error.stack.length < 1000) {
 					log.error("Stack:", error.stack);
+				}
+
+				if (
+					clientJwt &&
+					!isHelpRequestForUsage &&
+					isVerboseLlmSpendEnabled(this.env as Record<string, unknown>)
+				) {
+					const username = parseUsernameFromClientJwt(clientJwt);
+					if (username) {
+						const statusCode =
+							(error?.statusCode as number | undefined) ??
+							(error?.status as number | undefined);
+						logVerboseLlmSpend(this.env as Record<string, unknown>, {
+							intent: LLM_SPEND_INTENT.user_prompt,
+							source: "base_agent:onChatMessage_provider_error",
+							username,
+							tokens: 0,
+							queryCount: 0,
+							model: modelId,
+							extras: {
+								agent: this.constructor.name,
+								errorName: error?.name,
+								statusCode: statusCode ?? null,
+								code: error?.code ?? null,
+								message: errorMessage.slice(0, 500),
+							},
+						});
+					}
 				}
 				// User-facing error message is provided by toUIMessageStreamResponse onError
 			},

--- a/src/lib/llm-usage-intents.ts
+++ b/src/lib/llm-usage-intents.ts
@@ -1,0 +1,30 @@
+/**
+ * Controlled vocabulary for verbose LLM token spend logs (`intent` field).
+ * Add new values here only — keeps Cloudflare log drains grepable.
+ *
+ * | Intent | Typical triggers |
+ * |--------|------------------|
+ * | user_prompt | Chat / agent completion |
+ * | entity_extraction | Entity extraction / chunk gate |
+ * | graph_rebuild | GraphRAG / shard field generation |
+ * | graph_visualization | Graph visualization embeddings / search |
+ * | shard_embedding | Shard embedding queue |
+ * | visual_inspiration_title | Visual asset title LLM |
+ * | character_sheet_detection | Character sheet detect pass |
+ * | embedding_index | File embedding (Vectorize indexing path) |
+ * | vision_image_extract | Vision image description for extraction |
+ */
+export const LLM_SPEND_INTENT = {
+	user_prompt: "user_prompt",
+	entity_extraction: "entity_extraction",
+	graph_rebuild: "graph_rebuild",
+	graph_visualization: "graph_visualization",
+	shard_embedding: "shard_embedding",
+	visual_inspiration_title: "visual_inspiration_title",
+	character_sheet_detection: "character_sheet_detection",
+	embedding_index: "embedding_index",
+	vision_image_extract: "vision_image_extract",
+} as const;
+
+export type LlmSpendIntent =
+	(typeof LLM_SPEND_INTENT)[keyof typeof LLM_SPEND_INTENT];

--- a/src/lib/llm-usage-intents.ts
+++ b/src/lib/llm-usage-intents.ts
@@ -13,6 +13,7 @@
  * | character_sheet_detection | Character sheet detect pass |
  * | embedding_index | File embedding (Vectorize indexing path) |
  * | vision_image_extract | Vision image description for extraction |
+ * | session_plan_readout | Session plan readout (stitch / single-shot plan LLM) |
  */
 export const LLM_SPEND_INTENT = {
 	user_prompt: "user_prompt",
@@ -24,6 +25,7 @@ export const LLM_SPEND_INTENT = {
 	character_sheet_detection: "character_sheet_detection",
 	embedding_index: "embedding_index",
 	vision_image_extract: "vision_image_extract",
+	session_plan_readout: "session_plan_readout",
 } as const;
 
 export type LlmSpendIntent =

--- a/src/lib/llm-usage-verbose-log.ts
+++ b/src/lib/llm-usage-verbose-log.ts
@@ -1,0 +1,63 @@
+import type { EnvWithSecrets } from "@/lib/env-utils";
+import type { LlmSpendIntent } from "@/lib/llm-usage-intents";
+import { createLogger } from "@/lib/logger";
+
+export const LLM_SPEND_VERBOSE_ENV = "LORESMITH_VERBOSE_LLM_USAGE";
+
+function readVerboseFlag(env?: Record<string, unknown>): boolean {
+	const fromEnv = env?.[LLM_SPEND_VERBOSE_ENV];
+	const fromProcess =
+		typeof process !== "undefined"
+			? process.env[LLM_SPEND_VERBOSE_ENV]
+			: undefined;
+	const raw =
+		(typeof fromEnv === "string" ? fromEnv : undefined) ??
+		(typeof fromProcess === "string" ? fromProcess : undefined);
+	if (raw === undefined) {
+		return fromEnv === true;
+	}
+	return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}
+
+/** Whether structured `llm_token_spend` logs are enabled for this env / process. */
+export function isVerboseLlmSpendEnabled(
+	env?: EnvWithSecrets | Record<string, unknown>
+): boolean {
+	return readVerboseFlag(env as Record<string, unknown> | undefined);
+}
+
+export type VerboseLlmSpendPayload = {
+	intent: LlmSpendIntent;
+	source?: string;
+	username?: string;
+	tokens: number;
+	queryCount?: number;
+	model?: string;
+	promptTokens?: number;
+	completionTokens?: number;
+	totalTokens?: number;
+	/** Small, bounded context — never full prompts */
+	extras?: Record<string, unknown>;
+};
+
+/**
+ * Structured info log for token spend debugging when LORESMITH_VERBOSE_LLM_USAGE is on.
+ */
+export function logVerboseLlmSpend(
+	env: EnvWithSecrets | Record<string, unknown> | undefined,
+	payload: VerboseLlmSpendPayload
+): void {
+	if (!readVerboseFlag(env as Record<string, unknown> | undefined)) {
+		return;
+	}
+	const log = createLogger(
+		env as Record<string, unknown> | undefined,
+		"[LLM_USAGE]"
+	);
+	const { extras, ...rest } = payload;
+	log.info("llm_token_spend", {
+		event: "llm_token_spend",
+		...rest,
+		...(extras && Object.keys(extras).length > 0 ? { extras } : {}),
+	});
+}

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -977,7 +977,8 @@ async function processPendingFileChunks(env: Env): Promise<void> {
 									chunkDef,
 									fileSize,
 									contentType,
-									metadataId
+									metadataId,
+									chunk.username
 								);
 								log.debug("Successfully processed PDF chunk (R2 range)", {
 									chunkIndex: chunk.chunkIndex + 1,
@@ -1011,7 +1012,8 @@ async function processPendingFileChunks(env: Env): Promise<void> {
 									chunkDefinition,
 									chunkBuffer,
 									contentType,
-									metadataId
+									metadataId,
+									chunk.username
 								);
 							}
 							continue;
@@ -1034,7 +1036,8 @@ async function processPendingFileChunks(env: Env): Promise<void> {
 							chunkDefinition,
 							chunkBuffer,
 							contentType,
-							metadataId
+							metadataId,
+							chunk.username
 						);
 
 						log.debug("Successfully processed chunk", {

--- a/src/routes/app/index.ts
+++ b/src/routes/app/index.ts
@@ -1,5 +1,7 @@
 import { routeAgentRequest } from "agents";
 import type { Context, Hono } from "hono";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
+import { logVerboseLlmSpend } from "@/lib/llm-usage-verbose-log";
 import type { RequestLogger } from "@/lib/logger";
 import type { Env } from "@/routes/env";
 import { toApiRoutePath } from "@/routes/env";
@@ -63,6 +65,20 @@ export function registerAppRoutes(
 				authPayload.username,
 				authPayload.isAdmin ?? false
 			);
+			if (!check.allowed) {
+				logVerboseLlmSpend(c.env, {
+					intent: LLM_SPEND_INTENT.user_prompt,
+					source: "app_agents_route:quota_blocked",
+					username: authPayload.username,
+					tokens: 0,
+					queryCount: 0,
+					extras: {
+						reason: check.reason ?? null,
+						limitType: check.limitType ?? null,
+						nextResetAt: check.nextResetAt ?? null,
+					},
+				});
+			}
 			if (!check.allowed && check.nextResetAt) {
 				const retryAfterSeconds = Math.ceil(
 					(new Date(check.nextResetAt).getTime() - Date.now()) / 1000

--- a/src/routes/campaign-graphrag.ts
+++ b/src/routes/campaign-graphrag.ts
@@ -7,6 +7,7 @@ import {
 	isStubContentSufficient,
 } from "@/lib/entity/entity-required-fields";
 import { getEnvVar } from "@/lib/env-utils";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
 import { createLogger, getRequestLogger } from "@/lib/logger";
 import { notifyCampaignMembers } from "@/lib/notifications";
 import {
@@ -776,11 +777,19 @@ Rules:
 		const rateLimitService = getLLMRateLimitService(c.env);
 		const value = await provider.generateSummary(prompt, {
 			username: userAuth.username,
-			onUsage: async (usage) => {
+			onUsage: async (usage, ctx) => {
 				await rateLimitService.recordUsage(
 					userAuth.username,
 					usage.tokens,
-					usage.queryCount
+					usage.queryCount,
+					ctx?.model,
+					{
+						intent: LLM_SPEND_INTENT.graph_rebuild,
+						source: "campaign_graphrag:generate_shard_field",
+						campaignId,
+						shardId,
+						field,
+					}
 				);
 			},
 		});

--- a/src/routes/graph-visualization.ts
+++ b/src/routes/graph-visualization.ts
@@ -19,6 +19,7 @@ import {
 	computeOrphanNodes,
 	type GraphFilters,
 } from "@/lib/graph/graph-visualization-helpers";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
 import type { Env } from "@/middleware/auth";
 import type { AuthPayload } from "@/services/core/auth-service";
 import { ProviderEmbeddingService } from "@/services/embedding/provider-embedding-service";
@@ -455,11 +456,18 @@ export async function handleSearchEntityInGraph(c: ContextWithAuth) {
 				const getQueryEmbedding = async (q: string) => {
 					const [emb] = await embeddingProvider.generateEmbeddings([q], {
 						username: userAuth.username,
-						onUsage: async (usage) => {
+						onUsage: async (usage, ctx) => {
 							await rateLimitService.recordUsage(
 								userAuth.username,
 								usage.tokens,
-								usage.queryCount
+								usage.queryCount,
+								ctx?.model,
+								{
+									intent: LLM_SPEND_INTENT.graph_visualization,
+									source: "graph_visualization:search_entity_embedding",
+									campaignId,
+									entityName,
+								}
 							);
 						},
 					});

--- a/src/services/campaign/entity-staging-service.ts
+++ b/src/services/campaign/entity-staging-service.ts
@@ -17,6 +17,7 @@ import {
 	truncateContentAtSentenceBoundary,
 } from "@/lib/file/text-chunking-utils";
 import { getLibrarySyntheticCampaignId } from "@/lib/library-entity-id";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
 import { notifyCampaignMembers } from "@/lib/notifications";
 import { R2Helper } from "@/lib/r2";
 import {
@@ -335,7 +336,15 @@ async function stageEntitiesFromResourceImpl(
 							await rateLimitService.recordUsage(
 								username,
 								usage.tokens,
-								usage.queryCount
+								usage.queryCount,
+								undefined,
+								{
+									intent: LLM_SPEND_INTENT.visual_inspiration_title,
+									source: "entity_staging:visual_inspiration_title",
+									campaignId,
+									fileKey: normalizedResource.file_key || undefined,
+									libraryMode,
+								}
 							);
 						},
 					});
@@ -416,7 +425,15 @@ async function stageEntitiesFromResourceImpl(
 						await rateLimitService.recordUsage(
 							username,
 							usage.tokens,
-							usage.queryCount
+							usage.queryCount,
+							undefined,
+							{
+								intent: LLM_SPEND_INTENT.character_sheet_detection,
+								source: "entity_staging:character_sheet_detection",
+								campaignId,
+								fileKey: normalizedResource.file_key || undefined,
+								libraryMode,
+							}
 						);
 					},
 				}
@@ -684,7 +701,15 @@ async function stageEntitiesFromResourceImpl(
 								username,
 								usage.tokens,
 								usage.queryCount,
-								ctx?.model
+								ctx?.model,
+								{
+									intent: LLM_SPEND_INTENT.entity_extraction,
+									source: "entity_staging:extraction_chunk_gate",
+									phase: "chunk_gate",
+									campaignId,
+									fileKey: normalizedResource.file_key || undefined,
+									chunkIndex: chunkIndex,
+								}
 							);
 						},
 					});
@@ -726,7 +751,15 @@ async function stageEntitiesFromResourceImpl(
 							username,
 							usage.tokens,
 							usage.queryCount,
-							ctx?.model
+							ctx?.model,
+							{
+								intent: LLM_SPEND_INTENT.entity_extraction,
+								source: "entity_staging:extract_entities",
+								phase: "extract_entities",
+								campaignId,
+								fileKey: normalizedResource.file_key || undefined,
+								chunkIndex: chunkIndex,
+							}
 						);
 					},
 					metadata: {

--- a/src/services/campaign/impl/direct-file-content-extraction-provider.ts
+++ b/src/services/campaign/impl/direct-file-content-extraction-provider.ts
@@ -98,10 +98,14 @@ export class DirectFileContentExtractionProvider
 					typeof this.env.OPENAI_API_KEY === "string"
 						? this.env.OPENAI_API_KEY
 						: undefined;
-				const extractionService = new FileExtractionService(openAIApiKey);
+				const extractionService = new FileExtractionService(
+					openAIApiKey,
+					this.env as unknown as Record<string, unknown>
+				);
 				const imageResult = await extractionService.extractText(
 					fileBuffer,
-					effectiveType
+					effectiveType,
+					{ fileKey: resource.file_key ?? undefined }
 				);
 				if (!imageResult?.text?.trim()) {
 					return {

--- a/src/services/embedding/file-embedding-service.ts
+++ b/src/services/embedding/file-embedding-service.ts
@@ -6,6 +6,8 @@ import {
 	VectorizeIndexRequiredError,
 } from "@/lib/errors";
 import { chunkTextByCharacterCount } from "@/lib/file/text-chunking-utils";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
+import { logVerboseLlmSpend } from "@/lib/llm-usage-verbose-log";
 import { OpenAIEmbeddingService } from "./openai-embedding-service";
 
 const EMBEDDING_CHUNK_SIZE = 3500; // Stay safely under 4000 char limit
@@ -17,6 +19,12 @@ export interface EmbeddingMetadata {
 	metadataId: string;
 	type?: string;
 }
+
+/** Optional context for verbose `embedding_index` token logs only. */
+export type FileEmbeddingSpendContext = {
+	username?: string;
+	fileKey?: string;
+};
 
 /**
  * Service for storing file embeddings in Vectorize
@@ -36,7 +44,8 @@ export class FileEmbeddingService {
 	async storeEmbeddings(
 		text: string,
 		metadataId: string,
-		metadata: EmbeddingMetadata = { metadataId }
+		metadata: EmbeddingMetadata = { metadataId },
+		spendContext?: FileEmbeddingSpendContext
 	): Promise<string> {
 		if (!this.vectorize) {
 			throw new VectorizeIndexRequiredError();
@@ -66,7 +75,10 @@ export class FileEmbeddingService {
 				const chunkText = chunk.substring(0, EMBEDDING_CHUNK_SIZE);
 
 				// Generate embedding for this chunk using OpenAI
-				const embeddings = await this.generateEmbedding(chunkText);
+				const embeddings = await this.generateEmbedding(
+					chunkText,
+					spendContext
+				);
 
 				// Validate embedding dimensions
 				if (!Array.isArray(embeddings) || embeddings.length === 0) {
@@ -208,7 +220,10 @@ export class FileEmbeddingService {
 	/**
 	 * Generate embedding using OpenAI API
 	 */
-	private async generateEmbedding(text: string): Promise<number[]> {
+	private async generateEmbedding(
+		text: string,
+		spendContext?: FileEmbeddingSpendContext
+	): Promise<number[]> {
 		const apiKey = await this.resolveOpenAIKey();
 
 		try {
@@ -230,11 +245,38 @@ export class FileEmbeddingService {
 				);
 			}
 
-			const result = (await response.json()) as any;
-			const embedding = result.data[0]?.embedding;
+			const result = (await response.json()) as {
+				data?: Array<{ embedding?: unknown }>;
+				usage?: {
+					total_tokens?: number;
+					prompt_tokens?: number;
+					completion_tokens?: number;
+				};
+			};
+			const embedding = result.data?.[0]?.embedding;
 
 			if (!Array.isArray(embedding) || embedding.length === 0) {
 				throw new EmbeddingGenerationError("Invalid embedding response");
+			}
+
+			const totalTokens = result.usage?.total_tokens;
+			if (typeof totalTokens === "number" && totalTokens > 0) {
+				const extras: Record<string, unknown> = {};
+				if (spendContext?.fileKey) {
+					extras.fileKey = spendContext.fileKey;
+				}
+				logVerboseLlmSpend(this.env, {
+					intent: LLM_SPEND_INTENT.embedding_index,
+					source: "file_embedding_service",
+					username: spendContext?.username,
+					tokens: totalTokens,
+					queryCount: 1,
+					model: OpenAIEmbeddingService.EMBEDDING_MODEL,
+					promptTokens: result.usage?.prompt_tokens,
+					completionTokens: result.usage?.completion_tokens,
+					totalTokens,
+					extras: Object.keys(extras).length > 0 ? extras : undefined,
+				});
 			}
 
 			// Validate dimensions

--- a/src/services/file/chunked-processing-service.ts
+++ b/src/services/file/chunked-processing-service.ts
@@ -23,7 +23,12 @@ export class ChunkedProcessingService {
 
 	constructor(private env: Env) {
 		this.fileDAO = new FileDAO(env.DB);
-		this.extractionService = new FileExtractionService();
+		const openAIApiKey =
+			typeof env.OPENAI_API_KEY === "string" ? env.OPENAI_API_KEY : undefined;
+		this.extractionService = new FileExtractionService(
+			openAIApiKey,
+			env as unknown as Record<string, unknown>
+		);
 		this.pdfChunkingService = new PDFChunkingService();
 	}
 
@@ -164,11 +169,12 @@ export class ChunkedProcessingService {
 	 */
 	async processChunk(
 		chunkId: string,
-		_fileKey: string,
+		fileKey: string,
 		chunkDefinition: ChunkDefinition,
 		fileBuffer: ArrayBuffer,
 		contentType: string,
-		metadataId: string
+		metadataId: string,
+		username?: string
 	): Promise<{
 		success: boolean;
 		vectorId?: string;
@@ -226,7 +232,8 @@ export class ChunkedProcessingService {
 				{
 					metadataId,
 					type: "file_chunk",
-				}
+				},
+				{ username, fileKey }
 			);
 
 			// Mark chunk as completed
@@ -264,7 +271,8 @@ export class ChunkedProcessingService {
 		chunkDefinition: ChunkDefinition,
 		fileSize: number,
 		_contentType: string,
-		metadataId: string
+		metadataId: string,
+		username?: string
 	): Promise<{
 		success: boolean;
 		vectorId?: string;
@@ -312,7 +320,8 @@ export class ChunkedProcessingService {
 				{
 					metadataId,
 					type: "file_chunk",
-				}
+				},
+				{ username, fileKey }
 			);
 
 			await this.fileDAO.markFileChunkComplete(chunkId, vectorId);

--- a/src/services/file/file-extraction-service.ts
+++ b/src/services/file/file-extraction-service.ts
@@ -3,6 +3,8 @@ import { getDocument } from "pdfjs-serverless";
 import { PROCESSING_LIMITS } from "@/app-constants";
 import { MemoryLimitError, PDFExtractionError } from "@/lib/errors";
 import { getPdfPageCount as getPdfPageCountUtil } from "@/lib/file/pdf-utils";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
+import { logVerboseLlmSpend } from "@/lib/llm-usage-verbose-log";
 
 export interface ExtractionResult {
 	text: string;
@@ -10,19 +12,28 @@ export interface ExtractionResult {
 	totalPages?: number;
 }
 
+export type VisionExtractionSpendContext = {
+	username?: string;
+	fileKey?: string;
+};
+
 /**
  * Service for extracting text from various file types
  * Handles PDF, DOCX, text, and JSON files
  */
 export class FileExtractionService {
-	constructor(private readonly openAIApiKey?: string) {}
+	constructor(
+		private readonly openAIApiKey?: string,
+		private readonly env?: Record<string, unknown>
+	) {}
 
 	/**
 	 * Extract text from a file buffer based on content type
 	 */
 	async extractText(
 		buffer: ArrayBuffer,
-		contentType: string
+		contentType: string,
+		spendContext?: VisionExtractionSpendContext
 	): Promise<ExtractionResult | null> {
 		if (contentType.includes("pdf")) {
 			return await this.extractPdfText(buffer);
@@ -44,7 +55,7 @@ export class FileExtractionService {
 				return { text };
 			}
 		} else if (this.isImageContentType(contentType)) {
-			return await this.extractImageText(buffer, contentType);
+			return await this.extractImageText(buffer, contentType, spendContext);
 		}
 
 		return null;
@@ -62,7 +73,8 @@ export class FileExtractionService {
 
 	private async extractImageText(
 		buffer: ArrayBuffer,
-		contentType: string
+		contentType: string,
+		spendContext?: VisionExtractionSpendContext
 	): Promise<ExtractionResult> {
 		// Keep processing resilient if vision analysis is unavailable.
 		if (!this.openAIApiKey) {
@@ -136,7 +148,33 @@ export class FileExtractionService {
 
 			const data = (await response.json()) as {
 				choices?: Array<{ message?: { content?: string } }>;
+				usage?: {
+					total_tokens?: number;
+					prompt_tokens?: number;
+					completion_tokens?: number;
+				};
 			};
+
+			const totalTokens = data.usage?.total_tokens;
+			if (typeof totalTokens === "number" && totalTokens > 0) {
+				const extras: Record<string, unknown> = {};
+				if (spendContext?.fileKey) {
+					extras.fileKey = spendContext.fileKey;
+				}
+				logVerboseLlmSpend(this.env, {
+					intent: LLM_SPEND_INTENT.vision_image_extract,
+					source: "file_extraction_service",
+					username: spendContext?.username,
+					tokens: totalTokens,
+					queryCount: 1,
+					model: "gpt-4o-mini",
+					promptTokens: data.usage?.prompt_tokens,
+					completionTokens: data.usage?.completion_tokens,
+					totalTokens,
+					extras: Object.keys(extras).length > 0 ? extras : undefined,
+				});
+			}
+
 			const visionText = data.choices?.[0]?.message?.content?.trim();
 
 			if (!visionText) {

--- a/src/services/file/sync-queue-service.ts
+++ b/src/services/file/sync-queue-service.ts
@@ -573,7 +573,7 @@ export class SyncQueueService {
 	private static async processFileChunks(
 		env: any,
 		fileKey: string,
-		_username: string,
+		username: string,
 		fileName: string,
 		file: any,
 		dbMetadata: any
@@ -687,7 +687,8 @@ export class SyncQueueService {
 							chunkDef,
 							fileSize,
 							contentType,
-							metadataId
+							metadataId,
+							username
 						);
 					} else {
 						// Non-PDF or missing page range: load full file (may OOM)
@@ -716,7 +717,8 @@ export class SyncQueueService {
 							chunkDefinition,
 							chunkBuffer,
 							contentType,
-							metadataId
+							metadataId,
+							username
 						);
 					}
 					continue;
@@ -739,7 +741,8 @@ export class SyncQueueService {
 					chunkDefinition,
 					chunkBuffer,
 					contentType,
-					metadataId
+					metadataId,
+					username
 				);
 			} catch (chunkError) {
 				const errorMessage =

--- a/src/services/graph/shard-embedding-queue-processor.ts
+++ b/src/services/graph/shard-embedding-queue-processor.ts
@@ -1,5 +1,6 @@
 import { getDAOFactory } from "@/dao/dao-factory";
 import { getEnvVar } from "@/lib/env-utils";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
 import type { Env } from "@/middleware/auth";
 import { OpenAIEmbeddingService } from "@/services/embedding/openai-embedding-service";
 import { getLLMRateLimitService } from "@/services/llm/llm-rate-limit-service";
@@ -70,11 +71,18 @@ export class ShardEmbeddingQueueProcessor {
 					texts,
 					{
 						username,
-						onUsage: async (usage) => {
+						onUsage: async (usage, ctx) => {
 							await rateLimitService.recordUsage(
 								username,
 								usage.tokens,
-								usage.queryCount
+								usage.queryCount,
+								ctx?.model,
+								{
+									intent: LLM_SPEND_INTENT.shard_embedding,
+									source: "shard_embedding_queue_processor:batch",
+									campaignId,
+									entityCount: chunk.length,
+								}
 							);
 						},
 					}

--- a/src/services/llm/llm-rate-limit-service.ts
+++ b/src/services/llm/llm-rate-limit-service.ts
@@ -1,6 +1,14 @@
 import { getDAOFactory } from "@/dao/dao-factory";
+import type { LlmSpendIntent } from "@/lib/llm-usage-intents";
+import { logVerboseLlmSpend } from "@/lib/llm-usage-verbose-log";
 import type { Env } from "@/middleware/auth";
 import { getSubscriptionService } from "@/services/billing/subscription-service";
+
+/** Optional attribution for verbose token logs (intent required when passed). */
+export type LlmSpendLogMeta = {
+	intent: LlmSpendIntent;
+	source?: string;
+} & Record<string, unknown>;
 
 export interface CheckLimitResult {
 	allowed: boolean;
@@ -294,10 +302,27 @@ export class LLMRateLimitService {
 		username: string,
 		tokens: number,
 		queryCount: number,
-		model?: string
+		model?: string,
+		meta?: LlmSpendLogMeta
 	): Promise<void> {
 		const dao = getDAOFactory(this.env);
 		await dao.llmUsageDAO.insertUsage(username, tokens, queryCount, model);
+
+		if (meta) {
+			const { intent, source, ...extras } = meta;
+			logVerboseLlmSpend(this.env, {
+				intent,
+				source,
+				username,
+				tokens,
+				queryCount,
+				model,
+				extras:
+					Object.keys(extras).length > 0
+						? (extras as Record<string, unknown>)
+						: undefined,
+			});
+		}
 
 		// Free tier: track usage for cap (lifetime trial or monthly)
 		const subService = getSubscriptionService(this.env);

--- a/src/services/rag/rag-service.ts
+++ b/src/services/rag/rag-service.ts
@@ -30,7 +30,10 @@ export class LibraryRAGService extends BaseRAGService {
 		super(env.DB, env.VECTORIZE, env.OPENAI_API_KEY, env);
 		const openAIApiKey =
 			typeof env.OPENAI_API_KEY === "string" ? env.OPENAI_API_KEY : undefined;
-		this.extractionService = new FileExtractionService(openAIApiKey);
+		this.extractionService = new FileExtractionService(
+			openAIApiKey,
+			env as unknown as Record<string, unknown>
+		);
 		this.embeddingService = new FileEmbeddingService(
 			env.VECTORIZE,
 			env.OPENAI_API_KEY,
@@ -127,7 +130,8 @@ export class LibraryRAGService extends BaseRAGService {
 			}
 			extractionResult = await this.extractionService.extractText(
 				buffer!,
-				metadata.contentType
+				metadata.contentType,
+				{ username: metadata.userId, fileKey: metadata.fileKey }
 			);
 		} catch (memoryError) {
 			// Check if this is a memory limit error from Worker runtime
@@ -235,7 +239,9 @@ export class LibraryRAGService extends BaseRAGService {
 		// Store embeddings for search
 		const vectorId = await this.embeddingService.storeEmbeddings(
 			text,
-			metadata.id
+			metadata.id,
+			{ metadataId: metadata.id },
+			{ username: metadata.userId, fileKey: metadata.fileKey }
 		);
 
 		return {
@@ -309,7 +315,8 @@ export class LibraryRAGService extends BaseRAGService {
 				"application/pdf";
 			const extractionResult = await this.extractionService.extractText(
 				buffer,
-				contentType
+				contentType,
+				{ username, fileKey }
 			);
 
 			if (!extractionResult?.text) {
@@ -333,7 +340,9 @@ export class LibraryRAGService extends BaseRAGService {
 				try {
 					vectorId = await this.embeddingService.storeEmbeddings(
 						text,
-						metadata.id || fileKey
+						metadata.id || fileKey,
+						{ metadataId: metadata.id || fileKey },
+						{ username, fileKey }
 					);
 				} catch (_error) {}
 			}

--- a/src/tools/campaign-context/recap-tools.ts
+++ b/src/tools/campaign-context/recap-tools.ts
@@ -10,6 +10,7 @@ import { createLogger } from "@/lib/logger";
 import type { Env } from "@/middleware/auth";
 import { AuthService } from "@/services/core/auth-service";
 import { RecapService } from "@/services/core/recap-service";
+import type { LLMOptions, LLMProvider } from "@/services/llm/llm-provider";
 import { getLLMRateLimitService } from "@/services/llm/llm-rate-limit-service";
 import {
 	commonSchemas,
@@ -23,21 +24,101 @@ import {
 } from "@/tools/utils";
 import { searchCampaignContext } from "./search-tools";
 
+/** Wrangler tail surfaces `console.*` more reliably than tslog for DO-isolate debugging. */
+function emitSessionReadoutTelemetry(
+	level: "info" | "warn" | "error",
+	label: string,
+	jsonPayload: string
+): void {
+	switch (level) {
+		case "info":
+			// biome-ignore lint/suspicious/noConsole: Workers wrangler tail observability
+			console.info(label, jsonPayload);
+			return;
+		case "warn":
+			// biome-ignore lint/suspicious/noConsole: Workers wrangler tail observability
+			console.warn(label, jsonPayload);
+			return;
+		case "error":
+			// biome-ignore lint/suspicious/noConsole: Workers wrangler tail observability
+			console.error(label, jsonPayload);
+	}
+}
+
 function logSessionReadoutFailure(
 	env: unknown,
 	context: { phase: string; campaignId?: string; toolCallId?: string },
 	error: unknown
 ): void {
+	const err = error instanceof Error ? error : new Error(String(error));
+	try {
+		emitSessionReadoutTelemetry(
+			"error",
+			"[SessionReadout]",
+			JSON.stringify({
+				event: "session_readout_failure",
+				phase: context.phase,
+				campaignId: context.campaignId,
+				toolCallId: context.toolCallId,
+				message: err.message,
+				stack: err.stack?.slice(0, 800),
+			})
+		);
+	} catch {
+		emitSessionReadoutTelemetry(
+			"error",
+			"[SessionReadout]",
+			JSON.stringify({ event: "session_readout_failure", message: err.message })
+		);
+	}
 	const log = createLogger(
 		env as Record<string, unknown> | undefined,
 		"[SessionReadout]"
 	);
-	const err = error instanceof Error ? error : new Error(String(error));
 	log.error("Session readout step failed", err, {
 		phase: context.phase,
 		campaignId: context.campaignId,
 		toolCallId: context.toolCallId,
 	});
+}
+
+/** Plain console so `wrangler tail --format pretty` always shows readout LLM boundaries. */
+async function runSessionReadoutSummary(
+	llmProvider: LLMProvider,
+	prompt: string,
+	summaryOptions: LLMOptions,
+	meta: { phase: string; campaignId: string }
+): Promise<string> {
+	const promptLength = prompt.length;
+	emitSessionReadoutTelemetry(
+		"info",
+		"[SessionReadout]",
+		JSON.stringify({
+			event: "session_readout_summary_start",
+			phase: meta.phase,
+			campaignId: meta.campaignId,
+			promptLength,
+		})
+	);
+	try {
+		return await llmProvider.generateSummary(prompt, summaryOptions);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const name = error instanceof Error ? error.name : "unknown";
+		emitSessionReadoutTelemetry(
+			"error",
+			"[SessionReadout]",
+			JSON.stringify({
+				event: "session_readout_summary_failed",
+				phase: meta.phase,
+				campaignId: meta.campaignId,
+				promptLength,
+				message,
+				name,
+			})
+		);
+		throw error;
+	}
 }
 
 function sessionReadoutGenerateSummaryOptions(
@@ -734,6 +815,16 @@ export const getSessionReadoutContext = tool({
 				);
 				const providerApiKey = providerApiKeyRaw?.trim() ?? "";
 				if (!providerApiKey) {
+					emitSessionReadoutTelemetry(
+						"warn",
+						"[SessionReadout]",
+						JSON.stringify({
+							event: "session_readout_no_provider_key",
+							phase: "getSessionReadoutContext",
+							campaignId,
+							toolCallId,
+						})
+					);
 					return createToolError(
 						`${MODEL_CONFIG.PROVIDER.DEFAULT === "anthropic" ? "Anthropic" : "OpenAI"} API key not configured`,
 						"AI is not configured for this environment.",
@@ -761,17 +852,22 @@ export const getSessionReadoutContext = tool({
 						MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_TEMPERATURE,
 					defaultMaxTokens: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_MAX_TOKENS,
 				});
-				const transformedPlan = await llmProvider.generateSummary(prompt, {
-					model: getGenerationModelForProvider("SESSION_PLANNING"),
-					temperature: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_TEMPERATURE,
-					maxTokens: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_MAX_TOKENS,
-					...sessionReadoutGenerateSummaryOptions(
-						env,
-						jwt,
-						campaignId,
-						"recap_tools:getSessionReadoutContext"
-					),
-				});
+				const transformedPlan = await runSessionReadoutSummary(
+					llmProvider,
+					prompt,
+					{
+						model: getGenerationModelForProvider("SESSION_PLANNING"),
+						temperature: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_TEMPERATURE,
+						maxTokens: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_MAX_TOKENS,
+						...sessionReadoutGenerateSummaryOptions(
+							env,
+							jwt,
+							campaignId,
+							"recap_tools:getSessionReadoutContext"
+						),
+					},
+					{ phase: "getSessionReadoutContext", campaignId }
+				);
 
 				await sessionPlanReadoutDAO.save(
 					campaignId,
@@ -1080,6 +1176,17 @@ export const stitchSessionReadout = tool({
 				nextSessionNumber
 			);
 			if (steps.length === 0) {
+				emitSessionReadoutTelemetry(
+					"warn",
+					"[SessionReadout]",
+					JSON.stringify({
+						event: "session_readout_stitch_no_chunks",
+						phase: "stitchSessionReadout",
+						campaignId,
+						nextSessionNumber,
+						toolCallId,
+					})
+				);
 				return createToolError(
 					"No chunks to stitch",
 					"Call getSessionReadoutChunk at least once before stitchSessionReadout.",
@@ -1099,6 +1206,16 @@ export const stitchSessionReadout = tool({
 			);
 			const providerApiKey = providerApiKeyRaw?.trim() ?? "";
 			if (!providerApiKey) {
+				emitSessionReadoutTelemetry(
+					"warn",
+					"[SessionReadout]",
+					JSON.stringify({
+						event: "session_readout_no_provider_key",
+						phase: "stitchSessionReadout",
+						campaignId,
+						toolCallId,
+					})
+				);
 				return createToolError(
 					`${MODEL_CONFIG.PROVIDER.DEFAULT === "anthropic" ? "Anthropic" : "OpenAI"} API key not configured`,
 					"AI is not configured for this environment.",
@@ -1126,17 +1243,22 @@ export const stitchSessionReadout = tool({
 					MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_TEMPERATURE,
 				defaultMaxTokens: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_MAX_TOKENS,
 			});
-			const transformedPlan = await llmProvider.generateSummary(prompt, {
-				model: getGenerationModelForProvider("SESSION_PLANNING"),
-				temperature: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_TEMPERATURE,
-				maxTokens: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_MAX_TOKENS,
-				...sessionReadoutGenerateSummaryOptions(
-					env,
-					jwt,
-					campaignId,
-					"recap_tools:stitchSessionReadout"
-				),
-			});
+			const transformedPlan = await runSessionReadoutSummary(
+				llmProvider,
+				prompt,
+				{
+					model: getGenerationModelForProvider("SESSION_PLANNING"),
+					temperature: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_TEMPERATURE,
+					maxTokens: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_MAX_TOKENS,
+					...sessionReadoutGenerateSummaryOptions(
+						env,
+						jwt,
+						campaignId,
+						"recap_tools:stitchSessionReadout"
+					),
+				},
+				{ phase: "stitchSessionReadout", campaignId }
+			);
 
 			await sessionPlanReadoutDAO.save(
 				campaignId,

--- a/src/tools/campaign-context/recap-tools.ts
+++ b/src/tools/campaign-context/recap-tools.ts
@@ -5,7 +5,11 @@ import type { Community } from "@/dao/community-dao";
 import { getDAOFactory } from "@/dao/dao-factory";
 import type { PlanningTaskStatus } from "@/dao/planning-task-dao";
 import { getEnvVar } from "@/lib/env-utils";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
+import type { Env } from "@/middleware/auth";
+import { AuthService } from "@/services/core/auth-service";
 import { RecapService } from "@/services/core/recap-service";
+import { getLLMRateLimitService } from "@/services/llm/llm-rate-limit-service";
 import {
 	commonSchemas,
 	createToolError,
@@ -17,6 +21,40 @@ import {
 	type ToolExecuteOptions,
 } from "@/tools/utils";
 import { searchCampaignContext } from "./search-tools";
+
+function sessionReadoutGenerateSummaryOptions(
+	env: unknown,
+	jwt: string | null | undefined,
+	campaignId: string,
+	source:
+		| "recap_tools:getSessionReadoutContext"
+		| "recap_tools:stitchSessionReadout"
+) {
+	const username = jwt ? AuthService.parseJwtForUsername(jwt) : null;
+	if (!username || !env) {
+		return {};
+	}
+	const rateLimitService = getLLMRateLimitService(env as Env);
+	return {
+		username,
+		onUsage: async (
+			usage: { tokens: number; queryCount: number },
+			ctx?: { model?: string; username?: string }
+		) => {
+			await rateLimitService.recordUsage(
+				username,
+				usage.tokens,
+				usage.queryCount,
+				ctx?.model,
+				{
+					intent: LLM_SPEND_INTENT.session_plan_readout,
+					source,
+					campaignId,
+				}
+			);
+		},
+	};
+}
 
 const generateContextRecapSchema = z.object({
 	campaignId: commonSchemas.campaignId,
@@ -693,6 +731,12 @@ export const getSessionReadoutContext = tool({
 					model: getGenerationModelForProvider("SESSION_PLANNING"),
 					temperature: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_TEMPERATURE,
 					maxTokens: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_MAX_TOKENS,
+					...sessionReadoutGenerateSummaryOptions(
+						env,
+						jwt,
+						campaignId,
+						"recap_tools:getSessionReadoutContext"
+					),
 				});
 
 				await sessionPlanReadoutDAO.save(
@@ -1032,6 +1076,12 @@ export const stitchSessionReadout = tool({
 				model: getGenerationModelForProvider("SESSION_PLANNING"),
 				temperature: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_TEMPERATURE,
 				maxTokens: MODEL_CONFIG.PARAMETERS.SESSION_PLANNING_MAX_TOKENS,
+				...sessionReadoutGenerateSummaryOptions(
+					env,
+					jwt,
+					campaignId,
+					"recap_tools:stitchSessionReadout"
+				),
 			});
 
 			await sessionPlanReadoutDAO.save(

--- a/src/tools/campaign-context/recap-tools.ts
+++ b/src/tools/campaign-context/recap-tools.ts
@@ -6,6 +6,7 @@ import { getDAOFactory } from "@/dao/dao-factory";
 import type { PlanningTaskStatus } from "@/dao/planning-task-dao";
 import { getEnvVar } from "@/lib/env-utils";
 import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
+import { createLogger } from "@/lib/logger";
 import type { Env } from "@/middleware/auth";
 import { AuthService } from "@/services/core/auth-service";
 import { RecapService } from "@/services/core/recap-service";
@@ -21,6 +22,23 @@ import {
 	type ToolExecuteOptions,
 } from "@/tools/utils";
 import { searchCampaignContext } from "./search-tools";
+
+function logSessionReadoutFailure(
+	env: unknown,
+	context: { phase: string; campaignId?: string; toolCallId?: string },
+	error: unknown
+): void {
+	const log = createLogger(
+		env as Record<string, unknown> | undefined,
+		"[SessionReadout]"
+	);
+	const err = error instanceof Error ? error : new Error(String(error));
+	log.error("Session readout step failed", err, {
+		phase: context.phase,
+		campaignId: context.campaignId,
+		toolCallId: context.toolCallId,
+	});
+}
 
 function sessionReadoutGenerateSummaryOptions(
 	env: unknown,
@@ -41,17 +59,33 @@ function sessionReadoutGenerateSummaryOptions(
 			usage: { tokens: number; queryCount: number },
 			ctx?: { model?: string; username?: string }
 		) => {
-			await rateLimitService.recordUsage(
-				username,
-				usage.tokens,
-				usage.queryCount,
-				ctx?.model,
-				{
-					intent: LLM_SPEND_INTENT.session_plan_readout,
-					source,
-					campaignId,
-				}
-			);
+			try {
+				await rateLimitService.recordUsage(
+					username,
+					usage.tokens,
+					usage.queryCount,
+					ctx?.model,
+					{
+						intent: LLM_SPEND_INTENT.session_plan_readout,
+						source,
+						campaignId,
+					}
+				);
+			} catch (usageErr) {
+				const log = createLogger(
+					env as Record<string, unknown>,
+					"[SessionReadout]"
+				);
+				log.warn(
+					"Session readout usage record failed (readout still succeeds)",
+					{
+						campaignId,
+						source,
+						message:
+							usageErr instanceof Error ? usageErr.message : String(usageErr),
+					}
+				);
+			}
 		},
 	};
 }
@@ -770,6 +804,16 @@ export const getSessionReadoutContext = tool({
 
 			return await Promise.race([doReadoutWork(), timeoutPromise]);
 		} catch (error) {
+			const env = getEnvFromContext(options);
+			logSessionReadoutFailure(
+				env,
+				{
+					phase: "getSessionReadoutContext",
+					campaignId,
+					toolCallId,
+				},
+				error
+			);
 			const isTimeout =
 				error instanceof Error && error.message.includes("timed out");
 			return createToolError(
@@ -952,6 +996,16 @@ export const getSessionReadoutChunk = tool({
 				toolCallId
 			);
 		} catch (error) {
+			const env = getEnvFromContext(options);
+			logSessionReadoutFailure(
+				env,
+				{
+					phase: "getSessionReadoutChunk",
+					campaignId,
+					toolCallId,
+				},
+				error
+			);
 			return createToolError(
 				"Failed to process readout chunk",
 				error instanceof Error ? error.message : String(error),
@@ -1104,6 +1158,16 @@ export const stitchSessionReadout = tool({
 				toolCallId
 			);
 		} catch (error) {
+			const env = getEnvFromContext(options);
+			logSessionReadoutFailure(
+				env,
+				{
+					phase: "stitchSessionReadout",
+					campaignId,
+					toolCallId,
+				},
+				error
+			);
 			return createToolError(
 				"Failed to stitch session readout",
 				error instanceof Error ? error.message : String(error),

--- a/tests/lib/llm-usage-verbose-log.test.ts
+++ b/tests/lib/llm-usage-verbose-log.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
+import {
+	isVerboseLlmSpendEnabled,
+	LLM_SPEND_VERBOSE_ENV,
+	logVerboseLlmSpend,
+} from "@/lib/llm-usage-verbose-log";
+import * as loggerModule from "@/lib/logger";
+
+describe("logVerboseLlmSpend", () => {
+	afterEach(() => {
+		delete process.env[LLM_SPEND_VERBOSE_ENV];
+		vi.restoreAllMocks();
+	});
+
+	it("does not log when verbose flag is off", () => {
+		const info = vi.fn();
+		vi.spyOn(loggerModule, "createLogger").mockReturnValue({
+			info,
+		} as unknown as ReturnType<typeof loggerModule.createLogger>);
+
+		logVerboseLlmSpend(undefined, {
+			intent: LLM_SPEND_INTENT.embedding_index,
+			tokens: 10,
+		});
+
+		expect(info).not.toHaveBeenCalled();
+	});
+
+	it("emits llm_token_spend with intent when flag is enabled via env object", () => {
+		const info = vi.fn();
+		vi.spyOn(loggerModule, "createLogger").mockReturnValue({
+			info,
+		} as unknown as ReturnType<typeof loggerModule.createLogger>);
+
+		logVerboseLlmSpend(
+			{ [LLM_SPEND_VERBOSE_ENV]: "true" },
+			{
+				intent: LLM_SPEND_INTENT.user_prompt,
+				source: "test_source",
+				username: "alice",
+				tokens: 42,
+				queryCount: 1,
+			}
+		);
+
+		expect(info).toHaveBeenCalledTimes(1);
+		expect(info.mock.calls[0][0]).toBe("llm_token_spend");
+		expect(info.mock.calls[0][1]).toMatchObject({
+			event: "llm_token_spend",
+			intent: "user_prompt",
+			source: "test_source",
+			username: "alice",
+			tokens: 42,
+			queryCount: 1,
+		});
+	});
+
+	it("respects LORESMITH_VERBOSE_LLM_USAGE from process.env", () => {
+		process.env[LLM_SPEND_VERBOSE_ENV] = "1";
+		const info = vi.fn();
+		vi.spyOn(loggerModule, "createLogger").mockReturnValue({
+			info,
+		} as unknown as ReturnType<typeof loggerModule.createLogger>);
+
+		logVerboseLlmSpend(undefined, {
+			intent: LLM_SPEND_INTENT.graph_rebuild,
+			tokens: 99,
+		});
+
+		expect(info).toHaveBeenCalledTimes(1);
+		expect(info.mock.calls[0][1]).toMatchObject({
+			intent: "graph_rebuild",
+			tokens: 99,
+		});
+	});
+
+	it("isVerboseLlmSpendEnabled mirrors env flag", () => {
+		expect(isVerboseLlmSpendEnabled(undefined)).toBe(false);
+		expect(isVerboseLlmSpendEnabled({ [LLM_SPEND_VERBOSE_ENV]: "on" })).toBe(
+			true
+		);
+	});
+});

--- a/tests/services/campaign/direct-file-content-extraction-provider.test.ts
+++ b/tests/services/campaign/direct-file-content-extraction-provider.test.ts
@@ -45,7 +45,8 @@ describe("DirectFileContentExtractionProvider", () => {
 		expect(result.metadata?.contentType).toBe("image/png");
 		expect(mockExtractText).toHaveBeenCalledWith(
 			expect.any(ArrayBuffer),
-			"image/png"
+			"image/png",
+			{ fileKey: "library/user/forest.png" }
 		);
 	});
 
@@ -71,7 +72,8 @@ describe("DirectFileContentExtractionProvider", () => {
 		expect(result.metadata?.isVisualInspiration).toBe(true);
 		expect(mockExtractText).toHaveBeenCalledWith(
 			expect.any(ArrayBuffer),
-			"image/jpeg"
+			"image/jpeg",
+			{ fileKey: "library/user/photo.jpg" }
 		);
 	});
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,6 +20,7 @@
 		"run_worker_first": ["/api/*", "/auth/*"]
 	},
 	"vars": {
+		"LORESMITH_VERBOSE_LLM_USAGE": "1",
 		"MAX_INDEX_FILE_BYTES": "4194304",
 		"STAGING_PREFIX": "staging",
 		"READINESS_TIMEOUT_SEC": "600",


### PR DESCRIPTION
Introduce controlled intents, logVerboseLlmSpend gated by LORESMITH_VERBOSE_LLM_USAGE, and optional meta on recordUsage for structured logs. Thread intents through chat, entity staging, graph routes, shard embeddings, file embeddings, and vision extraction. Enable verbose logging in production wrangler vars; log user_prompt when agent quota blocks or the provider errors or finishes with zero recorded usage.