### PR TITLE
Persist file_chunks after embedding

### DIFF
--- a/src/dao/file/file-dao.ts
+++ b/src/dao/file/file-dao.ts
@@ -606,6 +606,8 @@ export class FileDAO extends BaseDAOClass {
 			chunkIndex: number;
 			content: string;
 			embedding?: string;
+			username?: string;
+			id?: string;
 		}>
 	): Promise<void> {
 		const sql = `
@@ -614,16 +616,90 @@ export class FileDAO extends BaseDAOClass {
     `;
 
 		await Promise.all(
-			chunks.map((chunk) =>
-				this.execute(sql, [
-					`${chunk.fileKey}-chunk-${chunk.chunkIndex}`,
+			chunks.map((chunk) => {
+				const username =
+					chunk.username ||
+					chunk.fileKey.split("/")[1] || // library/username/...
+					"";
+				return this.execute(sql, [
+					chunk.id ?? `${chunk.fileKey}-chunk-${chunk.chunkIndex}`,
 					chunk.fileKey,
-					chunk.fileKey.split("/")[1] || "", // Extract username from fileKey (library/username/...)
+					username,
 					chunk.content,
 					chunk.chunkIndex,
 					chunk.embedding || null,
-				])
-			)
+				]);
+			})
+		);
+	}
+
+	async deleteFileChunks(fileKey: string): Promise<void> {
+		await this.execute("DELETE FROM file_chunks WHERE file_key = ?", [fileKey]);
+	}
+
+	async countFileChunks(fileKey: string): Promise<number> {
+		const row = await this.queryFirst<{ c: number }>(
+			"SELECT COUNT(*) as c FROM file_chunks WHERE file_key = ?",
+			[fileKey]
+		);
+		return row?.c ?? 0;
+	}
+
+	/**
+	 * Replace all RAG text chunks for a file (used by direct indexing).
+	 */
+	async replaceFileChunks(
+		fileKey: string,
+		username: string,
+		chunks: Array<{
+			chunkIndex: number;
+			content: string;
+			embedding?: string;
+		}>
+	): Promise<void> {
+		await this.deleteFileChunks(fileKey);
+		if (chunks.length === 0) return;
+		await this.insertFileChunks(
+			chunks.map((chunk) => ({
+				fileKey,
+				username,
+				chunkIndex: chunk.chunkIndex,
+				content: chunk.content,
+				embedding: chunk.embedding,
+			}))
+		);
+	}
+
+	/**
+	 * Replace RAG text chunks whose chunk_index falls in [rangeStart, rangeEnd).
+	 * Used by chunked (large-file) indexing so a single processing chunk can be retried.
+	 */
+	async replaceFileChunksInIndexRange(
+		fileKey: string,
+		username: string,
+		rangeStart: number,
+		rangeEnd: number,
+		chunks: Array<{
+			id: string;
+			chunkIndex: number;
+			content: string;
+			embedding?: string;
+		}>
+	): Promise<void> {
+		await this.execute(
+			"DELETE FROM file_chunks WHERE file_key = ? AND chunk_index >= ? AND chunk_index < ?",
+			[fileKey, rangeStart, rangeEnd]
+		);
+		if (chunks.length === 0) return;
+		await this.insertFileChunks(
+			chunks.map((chunk) => ({
+				fileKey,
+				username,
+				id: chunk.id,
+				chunkIndex: chunk.chunkIndex,
+				content: chunk.content,
+				embedding: chunk.embedding,
+			}))
 		);
 	}
 

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -1073,9 +1073,16 @@ async function processPendingFileChunks(env: Env): Promise<void> {
 				// Check if all chunks for this file are complete
 				const mergeResult = await chunkedService.mergeChunkResults(fileKey);
 				if (mergeResult.allComplete && mergeResult.allSuccessful) {
-					// Mark file as completed
+					// Mark file as completed and sync RAG chunk count for agent tools
+					const ragChunkCount = await fileDAO.countFileChunks(fileKey);
+					await fileDAO.updateFileMetadata(fileKey, {
+						chunk_count: ragChunkCount,
+					});
 					await fileDAO.updateFileRecord(fileKey, FileDAO.STATUS.COMPLETED);
-					log.debug("All chunks complete for file", { fileKey });
+					log.debug("All chunks complete for file", {
+						fileKey,
+						ragChunkCount,
+					});
 				} else if (mergeResult.allComplete && !mergeResult.allSuccessful) {
 					// Some chunks failed - mark file as error (use MEMORY_LIMIT_EXCEEDED if applicable)
 					const msg = mergeResult.firstFailedErrorMessage ?? "";

--- a/src/services/embedding/file-embedding-service.ts
+++ b/src/services/embedding/file-embedding-service.ts
@@ -26,6 +26,18 @@ export type FileEmbeddingSpendContext = {
 	fileKey?: string;
 };
 
+/** One text chunk stored in Vectorize (full text kept for D1 `file_chunks`). */
+export type StoredEmbeddingChunk = {
+	chunkIndex: number;
+	text: string;
+	vectorId: string;
+};
+
+export type StoreEmbeddingsResult = {
+	primaryVectorId: string;
+	chunks: StoredEmbeddingChunk[];
+};
+
 /**
  * Service for storing file embeddings in Vectorize
  * Handles chunking, embedding generation, and batch insertion
@@ -38,15 +50,15 @@ export class FileEmbeddingService {
 	) {}
 
 	/**
-	 * Store embeddings for a text string in Vectorize
-	 * Returns the primary vector ID (first chunk)
+	 * Store embeddings for a text string in Vectorize.
+	 * Returns the primary vector ID plus full chunk texts for D1 persistence.
 	 */
 	async storeEmbeddings(
 		text: string,
 		metadataId: string,
 		metadata: EmbeddingMetadata = { metadataId },
 		spendContext?: FileEmbeddingSpendContext
-	): Promise<string> {
+	): Promise<StoreEmbeddingsResult> {
 		if (!this.vectorize) {
 			throw new VectorizeIndexRequiredError();
 		}
@@ -68,6 +80,7 @@ export class FileEmbeddingService {
 				values: number[];
 				metadata: Record<string, any>;
 			}> = [];
+			const storedChunks: StoredEmbeddingChunk[] = [];
 			let primaryVectorId: string | undefined;
 
 			for (let i = 0; i < textChunks.length; i++) {
@@ -141,6 +154,12 @@ export class FileEmbeddingService {
 						timestamp: new Date().toISOString(),
 					},
 				});
+
+				storedChunks.push({
+					chunkIndex: i,
+					text: chunkText,
+					vectorId: chunkVectorId,
+				});
 			}
 
 			// Store all embeddings in Vectorize
@@ -150,7 +169,10 @@ export class FileEmbeddingService {
 				throw new Error("Failed to generate primary vector ID");
 			}
 
-			return primaryVectorId;
+			return {
+				primaryVectorId,
+				chunks: storedChunks,
+			};
 		} catch (error) {
 			throw new Error(
 				`Failed to store embeddings: ${error instanceof Error ? error.message : String(error)}. File may be too large or processing timed out.`

--- a/src/services/file/chunked-processing-service.ts
+++ b/src/services/file/chunked-processing-service.ts
@@ -6,6 +6,7 @@ import { extractPdfPagesRange } from "@/lib/file/pdf-utils";
 import { createLogger } from "@/lib/logger";
 import type { Env } from "@/middleware/auth";
 import { FileEmbeddingService } from "@/services/embedding/file-embedding-service";
+import { persistProcessingChunkTextChunks } from "@/services/file/file-chunk-persistence";
 import type { ChunkDefinition } from "@/types/upload";
 import {
 	type ExtractionResult,
@@ -161,6 +162,9 @@ export class ChunkedProcessingService {
 			});
 		}
 
+		// Clear any stale RAG text chunks from a prior incomplete/re-index attempt
+		await this.fileDAO.deleteFileChunks(fileKey);
+
 		return chunks;
 	}
 
@@ -236,12 +240,26 @@ export class ChunkedProcessingService {
 				{ username, fileKey }
 			);
 
+			if (username) {
+				await persistProcessingChunkTextChunks(
+					this.fileDAO,
+					fileKey,
+					username,
+					chunkDefinition.chunkIndex,
+					vectorId.chunks,
+					{ env: this.env as unknown as Record<string, unknown> }
+				);
+			}
+
 			// Mark chunk as completed
-			await this.fileDAO.markFileChunkComplete(chunkId, vectorId);
+			await this.fileDAO.markFileChunkComplete(
+				chunkId,
+				vectorId.primaryVectorId
+			);
 
 			return {
 				success: true,
-				vectorId,
+				vectorId: vectorId.primaryVectorId,
 				text: extractionResult.text,
 			};
 		} catch (error) {
@@ -324,11 +342,25 @@ export class ChunkedProcessingService {
 				{ username, fileKey }
 			);
 
-			await this.fileDAO.markFileChunkComplete(chunkId, vectorId);
+			if (username) {
+				await persistProcessingChunkTextChunks(
+					this.fileDAO,
+					fileKey,
+					username,
+					chunkDefinition.chunkIndex,
+					vectorId.chunks,
+					{ env: this.env as unknown as Record<string, unknown> }
+				);
+			}
+
+			await this.fileDAO.markFileChunkComplete(
+				chunkId,
+				vectorId.primaryVectorId
+			);
 
 			return {
 				success: true,
-				vectorId,
+				vectorId: vectorId.primaryVectorId,
 				text: extractionResult.text,
 			};
 		} catch (error) {

--- a/src/services/file/file-chunk-persistence.ts
+++ b/src/services/file/file-chunk-persistence.ts
@@ -1,0 +1,88 @@
+import type { FileDAO } from "@/dao/file/file-dao";
+import { createLogger } from "@/lib/logger";
+import type { StoredEmbeddingChunk } from "@/services/embedding/file-embedding-service";
+
+/**
+ * Stride between processing-chunk index ranges in `file_chunks.chunk_index`.
+ * Keeps ranges non-overlapping so retries can replace one processing chunk safely.
+ */
+export const PROCESSING_CHUNK_INDEX_STRIDE = 10_000;
+
+/**
+ * Replace all RAG text chunks for a file (direct / non-chunked indexing path).
+ * Call after Vectorize embeddings succeed so agent tools can read full text.
+ */
+export async function persistFileTextChunks(
+	fileDAO: FileDAO,
+	fileKey: string,
+	username: string,
+	chunks: StoredEmbeddingChunk[],
+	options?: {
+		vectorId?: string;
+		env?: Record<string, unknown>;
+	}
+): Promise<void> {
+	const log = createLogger(options?.env, "[FileChunkPersistence]");
+
+	await fileDAO.replaceFileChunks(
+		fileKey,
+		username,
+		chunks.map((c) => ({
+			chunkIndex: c.chunkIndex,
+			content: c.text,
+			embedding: c.vectorId,
+		}))
+	);
+
+	const metadataUpdates: { vector_id?: string; chunk_count: number } = {
+		chunk_count: chunks.length,
+	};
+	if (options?.vectorId) {
+		metadataUpdates.vector_id = options.vectorId;
+	}
+	await fileDAO.updateFileMetadata(fileKey, metadataUpdates);
+
+	log.info("Persisted file_chunks after embedding", {
+		fileKey,
+		username,
+		chunkCount: chunks.length,
+		vectorId: options?.vectorId,
+	});
+}
+
+/**
+ * Replace RAG text chunks belonging to one large-file processing chunk.
+ * Safe to call on retry: deletes the prior index range for that processing chunk first.
+ */
+export async function persistProcessingChunkTextChunks(
+	fileDAO: FileDAO,
+	fileKey: string,
+	username: string,
+	processingChunkIndex: number,
+	chunks: StoredEmbeddingChunk[],
+	options?: { env?: Record<string, unknown> }
+): Promise<void> {
+	const log = createLogger(options?.env, "[FileChunkPersistence]");
+	const base = processingChunkIndex * PROCESSING_CHUNK_INDEX_STRIDE;
+
+	await fileDAO.replaceFileChunksInIndexRange(
+		fileKey,
+		username,
+		base,
+		base + PROCESSING_CHUNK_INDEX_STRIDE,
+		chunks.map((c, i) => ({
+			id: `${fileKey}-pc${processingChunkIndex}-${i}`,
+			chunkIndex: base + i,
+			content: c.text,
+			embedding: c.vectorId,
+		}))
+	);
+
+	log.info("Persisted file_chunks for processing chunk", {
+		fileKey,
+		username,
+		processingChunkIndex,
+		chunkCount: chunks.length,
+		chunkIndexBase: base,
+	});
+}

--- a/src/services/file/sync-queue-service.ts
+++ b/src/services/file/sync-queue-service.ts
@@ -329,6 +329,10 @@ export class SyncQueueService {
 
 					if (mergeResult.allComplete && mergeResult.allSuccessful) {
 						// All chunks processed successfully - mark file as completed
+						const ragChunkCount = await fileDAO.countFileChunks(item.file_key);
+						await fileDAO.updateFileMetadata(item.file_key, {
+							chunk_count: ragChunkCount,
+						});
 						await fileDAO.updateFileRecord(
 							item.file_key,
 							FileDAO.STATUS.COMPLETED
@@ -343,6 +347,7 @@ export class SyncQueueService {
 						log.info("All chunks completed", {
 							file_key: item.file_key,
 							stats: mergeResult.stats,
+							ragChunkCount,
 						});
 						fireFileProcessingTelemetry(env, Date.now() - itemStartedAt, {
 							pipeline: "library_sync_chunked",

--- a/src/services/rag/rag-service.ts
+++ b/src/services/rag/rag-service.ts
@@ -3,10 +3,13 @@
 // Uses Vectorize for embeddings and Cloudflare AI for content generation
 
 import { PROCESSING_LIMITS } from "@/app-constants";
+import { getDAOFactory } from "@/dao/dao-factory";
 import { FileNotFoundError, MemoryLimitError } from "@/lib/errors";
+import { createLogger } from "@/lib/logger";
 import type { Env } from "@/middleware/auth";
 import { FileEmbeddingService } from "@/services/embedding/file-embedding-service";
 import { ChunkedProcessingService } from "@/services/file/chunked-processing-service";
+import { persistFileTextChunks } from "@/services/file/file-chunk-persistence";
 import { FileExtractionService } from "@/services/file/file-extraction-service";
 import { FileQueueUtils } from "@/services/file/file-queue-utils";
 import { LibraryContentSearchService } from "@/services/file/library-content-search-service";
@@ -236,17 +239,43 @@ export class LibraryRAGService extends BaseRAGService {
 			};
 		}
 
-		// Store embeddings for search
-		const vectorId = await this.embeddingService.storeEmbeddings(
+		// Store embeddings for search, then persist full text chunks for agent/tools
+		const embeddingResult = await this.embeddingService.storeEmbeddings(
 			text,
 			metadata.id,
 			{ metadataId: metadata.id },
 			{ username: metadata.userId, fileKey: metadata.fileKey }
 		);
 
+		const log = createLogger(
+			this.env as unknown as Record<string, unknown>,
+			"[LibraryRAG]"
+		);
+		try {
+			const fileDAO = getDAOFactory(this.env).fileDAO;
+			await persistFileTextChunks(
+				fileDAO,
+				metadata.fileKey,
+				metadata.userId,
+				embeddingResult.chunks,
+				{
+					vectorId: embeddingResult.primaryVectorId,
+					env: this.env as unknown as Record<string, unknown>,
+				}
+			);
+		} catch (persistError) {
+			// Embeddings already succeeded; surface persistence failures so status is not
+			// marked completed with empty file_chunks (the bug this path fixes).
+			log.error("Failed to persist file_chunks after embedding", persistError, {
+				fileKey: metadata.fileKey,
+				chunkCount: embeddingResult.chunks.length,
+			});
+			throw persistError;
+		}
+
 		return {
 			...result,
-			vectorId,
+			vectorId: embeddingResult.primaryVectorId,
 		};
 	}
 
@@ -338,12 +367,28 @@ export class LibraryRAGService extends BaseRAGService {
 			let vectorId: string | undefined;
 			if (this.vectorize && text) {
 				try {
-					vectorId = await this.embeddingService.storeEmbeddings(
+					const embeddingResult = await this.embeddingService.storeEmbeddings(
 						text,
 						metadata.id || fileKey,
 						{ metadataId: metadata.id || fileKey },
 						{ username, fileKey }
 					);
+					vectorId = embeddingResult.primaryVectorId;
+					try {
+						const fileDAO = getDAOFactory(this.env).fileDAO;
+						await persistFileTextChunks(
+							fileDAO,
+							fileKey,
+							username,
+							embeddingResult.chunks,
+							{
+								vectorId,
+								env: this.env as unknown as Record<string, unknown>,
+							}
+						);
+					} catch (_persistError) {
+						// Legacy path: keep vectorId even if D1 chunk persist fails
+					}
 				} catch (_error) {}
 			}
 

--- a/tests/dao/file-dao.test.ts
+++ b/tests/dao/file-dao.test.ts
@@ -266,4 +266,41 @@ describe("FileDAO", () => {
 			expect(mockVectorizeIndex.deleteByIds).not.toHaveBeenCalled();
 		});
 	});
+
+	describe("replaceFileChunks", () => {
+		it("deletes existing chunks then inserts with explicit username", async () => {
+			expect.hasAssertions();
+
+			mockPreparedStatement.run.mockResolvedValue({});
+
+			await fileDAO.replaceFileChunks("library/alice/doc.pdf", "alice", [
+				{ chunkIndex: 0, content: "chunk zero", embedding: "v1" },
+			]);
+
+			expect(mockDB.prepare).toHaveBeenCalledWith(
+				"DELETE FROM file_chunks WHERE file_key = ?"
+			);
+			expect(mockDB.prepare).toHaveBeenCalledWith(
+				expect.stringContaining("INSERT INTO file_chunks")
+			);
+			expect(mockPreparedStatement.bind).toHaveBeenCalledWith(
+				"library/alice/doc.pdf-chunk-0",
+				"library/alice/doc.pdf",
+				"alice",
+				"chunk zero",
+				0,
+				"v1"
+			);
+		});
+	});
+
+	describe("countFileChunks", () => {
+		it("returns count from D1", async () => {
+			expect.hasAssertions();
+			mockPreparedStatement.first.mockResolvedValue({ c: 3 });
+			await expect(
+				fileDAO.countFileChunks("library/alice/doc.pdf")
+			).resolves.toBe(3);
+		});
+	});
 });

--- a/tests/services/file-chunk-persistence.test.ts
+++ b/tests/services/file-chunk-persistence.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	PROCESSING_CHUNK_INDEX_STRIDE,
+	persistFileTextChunks,
+	persistProcessingChunkTextChunks,
+} from "../../src/services/file/file-chunk-persistence";
+
+describe("file-chunk-persistence", () => {
+	const mockFileDAO = {
+		replaceFileChunks: vi.fn(),
+		updateFileMetadata: vi.fn(),
+		replaceFileChunksInIndexRange: vi.fn(),
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockFileDAO.replaceFileChunks.mockResolvedValue(undefined);
+		mockFileDAO.updateFileMetadata.mockResolvedValue(undefined);
+		mockFileDAO.replaceFileChunksInIndexRange.mockResolvedValue(undefined);
+	});
+
+	it("persists embedding chunks and updates vector_id + chunk_count", async () => {
+		await persistFileTextChunks(
+			mockFileDAO as any,
+			"library/user/doc.pdf",
+			"user",
+			[
+				{ chunkIndex: 0, text: "hello", vectorId: "v_a" },
+				{ chunkIndex: 1, text: "world", vectorId: "v_b" },
+			],
+			{ vectorId: "v_a" }
+		);
+
+		expect(mockFileDAO.replaceFileChunks).toHaveBeenCalledWith(
+			"library/user/doc.pdf",
+			"user",
+			[
+				{ chunkIndex: 0, content: "hello", embedding: "v_a" },
+				{ chunkIndex: 1, content: "world", embedding: "v_b" },
+			]
+		);
+		expect(mockFileDAO.updateFileMetadata).toHaveBeenCalledWith(
+			"library/user/doc.pdf",
+			{ vector_id: "v_a", chunk_count: 2 }
+		);
+	});
+
+	it("persists processing-chunk text in a stable index range for retries", async () => {
+		await persistProcessingChunkTextChunks(
+			mockFileDAO as any,
+			"library/user/big.pdf",
+			"user",
+			2,
+			[{ chunkIndex: 0, text: "page range text", vectorId: "v_pc2" }]
+		);
+
+		const base = 2 * PROCESSING_CHUNK_INDEX_STRIDE;
+		expect(mockFileDAO.replaceFileChunksInIndexRange).toHaveBeenCalledWith(
+			"library/user/big.pdf",
+			"user",
+			base,
+			base + PROCESSING_CHUNK_INDEX_STRIDE,
+			[
+				{
+					id: "library/user/big.pdf-pc2-0",
+					chunkIndex: base,
+					content: "page range text",
+					embedding: "v_pc2",
+				},
+			]
+		);
+	});
+});

--- a/tests/services/rag-service.test.ts
+++ b/tests/services/rag-service.test.ts
@@ -100,6 +100,10 @@ describe("LibraryRAGService", () => {
 			getFileForRag: vi.fn(),
 			updateFileMetadataForRag: vi.fn(),
 			updateFileRecord: vi.fn(),
+			replaceFileChunks: vi.fn().mockResolvedValue(undefined),
+			updateFileMetadata: vi.fn().mockResolvedValue(undefined),
+			deleteFileChunks: vi.fn().mockResolvedValue(undefined),
+			countFileChunks: vi.fn().mockResolvedValue(0),
 		};
 
 		(getDAOFactory as any).mockReturnValue({
@@ -146,6 +150,24 @@ describe("LibraryRAGService", () => {
 			expect(result.description).toBe("A test PDF document");
 			expect(result.tags).toEqual(["test", "document", "pdf"]);
 			expect(result.vectorId).toBeDefined();
+			expect(mockFileDAO.replaceFileChunks).toHaveBeenCalledWith(
+				"uploads/test-file.pdf",
+				"user-123",
+				expect.arrayContaining([
+					expect.objectContaining({
+						chunkIndex: 0,
+						content: expect.any(String),
+						embedding: expect.any(String),
+					}),
+				])
+			);
+			expect(mockFileDAO.updateFileMetadata).toHaveBeenCalledWith(
+				"uploads/test-file.pdf",
+				expect.objectContaining({
+					vector_id: result.vectorId,
+					chunk_count: expect.any(Number),
+				})
+			);
 			expect(mockEnv.R2.get).toHaveBeenCalledWith("uploads/test-file.pdf");
 			expect(mockAI.run).toHaveBeenCalledWith(
 				expect.any(String), // model


### PR DESCRIPTION
## Summary
- Write `file_chunks` (and update `chunk_count` / `vector_id`) when indexing completes via the direct and chunked embedding paths
- Fixes completed files that had searchable Vectorize/entity data but zero readable chunks for agent tools

## Test plan
- [ ] Upload a small text/PDF file and confirm `file_chunks` rows exist after status is completed
- [ ] Confirm chunked/large-file path also persists chunks after merge
- [ ] `npm test` (pre-commit already ran full suite)


Made with [Cursor](https://cursor.com)