### PR TITLE
Clarify getDocumentContent for empty completed chunks

### DIFF
--- a/src/tools/campaign-context/get-document-content-tool.ts
+++ b/src/tools/campaign-context/get-document-content-tool.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { getDAOFactory } from "@/dao/dao-factory";
+import { createLogger } from "@/lib/logger";
 import {
 	createToolError,
 	createToolSuccess,
@@ -41,7 +42,7 @@ const getDocumentContentSchema = z.object({
  */
 export const getDocumentContent = tool({
 	description:
-		"Get the indexed text content of a document that is linked to the campaign (e.g. a PDF or file added as a campaign resource). Use when you need to read or answer questions about what a specific file says. Provide the file name or display name (e.g. 'istelle-character-sheet.pdf'). Returns text chunks from the document.",
+		"Get the indexed text content of a document that is linked to the campaign (e.g. a PDF or file added as a campaign resource). Use when you need to read or answer questions about what a specific file says. Provide the file name or display name (e.g. 'istelle-character-sheet.pdf'). Returns text chunks from the document. Prefer campaign entity search when this returns no chunks but the file status is completed — entities may still be available from discovery.",
 	inputSchema: getDocumentContentSchema,
 	execute: async (
 		input: z.infer<typeof getDocumentContentSchema>,
@@ -123,14 +124,36 @@ export const getDocumentContent = tool({
 			);
 
 			if (!chunks || chunks.length === 0) {
+				const fileMeta = await daoFactory.fileDAO.getFileMetadata(fileKey);
+				const status = fileMeta?.status ?? "unknown";
+				const log = createLogger(
+					env as unknown as Record<string, unknown>,
+					"[getDocumentContent]"
+				);
+				log.warn("Document has no file_chunks", {
+					fileKey,
+					fileName: resource.file_name,
+					status,
+					campaignId,
+				});
+
+				const isTerminalIndexed =
+					status === "completed" || status === "processed";
+				const message = isTerminalIndexed
+					? `Document "${resource.file_name}" is marked ${status} but has no stored text chunks (chunkCount: 0). This can happen for files indexed before text-chunk persistence was added, or if chunk persistence failed. Do not assume PDF extraction failed — try campaign entity/graph search or ask the user to re-index the file. Vector search may still work.`
+					: `Document "${resource.file_name}" is linked to the campaign but has no indexed text chunks yet (status: ${status}). It may still be processing.`;
+
 				return createToolSuccess(
-					`Document "${resource.file_name}" is linked to the campaign but has no indexed text chunks yet. It may still be processing.`,
+					message,
 					{
 						fileKey,
 						fileName: resource.file_name,
 						displayName: resource.display_name,
+						status,
 						chunks: [],
 						chunkCount: 0,
+						suggestEntitySearch: isTerminalIndexed,
+						suggestReindex: isTerminalIndexed,
 					},
 					toolCallId
 				);

--- a/tests/tools/get-document-content-tool.test.ts
+++ b/tests/tools/get-document-content-tool.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/dao/dao-factory", () => ({
+	getDAOFactory: vi.fn(),
+}));
+
+vi.mock("../../src/tools/utils", async () => {
+	const actual = await vi.importActual<typeof import("../../src/tools/utils")>(
+		"../../src/tools/utils"
+	);
+	return {
+		...actual,
+		getEnvFromContext: vi.fn(),
+		extractUsernameFromJwt: vi.fn(() => "user-1"),
+		requireCanSeeSpoilersForTool: vi.fn(async () => ({ userId: "user-1" })),
+	};
+});
+
+import { getDAOFactory } from "../../src/dao/dao-factory";
+import { getDocumentContent } from "../../src/tools/campaign-context/get-document-content-tool";
+import {
+	extractUsernameFromJwt,
+	getEnvFromContext,
+	requireCanSeeSpoilersForTool,
+} from "../../src/tools/utils";
+
+describe("getDocumentContent", () => {
+	const mockFileDAO = {
+		getFileChunksForRag: vi.fn(),
+		getFileMetadata: vi.fn(),
+	};
+	const mockCampaignDAO = {
+		getCampaignById: vi.fn(),
+		getCampaignResources: vi.fn(),
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(getEnvFromContext as any).mockReturnValue({ DB: {} });
+		(extractUsernameFromJwt as any).mockReturnValue("user-1");
+		(requireCanSeeSpoilersForTool as any).mockResolvedValue({
+			userId: "user-1",
+		});
+		(getDAOFactory as any).mockReturnValue({
+			fileDAO: mockFileDAO,
+			campaignDAO: mockCampaignDAO,
+		});
+		mockCampaignDAO.getCampaignById.mockResolvedValue({ id: "camp-1" });
+		mockCampaignDAO.getCampaignResources.mockResolvedValue([
+			{
+				file_key: "library/user-1/dhrolin.pdf",
+				file_name: "Dr Dhrolin's dictionary of dinosaurs.pdf",
+				display_name: "Dr Dhrolin's dictionary of dinosaurs",
+			},
+		]);
+	});
+
+	it("does not claim extraction failed when completed with zero chunks", async () => {
+		mockFileDAO.getFileChunksForRag.mockResolvedValue([]);
+		mockFileDAO.getFileMetadata.mockResolvedValue({ status: "completed" });
+
+		const result = await (getDocumentContent as any).execute(
+			{
+				campaignId: "camp-1",
+				fileIdentifier: "Dr Dhrolin's dictionary of dinosaurs",
+				jwt: "token",
+			},
+			{ toolCallId: "t1" }
+		);
+
+		expect(result.result.success).toBe(true);
+		expect(result.result.message).toContain("no stored text chunks");
+		expect(result.result.message).not.toMatch(/still be processing/i);
+		expect(result.result.message).toMatch(
+			/Do not assume PDF extraction failed/i
+		);
+		expect(result.result.data.chunkCount).toBe(0);
+		expect(result.result.data.suggestEntitySearch).toBe(true);
+		expect(result.result.data.suggestReindex).toBe(true);
+		expect(result.result.data.status).toBe("completed");
+	});
+
+	it("says still processing when status is not completed", async () => {
+		mockFileDAO.getFileChunksForRag.mockResolvedValue([]);
+		mockFileDAO.getFileMetadata.mockResolvedValue({ status: "indexing" });
+
+		const result = await (getDocumentContent as any).execute(
+			{
+				campaignId: "camp-1",
+				fileIdentifier: "dhrolin",
+				jwt: "token",
+			},
+			{ toolCallId: "t2" }
+		);
+
+		expect(result.result.success).toBe(true);
+		expect(result.result.message).toMatch(/still be processing/i);
+		expect(result.result.data.suggestEntitySearch).toBe(false);
+	});
+
+	it("returns chunks when present", async () => {
+		mockFileDAO.getFileChunksForRag.mockResolvedValue([
+			{ chunk_index: 0, chunk_text: "A Pluvenn is a dinosaur." },
+		]);
+
+		const result = await (getDocumentContent as any).execute(
+			{
+				campaignId: "camp-1",
+				fileIdentifier: "dhrolin",
+				jwt: "token",
+				maxChunks: 10,
+			},
+			{ toolCallId: "t3" }
+		);
+
+		expect(result.result.success).toBe(true);
+		expect(result.result.data.chunkCount).toBe(1);
+		expect(result.result.data.chunks[0].text).toContain("Pluvenn");
+	});
+});


### PR DESCRIPTION
## Summary
- When a file is completed/processed but has no `file_chunks`, stop telling the agent that PDF extraction/OCR failed
- Log a warning and suggest re-index or entity search instead

## Test plan
- [ ] Call getDocumentContent on a completed file with empty chunks; response should not claim extraction failed
- [ ] Normal files with chunks still return content as before
- [ ] Unit tests in `tests/tools/get-document-content-tool.test.ts`


Made with [Cursor](https://cursor.com)