### PR TITLE
Upgrade to Sonnet 5 for quality paths; Haiku for analysis to cut costs.

### DIFF
--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -2,6 +2,7 @@ import { stepCountIs, streamText } from "ai";
 import {
 	getGenerationModelForProvider,
 	JWT_STORAGE_KEY,
+	MODEL_CONFIG,
 } from "@/app-constants";
 import { CAMPAIGN_ROLES, PLAYER_ROLES } from "@/constants/campaign-roles";
 import { getDAOFactory } from "@/dao/dao-factory";
@@ -10,6 +11,7 @@ import {
 	resolveClaimedPlayerContext,
 } from "@/lib/agent-role-utils";
 import { getStatusMessageForTool } from "@/lib/agent-status-messages";
+import { anthropicSamplingParams } from "@/lib/anthropic-model-options";
 import { getEnvVar } from "@/lib/env-utils";
 import { buildExplainabilityFromSteps } from "@/lib/explainability-builder";
 import { normalizeMessageHistoryScope } from "@/lib/get-message-history-query";
@@ -851,12 +853,22 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 
 		const MESSAGE_COMPRESSION_THRESHOLD = 30;
 
+		const sampling =
+			MODEL_CONFIG.PROVIDER.DEFAULT === "anthropic"
+				? anthropicSamplingParams(
+						modelId,
+						MODEL_CONFIG.PARAMETERS.CHAT_TEMPERATURE
+					)
+				: { temperature: MODEL_CONFIG.PARAMETERS.CHAT_TEMPERATURE };
+
 		const result = streamText({
 			model: this.model,
 			system: mergedSystemPrompt,
 			toolChoice,
 			messages: processedMessages,
 			tools: enhancedTools,
+			...sampling,
+			maxOutputTokens: MODEL_CONFIG.PARAMETERS.MAX_TOKENS,
 			stopWhen: stepCountIs(MAX_AGENT_STEPS),
 			prepareStep: async ({ messages }) => {
 				if (messages.length > MESSAGE_COMPRESSION_THRESHOLD) {

--- a/src/app-constants.ts
+++ b/src/app-constants.ts
@@ -268,19 +268,21 @@ export const MODEL_CONFIG = {
 		EMBEDDINGS: "text-embedding-3-small",
 	},
 	// Anthropic Models
+	// Sonnet 5 for quality-critical tiers; Haiku for light/analysis (see cost plan).
+	// Sonnet 5: use effort medium via anthropic-model-options (not temperature).
 	ANTHROPIC: {
-		PRIMARY: "claude-sonnet-4-6",
-		INTERACTIVE: "claude-sonnet-4-6",
-		ANALYSIS: "claude-sonnet-4-6",
-		PIPELINE_STRUCTURED: "claude-sonnet-4-6",
+		PRIMARY: "claude-sonnet-5",
+		INTERACTIVE: "claude-sonnet-5",
+		ANALYSIS: "claude-haiku-4-5",
+		PIPELINE_STRUCTURED: "claude-sonnet-5",
 		PIPELINE_LIGHT: "claude-haiku-4-5",
-		PIPELINE_ANALYSIS: "claude-sonnet-4-6",
-		METADATA_ANALYSIS: "claude-sonnet-4-6",
-		SESSION_PLANNING: "claude-sonnet-4-6",
+		PIPELINE_ANALYSIS: "claude-haiku-4-5",
+		METADATA_ANALYSIS: "claude-haiku-4-5",
+		SESSION_PLANNING: "claude-sonnet-5",
 	},
 	// Model parameters
 	PARAMETERS: {
-		// Default temperature for chat responses
+		// Default temperature for chat responses (ignored on Sonnet 5+)
 		CHAT_TEMPERATURE: 0.7,
 		// Default temperature for analysis tasks
 		ANALYSIS_TEMPERATURE: 0.3,
@@ -288,12 +290,12 @@ export const MODEL_CONFIG = {
 		METADATA_ANALYSIS_TEMPERATURE: 0.1,
 		// Default temperature for session planning
 		SESSION_PLANNING_TEMPERATURE: 0.7,
-		// Maximum tokens for responses
-		MAX_TOKENS: 4000,
+		// Maximum tokens for responses (headroom for Sonnet 5 adaptive thinking)
+		MAX_TOKENS: 8000,
 		// Maximum tokens for metadata analysis
 		METADATA_ANALYSIS_MAX_TOKENS: 2000,
 		// Maximum tokens for session planning (longer scripts need more tokens)
-		SESSION_PLANNING_MAX_TOKENS: 8000,
+		SESSION_PLANNING_MAX_TOKENS: 12000,
 		// Top P for response generation
 		TOP_P: 0.9,
 	},

--- a/src/lib/agent-router.ts
+++ b/src/lib/agent-router.ts
@@ -1,5 +1,6 @@
 import { generateText } from "ai";
 import { getGenerationModelForProvider, MODEL_CONFIG } from "@/app-constants";
+import { anthropicSamplingParams } from "@/lib/anthropic-model-options";
 import { AgentNotRegisteredError } from "@/lib/errors";
 import { createModel } from "./model-config";
 import { ModelManager } from "./model-manager";
@@ -229,15 +230,20 @@ Example format: "agent_type|confidence|reason"`;
 		}
 
 		// Use generateText for the routing decision (single turn, no tools)
+		const routedModelId =
+			(modelToUse as { modelId?: string })?.modelId ??
+			getGenerationModelForProvider("PIPELINE_LIGHT");
+		const sampling =
+			MODEL_CONFIG.PROVIDER.DEFAULT === "anthropic"
+				? anthropicSamplingParams(routedModelId, 0)
+				: !MODEL_CONFIG.isReasoningModel(routedModelId.toLowerCase())
+					? { temperature: 0 }
+					: {};
 		const result = await generateText({
 			model: modelToUse,
 			system: systemPrompt,
 			messages: [{ role: "user", content: userMessage }],
-			...(!MODEL_CONFIG.isReasoningModel(
-				((modelToUse as { modelId?: string })?.modelId ?? "").toLowerCase()
-			) && {
-				temperature: 0,
-			}),
+			...sampling,
 		});
 
 		const trimmedResponse = (result.text ?? "").trim();

--- a/src/lib/anthropic-model-options.ts
+++ b/src/lib/anthropic-model-options.ts
@@ -1,0 +1,56 @@
+/**
+ * Claude Sonnet 5 (and later) compatibility helpers.
+ *
+ * Sonnet 5: adaptive thinking on by default at effort "high"; non-default
+ * temperature / top_p / top_k return 400. We default effort to "medium" for cost.
+ */
+
+export type AnthropicEffort = "low" | "medium" | "high" | "xhigh" | "max";
+
+/** Default effort for Sonnet 5+ generation (cost step-down from API default "high"). */
+export const DEFAULT_SONNET5_EFFORT: AnthropicEffort = "medium";
+
+/**
+ * True for Claude Sonnet 5 and newer Sonnet IDs that reject non-default sampling
+ * and use adaptive thinking + effort (e.g. claude-sonnet-5, claude-sonnet-5-...).
+ */
+export function isSonnet5OrNewer(modelId: string): boolean {
+	const id = modelId.toLowerCase();
+	// Match claude-sonnet-5 but not claude-sonnet-4-5 / claude-sonnet-4-6
+	return /^claude-sonnet-5($|-)/.test(id);
+}
+
+/**
+ * Provider options for AI SDK Anthropic calls on Sonnet 5+.
+ */
+export function getAnthropicSonnet5ProviderOptions(
+	effort: AnthropicEffort = DEFAULT_SONNET5_EFFORT
+): { anthropic: { effort: AnthropicEffort } } {
+	return {
+		anthropic: {
+			effort,
+		},
+	};
+}
+
+/**
+ * Build generateText / streamText sampling fields.
+ * Omits temperature (and related) for Sonnet 5+; includes temperature otherwise.
+ */
+export function anthropicSamplingParams(
+	modelId: string,
+	temperature: number | undefined
+): {
+	temperature?: number;
+	providerOptions?: ReturnType<typeof getAnthropicSonnet5ProviderOptions>;
+} {
+	if (isSonnet5OrNewer(modelId)) {
+		return {
+			providerOptions: getAnthropicSonnet5ProviderOptions(),
+		};
+	}
+	if (temperature === undefined) {
+		return {};
+	}
+	return { temperature };
+}

--- a/src/services/llm/anthropic-provider.ts
+++ b/src/services/llm/anthropic-provider.ts
@@ -1,6 +1,7 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { APICallError, generateText, type ModelMessage } from "ai";
 import { MODEL_CONFIG } from "@/app-constants";
+import { anthropicSamplingParams } from "@/lib/anthropic-model-options";
 import { LLMProviderAPIKeyError } from "@/lib/errors";
 import { describeLlmFailure, wrapLlmError } from "@/lib/llm-error-utils";
 import type {
@@ -103,10 +104,11 @@ export class AnthropicProvider implements LLMProvider {
 		try {
 			const anthropic = createAnthropic({ apiKey: this.apiKey });
 			const model = anthropic(modelId as any);
+			const sampling = anthropicSamplingParams(modelId, temperature);
 			const result = await generateText({
 				model,
 				prompt,
-				temperature,
+				...sampling,
 				maxOutputTokens: maxTokens,
 				...(options.maxRetries != null
 					? { maxRetries: options.maxRetries }
@@ -185,10 +187,11 @@ export class AnthropicProvider implements LLMProvider {
 		}
 
 		try {
+			const sampling = anthropicSamplingParams(modelId, temperature);
 			const result = await generateText({
 				model,
 				...(messages ? { messages } : { prompt: singlePrompt as string }),
-				temperature,
+				...sampling,
 				maxOutputTokens: maxTokens,
 			});
 
@@ -222,10 +225,11 @@ export class AnthropicProvider implements LLMProvider {
 					.filter(Boolean)
 					.join("\n\n");
 
+				const repairSampling = anthropicSamplingParams(modelId, 0);
 				const repairResult = await generateText({
 					model,
 					prompt: repairPrompt,
-					temperature: 0,
+					...repairSampling,
 					maxOutputTokens: Math.max(maxTokens, 3000),
 				});
 				repairResultUsage = repairResult.usage;

--- a/src/services/rag/entity-extraction-service.ts
+++ b/src/services/rag/entity-extraction-service.ts
@@ -19,11 +19,11 @@ import type { TelemetryService } from "@/services/telemetry/telemetry-service";
 /**
  * Maximum tokens for entity extraction responses.
  *
- * Entity extraction uses PIPELINE_STRUCTURED (e.g. claude-sonnet-4-6 on Anthropic).
- * 8192 for Anthropic and 16384 for OpenAI reduce silent truncation on large chunks.
+ * Entity extraction uses PIPELINE_STRUCTURED (e.g. claude-sonnet-5 on Anthropic).
+ * Higher Anthropic budget leaves room for Sonnet 5 adaptive thinking + JSON.
  */
 const MAX_EXTRACTION_RESPONSE_TOKENS =
-	MODEL_CONFIG.PROVIDER.DEFAULT === "anthropic" ? 8192 : 16384;
+	MODEL_CONFIG.PROVIDER.DEFAULT === "anthropic" ? 16384 : 16384;
 
 // Zod schema for entity extraction response
 // This matches the structure expected by the RPG extraction prompt


### PR DESCRIPTION
- Add anthropic-model-options helper to handle Sonnet 5+ sampling (effort instead of temperature) and wire it into base-agent, agent-router, and anthropic-provider so no call site sends temperature to a Sonnet 5 model.
- Promote PRIMARY/INTERACTIVE/PIPELINE_STRUCTURED/SESSION_PLANNING to claude-sonnet-5; downgrade ANALYSIS/PIPELINE_ANALYSIS/METADATA_ANALYSIS to claude-haiku-4-5.
- Raise MAX_TOKENS 4k→8k (Sonnet 5 adaptive thinking headroom) and SESSION_PLANNING_MAX_TOKENS 8k→12k; entity extraction budget 8192→16384.