### PR TITLE
fix(skills): install locked skills for Claude Code, not just universal agents

### DIFF
--- a/scripts/skills/postinstall-skills.mjs
+++ b/scripts/skills/postinstall-skills.mjs
@@ -4,6 +4,8 @@
  * does not depend on cloning many GitHub repos or private templates.
  */
 import { execSync } from "node:child_process";
+import { cpSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
 
 if (process.env.CI === "true" || process.env.CI === "1") {
 	console.log("[postinstall] Skipping agent skills install (CI=true)");
@@ -14,3 +16,27 @@ execSync("npx skills experimental_install --yes", {
 	stdio: "inherit",
 	env: process.env,
 });
+
+// `experimental_install` only targets the shared ".agents/skills" directory
+// used by "universal" agents (Codex, Cursor, GitHub Copilot, ...). Claude
+// Code reads skills from its own ".claude/skills" directory instead, so
+// mirror the resolved skills there. This copies already-resolved skill
+// folders rather than re-running `skills add --agent claude-code`, because
+// that re-fetches from each skill's source repo and, for repos structured as
+// multi-skill plugin marketplaces (e.g. wshobson/agents), the CLI's --skill
+// filter doesn't apply and pulls in the source repo's entire skill catalog.
+const universalSkillsDir = ".agents/skills";
+const claudeSkillsDir = ".claude/skills";
+if (existsSync(universalSkillsDir)) {
+	const managed = readdirSync(universalSkillsDir);
+	for (const name of managed) {
+		// Replace only the skills we manage, so any hand-written skills a
+		// developer keeps in .claude/skills are left alone.
+		const target = join(claudeSkillsDir, name);
+		rmSync(target, { recursive: true, force: true });
+		cpSync(join(universalSkillsDir, name), target, { recursive: true });
+	}
+	console.log(
+		`[postinstall] Mirrored ${managed.length} skill(s) into ${claudeSkillsDir}`
+	);
+}


### PR DESCRIPTION
## Problem

This repo pins 13 agent skills in `skills-lock.json` and restores them via `npm run postinstall` → `npx skills experimental_install`.

That command only populates **`.agents/skills/`** — the directory shared by the "universal" agents (Codex, Cursor, GitHub Copilot, …). Claude Code reads project skills from its own **`.claude/skills/`** directory, which was never created.

**Net effect: none of the 13 locked skills were actually available to Claude Code in this project**, including the ones most relevant to this codebase — `cloudflare`, `wrangler`, `vitest`, `typescript-advanced-types`, and `ai-sdk`.

Verified before the fix:

```
$ npx skills list
ai-sdk        ~/loresmith-ai/.agents/skills/ai-sdk        Agents: Codex, Cursor, GitHub Copilot
cloudflare    ~/loresmith-ai/.agents/skills/cloudflare    Agents: Codex, Cursor, GitHub Copilot
...                                                       # Claude Code absent from every row
```

## Fix

Mirror the resolved skill folders from `.agents/skills/` into `.claude/skills/` as a postinstall step.

### Why copy locally instead of `skills add --agent claude-code`?

The seemingly obvious fix — re-running the installer with `--agent claude-code` — is broken for this skill set. It re-fetches from each source repo, and for repos structured as multi-skill plugin *marketplaces* (e.g. `wshobson/agents`, `anthropics/skills`) the CLI's `--skill` filter is not applied, so it installs the source repo's **entire catalog**: 254 skills instead of 13.

Copying the already-resolved folders sidesteps that entirely, and avoids 9 redundant repo clones on every `npm install`.

### Preserves hand-written skills

Only skills present in `.agents/skills/` are replaced, so any hand-written skills a developer keeps in `.claude/skills/` survive.

## Verification

Ran the updated script from a clean state (`rm -rf .agents/skills .claude/skills`):

- `.agents/skills/` → exactly the 13 locked skills
- `.claude/skills/` → exactly the 13 locked skills
- Both directory listings compared equal to `Object.keys(skills-lock.json.skills)`
- All 13 have a valid `SKILL.md` with `name`/`description` frontmatter
- `npx skills list -a claude-code` now lists all 13 under `Agents: Claude Code`
- Confirmed a hand-written `.claude/skills/my-custom-skill/` is preserved while a stale managed skill is refreshed

Pre-commit hooks passed: Biome clean, 1258 tests across 150 files passing.

## Notes

- `.claude/` and `.agents/` are gitignored, so this PR only contains the script change; the directories are generated at install time.
- Left `skills-lock.json` untouched. Re-running the installer rewrites 9 hashes and a `skillPath` (upstream drift, including a restructure of the playwright skill repo). That's unrelated to this fix and worth a separate lockfile-refresh PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)