### PR TITLE
fix: unbreak library uploads — D1 schema drift, dead logger, and a premature stuck-file cron

### DIFF
--- a/migrations/0026_file_metadata_id_and_content_type.sql
+++ b/migrations/0026_file_metadata_id_and_content_type.sql
@@ -1,0 +1,26 @@
+-- Restore the `id` and `content_type` columns on file_metadata for hosted databases.
+--
+-- Both prod (loresmith-db) and dev (loresmith-db-dev) predate scripts/d1/d1-bootstrap.sql
+-- and never received these two columns. Since PR #677 (2026-05-11) FileDAO names both of
+-- them in every file_metadata INSERT (insertFileForProcessing, createFileMetadata,
+-- createFileRecord), so the INSERT failed with "no such column: id" on those databases.
+--
+-- handleDirectUpload swallowed that failure ("don't fail the upload if metadata insertion
+-- fails"), so the file landed in R2, processing continued, and the upload then died two
+-- layers downstream in SyncQueueService.processFileUpload with the misleading
+-- "File metadata not found in database". Net effect: every library upload has failed
+-- since 2026-05-11.
+--
+-- Bootstrap declares `id text not null unique` and `content_type text not null default ''`.
+-- SQLite cannot ALTER TABLE ADD a UNIQUE column, so `id` is added nullable, backfilled from
+-- file_key (every DAO insert already passes file_key as the id), then given a unique index.
+--
+-- Fresh installs never run this file: d1-seed-d1-migrations.mjs baselines d1_migrations
+-- immediately after d1-bootstrap.sql, which already creates both columns.
+
+ALTER TABLE file_metadata ADD COLUMN id text;
+ALTER TABLE file_metadata ADD COLUMN content_type text NOT NULL DEFAULT '';
+
+UPDATE file_metadata SET id = file_key WHERE id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_file_metadata_id ON file_metadata (id);

--- a/src/routes/upload.ts
+++ b/src/routes/upload.ts
@@ -182,7 +182,11 @@ export async function handleDirectUpload(c: ContextWithAuth) {
 			directUploadLog.debug("Inserted file metadata", { key });
 		} catch (error) {
 			directUploadLog.error("Failed to insert file metadata", error);
-			// Don't fail the upload if metadata insertion fails
+			// The metadata row is a hard prerequisite, not optional bookkeeping:
+			// SyncQueueService.processFileUpload() looks it up via getFileForRag() and
+			// throws "File metadata not found in database" without it. Swallowing here
+			// hid a schema drift for months behind that misleading downstream error.
+			throw error;
 		}
 
 		// Extract JWT token from Authorization header
@@ -821,7 +825,10 @@ export async function handleCompleteLargeUpload(c: ContextWithAuth) {
 			log.debug("Inserted file metadata", { fileKey: session.fileKey });
 		} catch (error) {
 			log.error("Failed to insert file metadata", error);
-			// Don't fail the upload if metadata insertion fails
+			// See handleDirectUpload: the metadata row is required by
+			// SyncQueueService.processFileUpload(), so a failure here must surface now
+			// rather than resurfacing as "File metadata not found in database".
+			throw error;
 		}
 
 		// Extract JWT token from Authorization header


### PR DESCRIPTION
Three independent bugs. #1 broke every upload, #2 made it invisible, #3 kills whatever survives #1.

---

## Bug 1 — uploads fail: hosted D1 missing `file_metadata.id` and `content_type`

`d1-bootstrap.sql` declares `id text not null unique` and `content_type text not null default ''`. The hosted prod and dev databases predate it and had **neither**:

```
$ wrangler d1 execute loresmith-db --remote --command "SELECT id FROM file_metadata LIMIT 1;"
no such column: id [code: 7500]
```

A full bootstrap-vs-production column diff confirmed these two were the *only* real drift. PR #677 (2026-05-11) changed all three `FileDAO` `file_metadata` INSERTs to name both, so `insertFileForProcessing()` threw on every upload from that day forward. Newest row in production was `2026-05-11 00:36`; production tail showed `PUT /api/upload/direct/...` → **500**.

Both upload paths swallowed the failure (`// Don't fail the upload if metadata insertion fails`), so the file still reached R2 and processing continued, dying two layers later in `SyncQueueService.processFileUpload()` where `getFileForRag()` returned `null` → `File metadata not found in database`. That produced the user-visible pair "Couldn't prepare file" + "Upload Faltered" — two notifications, one failure, real cause discarded.

**Changes:** `migrations/0026` adds both columns (`id` nullable → backfilled from `file_key` → unique index, since SQLite cannot `ALTER ADD` a `UNIQUE` column); `upload.ts` rethrows metadata-insert failures in both the direct and multipart paths. Also fixes `getFileMetadataById()` and `getFilesByContentType()`, broken by the same drift.

**Status: applied to prod + dev** (approved by @ofisk). Verified: both columns present, 95 rows backfilled, 0 nulls, 0 mismatches. **Confirmed working** — `PUT /api/upload/direct/...` returned **200** at 8:22:21 PM and created the first new `file_metadata` row since 2026-05-11.

---

## Bug 2 — the application emits no logs at all

Tailing production during the above showed `"logs": []` on **every** request, including the 500.

`src/lib/logger.ts` routes all logging through tslog's `transportFormatted` overwrite, which **replaces** the built-in transport. PR #552 (2026-03-13) deleted every `console.*` from it:

```diff
 case "ERROR":
 case "FATAL":
-    console.error(...logArgs);
     return;          // ← every branch is now a bare return
```

So every `logger.error/warn/info/debug` call has been discarded since 2026-03-13. The same commit renamed `logArgs` → `_logArgs`, silencing the `noUnusedFunctionParameters` lint that would have caught it.

Logging died 2026-03-13; uploads broke 2026-05-11. The app had been blind for two months, so a hard `no such column` on every upload emitted nothing anywhere — which is how a total outage passed for a flaky "please try again later" for 2.5 months.

**Changes:** restore `console.warn/error/info/log`; exempt `src/lib/logger.ts` from `noConsole` in `biome.json` (it is the one place `console.*` is the intended sink); add `tests/lib/logger-transport.test.ts`, which asserts log calls reach console. Verified as a real guard — all 5 fail against the broken transport.

---

## Bug 3 — the stuck-file cron marks in-flight uploads as failed

With bug 1 fixed, the upload succeeded and then flipped to `error` ~3 minutes later:

```json
{"code":"PROCESSING_TIMEOUT",
 "message":"Processing timeout - stuck in ... for more than 10 minutes",
 "timestamp":"2026-07-26T01:25:29.045Z"}
```

Created `01:22:22`, killed `01:25:29`. Three minutes, not ten.

`getStuckProcessingFiles()` compared `updated_at` against a JS `toISOString()` cutoff. `updated_at` is TEXT written by `CURRENT_TIMESTAMP` → `"YYYY-MM-DD HH:MM:SS"`; the cutoff was `"YYYY-MM-DDTHH:MM:SS.mmmZ"`. SQLite compares them as **strings**: identical for 10 chars, then `' '` (0x20) vs `'T'` (0x54). Space sorts lower, so **any same-day row in an in-flight status compares as older than the cutoff regardless of elapsed time** — the 10-minute grace period was effectively zero, and the `*/5` cron killed every upload on its next tick.

```
sqlite> SELECT '2026-07-26 01:22:23' < '2026-07-26T01:22:22.000Z';
1     -- a row updated one second AFTER the cutoff still looks older
```

This is also the likely source of the misflagged rows that migration `0025` backfills.

**Changes:** compute the cutoff in SQL via `datetime('now', ?)` so both sides share one format, and skip `NULL` `updated_at`. `tests/dao/file-dao-stuck-files.test.ts` runs the real DAO against real SQLite (`node:sqlite`) — a mocked D1 cannot exercise comparison semantics, which is the whole defect. Verified as a real guard: the two behavioural cases fail against the previous query.

---

## Deploying

- Bug 1 is **already live** (migration applied; no redeploy needed, the running Worker already emits the corrected INSERT).
- **Bugs 2 and 3 need a deploy.** Until then every upload still succeeds and is then killed by the cron within ~5 minutes.
- Merging matters: prod's `d1_migrations` now references `0026`, which exists only on this branch.

## Verification

`tsc --noEmit` clean; **1283 tests across 153 files passing**; complexity gate passing. Migration additionally rehearsed against a local SQLite replica of production's exact DDL before being applied for real.

## Noted, not fixed

- `src/dao/assessment-dao.ts:79` has the same date-format mismatch in the recent-activity feed (`created_at > thirtyDaysAgo.toISOString()`). Low impact and unrelated to uploads, so left alone.
- The main checkout's `node_modules` is stale — `ai@6.0.184` installed vs `^7.0.34` in package.json/lock — which yields 19 spurious `tsc` errors and fails the pre-commit hook. `npm ci` resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)