### PR TITLE
fix: restore dropped log output and stop the stuck-file cron killing in-flight uploads

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -93,6 +93,7 @@
 		},
 		{
 			"includes": [
+				"src/lib/logger.ts",
 				"src/lib/zod-utils.ts",
 				"src/lib/notifications.ts",
 				"src/lib/shard-generation-utils.ts",

--- a/src/dao/file/file-dao.ts
+++ b/src/dao/file/file-dao.ts
@@ -307,10 +307,19 @@ export class FileDAO extends BaseDAOClass {
 	async getStuckProcessingFiles(
 		timeoutMinutes: number = 1
 	): Promise<ParsedFileMetadata[]> {
-		const timeoutDate = new Date(Date.now() - timeoutMinutes * 60 * 1000);
+		// `updated_at` is TEXT, so this is a lexicographic string comparison.
+		// Every writer sets it via CURRENT_TIMESTAMP / datetime('now'), which
+		// yields "YYYY-MM-DD HH:MM:SS". A JS `toISOString()` cutoff yields
+		// "YYYY-MM-DDTHH:MM:SS.mmmZ": identical for 10 chars, then ' ' (0x20) vs
+		// 'T' (0x54). Space sorts lower, so every same-day row compared as older
+		// than the cutoff regardless of elapsed time -- in-flight uploads were
+		// marked ERROR by the very next cron tick, minutes into a 10-minute
+		// timeout. Build the cutoff in SQL so both sides share one format.
 		const sql = `
-      SELECT * FROM file_metadata 
-      WHERE status IN (?, ?, ?, ?) AND updated_at < ?
+      SELECT * FROM file_metadata
+      WHERE status IN (?, ?, ?, ?)
+        AND updated_at IS NOT NULL
+        AND updated_at < datetime('now', ?)
       ORDER BY updated_at ASC
     `;
 		return this.queryAndParseMultipleFileMetadata(sql, [
@@ -318,7 +327,7 @@ export class FileDAO extends BaseDAOClass {
 			FileDAO.STATUS.SYNCING,
 			FileDAO.STATUS.INDEXING,
 			FileDAO.STATUS.UPLOADED,
-			timeoutDate.toISOString(),
+			`-${timeoutMinutes} minutes`,
 		]);
 	}
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -139,17 +139,27 @@ function getTsLog(env?: Record<string, unknown>): TsLogger<ILogObj> {
 
 			// Ensure WARN/ERROR use console.warn/error (and keep argument order),
 			// which also keeps existing tests that spy on console.error working.
-			transportFormatted: (_meta, _logArgs, _errors, logMeta) => {
+			//
+			// This overwrite REPLACES tslog's built-in transport, so every branch must
+			// actually write. PR #552 dropped the console.* calls here (and renamed
+			// `logArgs` to `_logArgs`, silencing the unused-param lint), which left each
+			// branch a bare `return` -- discarding every log line the app produced.
+			// Workers `wrangler tail` showed `"logs": []` on every request as a result.
+			transportFormatted: (_meta, logArgs, _errors, logMeta) => {
 				const level = (logMeta?.logLevelName || "").toUpperCase();
 				switch (level) {
 					case "WARN":
+						console.warn(...logArgs);
 						return;
 					case "ERROR":
 					case "FATAL":
+						console.error(...logArgs);
 						return;
 					case "INFO":
+						console.info(...logArgs);
 						return;
 					default:
+						console.log(...logArgs);
 						return;
 				}
 			},

--- a/tests/dao/file-dao-stuck-files.test.ts
+++ b/tests/dao/file-dao-stuck-files.test.ts
@@ -1,0 +1,125 @@
+import { DatabaseSync } from "node:sqlite";
+import type { D1Database } from "@cloudflare/workers-types";
+import { beforeEach, describe, expect, it } from "vitest";
+import { FileDAO } from "@/dao/file/file-dao";
+
+/**
+ * Regression guard for the stuck-file cleanup timeout.
+ *
+ * `file_metadata.updated_at` is TEXT and every writer sets it via
+ * CURRENT_TIMESTAMP / datetime('now') => "YYYY-MM-DD HH:MM:SS". The cleanup
+ * query previously compared it against a JS `toISOString()` cutoff
+ * ("YYYY-MM-DDTHH:MM:SS.mmmZ"). SQLite compares those as strings: they match
+ * for 10 characters, then ' ' (0x20) sorts below 'T' (0x54), so every same-day
+ * row looked older than the cutoff no matter how recently it was touched.
+ * Result: the 5-minute cron marked in-flight uploads ERROR minutes into what
+ * was supposed to be a 10-minute grace period.
+ *
+ * These run against real SQLite -- a mocked D1 cannot exercise comparison
+ * semantics, which is the entire defect.
+ */
+
+function d1Adapter(db: DatabaseSync): D1Database {
+	return {
+		prepare(sql: string) {
+			return {
+				bind(...params: unknown[]) {
+					return {
+						all: async () => ({
+							results: db.prepare(sql).all(...(params as [])),
+						}),
+						first: async () => db.prepare(sql).get(...(params as [])) ?? null,
+						run: async () => {
+							db.prepare(sql).run(...(params as []));
+							return {};
+						},
+					};
+				},
+			};
+		},
+	} as unknown as D1Database;
+}
+
+describe("FileDAO.getStuckProcessingFiles", () => {
+	let db: DatabaseSync;
+	let fileDAO: FileDAO;
+
+	beforeEach(() => {
+		db = new DatabaseSync(":memory:");
+		db.exec(`
+			CREATE TABLE file_metadata (
+				file_key text primary key,
+				username text not null,
+				file_name text not null,
+				tags text,
+				status text,
+				updated_at datetime
+			);
+		`);
+		fileDAO = new FileDAO(d1Adapter(db));
+	});
+
+	const insert = (key: string, status: string, updatedAtSql: string) => {
+		db.exec(
+			`INSERT INTO file_metadata (file_key, username, file_name, tags, status, updated_at)
+			 VALUES ('${key}', 'ofisk', '${key}.pdf', '[]', '${status}', ${updatedAtSql})`
+		);
+	};
+
+	it("does not flag a file that is still well inside the timeout", async () => {
+		insert("fresh", "syncing", "CURRENT_TIMESTAMP");
+
+		const stuck = await fileDAO.getStuckProcessingFiles(10);
+
+		expect(stuck).toHaveLength(0);
+	});
+
+	it("flags a file that has genuinely exceeded the timeout", async () => {
+		insert("old", "syncing", "datetime('now', '-30 minutes')");
+
+		const stuck = await fileDAO.getStuckProcessingFiles(10);
+
+		expect(stuck.map((f) => f.file_key)).toEqual(["old"]);
+	});
+
+	it("separates fresh from expired files in the same sweep", async () => {
+		insert("fresh", "syncing", "CURRENT_TIMESTAMP");
+		insert("recent", "uploaded", "datetime('now', '-2 minutes')");
+		insert("expired", "processing", "datetime('now', '-11 minutes')");
+		insert("ancient", "indexing", "datetime('now', '-3 hours')");
+
+		const stuck = await fileDAO.getStuckProcessingFiles(10);
+
+		expect(stuck.map((f) => f.file_key).sort()).toEqual(["ancient", "expired"]);
+	});
+
+	it("ignores files that are not in an in-flight status", async () => {
+		insert("done", "completed", "datetime('now', '-3 hours')");
+		insert("failed", "error", "datetime('now', '-3 hours')");
+
+		const stuck = await fileDAO.getStuckProcessingFiles(10);
+
+		expect(stuck).toHaveLength(0);
+	});
+
+	it("ignores rows with a null updated_at rather than treating them as stuck", async () => {
+		insert("nulled", "syncing", "NULL");
+
+		const stuck = await fileDAO.getStuckProcessingFiles(10);
+
+		expect(stuck).toHaveLength(0);
+	});
+
+	it("documents the format mismatch that caused the original bug", () => {
+		// Both sides describe the same instant, but the serializations disagree.
+		const stored = "2026-07-26 01:22:23"; // CURRENT_TIMESTAMP
+		const cutoff = new Date("2026-07-26T01:12:23.000Z").toISOString();
+
+		const row = db
+			.prepare("SELECT (? < ?) AS looks_older")
+			.get(stored, cutoff) as { looks_older: number };
+
+		// A row updated 10 minutes AFTER the cutoff still compares as older.
+		expect(row.looks_older).toBe(1);
+	});
+});

--- a/tests/lib/logger-transport.test.ts
+++ b/tests/lib/logger-transport.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLogger, logger } from "@/lib/logger";
+
+/**
+ * Regression guard for PR #552, which removed the console.* calls from tslog's
+ * `transportFormatted` overwrite in src/lib/logger.ts. Because that overwrite
+ * REPLACES tslog's built-in transport, every branch became a bare `return` and
+ * the application emitted no logs at all -- for ~5 months, across every level.
+ *
+ * The failure mode is silence, so it is invisible to any test that only checks
+ * that logging doesn't throw. These assert that log calls actually reach console.
+ */
+describe("logger transport", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("writes error-level logs to console.error", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		createLogger({}, "[Test]").error("upload exploded");
+
+		expect(spy).toHaveBeenCalled();
+		expect(
+			spy.mock.calls.flat().some((a) => String(a).includes("upload exploded"))
+		).toBe(true);
+	});
+
+	it("keeps Error objects inspectable in the argument list", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const boom = new Error("no such column: id");
+
+		createLogger({}, "[Test]").error("insert failed", boom);
+
+		expect(spy.mock.calls.flat()).toContain(boom);
+	});
+
+	it("writes warn-level logs to console.warn", () => {
+		const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		createLogger({}, "[Test]").warn("heads up");
+
+		expect(spy).toHaveBeenCalled();
+	});
+
+	it("writes info-level logs to console.info", () => {
+		const spy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+		createLogger({}, "[Test]").info("hello");
+
+		expect(spy).toHaveBeenCalled();
+	});
+
+	it("writes scoped-logger errors to console.error", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		logger.scope("[DirectUpload]").error("Failed to insert file metadata");
+
+		expect(spy).toHaveBeenCalled();
+		expect(
+			spy.mock.calls
+				.flat()
+				.some((a) => String(a).includes("Failed to insert file metadata"))
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
Follow-up to #727. That PR was squash-merged while it still contained only the first of three commits, so the D1 schema fix landed on `main` but these two did not. Same investigation, rebased onto `main`.

Context: uploads had been failing since 2026-05-11 because hosted D1 was missing `file_metadata.id` and `content_type` (fixed and deployed via #727 + migration `0026`). With that fixed, uploads now return **200** and create a row — and then hit bug 2 below.

---

## Bug 1 — the application emits no logs at all

While tailing production, **every** request came back with `"logs": []`, including a 500.

`src/lib/logger.ts` routes all logging through tslog's `transportFormatted` overwrite, which **replaces** the built-in transport. PR #552 (2026-03-13) deleted every `console.*` call from it:

```diff
 case "ERROR":
 case "FATAL":
-    console.error(...logArgs);
     return;          // ← every branch is now a bare return
```

All four branches return nothing, so every `logger.error/warn/info/debug` call in the app has been discarded since 2026-03-13. The same commit renamed `logArgs` → `_logArgs`, which silenced the `noUnusedFunctionParameters` lint that would otherwise have flagged the now-unused argument.

This is why the upload outage stayed invisible: logging died 2026-03-13, uploads broke 2026-05-11, so a hard `no such column: id` on every single upload produced no output anywhere for 2.5 months.

**Changes**
- `src/lib/logger.ts` — restore `console.warn/error/info/log` in the transport.
- `biome.json` — exempt `src/lib/logger.ts` from `noConsole`; the logger is the one place `console.*` is the intended sink, matching the other entries in that list.
- `tests/lib/logger-transport.test.ts` — assert log calls actually reach console. Verified as a real guard: all 5 fail against the broken transport. The failure mode is silence, so nothing short of asserting on the sink catches it.

---

## Bug 2 — the stuck-file cron marks in-flight uploads as failed

With uploads working again, a 10.5MB PDF uploaded at `01:22:22` was flipped to `error` at `01:25:29`:

```json
{"code":"PROCESSING_TIMEOUT",
 "message":"Processing timeout - stuck in ... for more than 10 minutes"}
```

Three minutes, not ten.

`getStuckProcessingFiles()` compared `updated_at` against a JS `toISOString()` cutoff. `updated_at` is TEXT, written by `CURRENT_TIMESTAMP` / `datetime('now')` → `"YYYY-MM-DD HH:MM:SS"`, while `toISOString()` produces `"YYYY-MM-DDTHH:MM:SS.mmmZ"`. SQLite compares them as **strings**: identical for 10 characters, then `' '` (0x20) sorts below `'T'` (0x54).

```
sqlite> SELECT '2026-07-26 01:22:23' < '2026-07-26T01:22:22.000Z';
1     -- a row updated one second AFTER the cutoff still compares as older
```

So **any same-day row in `processing`/`syncing`/`indexing`/`uploaded` compared as older than the cutoff regardless of elapsed time**, and the `*/5 * * * *` cron marked it `ERROR` on its next tick. The 10-minute grace period was effectively zero. This is also the likely source of the misflagged rows that migration `0025` backfills.

**Changes**
- `src/dao/file/file-dao.ts` — compute the cutoff in SQL via `datetime('now', ?)` so both sides share one format; skip `NULL` `updated_at` rather than letting it fall through.
- `tests/dao/file-dao-stuck-files.test.ts` — run the real DAO against real SQLite (`node:sqlite`). A mocked D1 cannot exercise comparison semantics, which is the entire defect. Verified as a real guard: the two behavioural cases fail against the previous query.

---

## Verification

`tsc --noEmit` clean; **1283 tests across 153 files passing**; complexity gate passing.

Both fixes need a deploy to take effect — unlike #727, which took effect via the migration alone. Until this ships, uploads succeed and are then killed by the cron within ~5 minutes.

## Noted, not fixed

`src/dao/assessment-dao.ts:79` has the same date-format mismatch in the recent-activity feed (`created_at > thirtyDaysAgo.toISOString()`). Low impact and unrelated to uploads, so left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)