### PR TITLE
fix(d1): add file_metadata.vector_id and chunk_count

### DIFF
--- a/migrations/0027_file_metadata_vector_id_and_chunk_count.sql
+++ b/migrations/0027_file_metadata_vector_id_and_chunk_count.sql
@@ -1,0 +1,29 @@
+-- Add file_metadata.vector_id and file_metadata.chunk_count.
+--
+-- persistFileTextChunks() (src/services/file/file-chunk-persistence.ts) always
+-- writes chunk_count, and vector_id whenever the caller supplies one, via
+-- FileDAO.updateFileMetadata(). Both columns are declared on the FileMetadata
+-- interface, but neither existed in the hosted databases *or* in
+-- scripts/d1/d1-bootstrap.sql -- so unlike migration 0026 this was never drift:
+-- the columns were simply never created anywhere, and the write failed on every
+-- install.
+--
+-- Symptom, straight from the production logs once logging was restored:
+--
+--   D1_ERROR: no such column: chunk_count: SQLITE_ERROR
+--     at _FileDAO.updateFileMetadata
+--     at persistFileTextChunks
+--     at LibraryRAGService.processFile
+--     at SyncQueueService.processSyncQueue
+--
+-- The failure lands *after* replaceFileChunks() has already stored the chunks,
+-- so indexing does all its real work and then dies on the bookkeeping update,
+-- leaving the file stuck in 'syncing' with its chunks orphaned.
+--
+-- Both columns are nullable, matching their optional declarations on
+-- FileMetadata; existing rows keep NULL until their next successful indexing
+-- pass. d1-bootstrap.sql is updated in the same commit so fresh installs get
+-- them at CREATE TABLE time and skip this file via the journal baseline.
+
+ALTER TABLE file_metadata ADD COLUMN vector_id text;
+ALTER TABLE file_metadata ADD COLUMN chunk_count integer;

--- a/scripts/d1/d1-bootstrap.sql
+++ b/scripts/d1/d1-bootstrap.sql
@@ -93,6 +93,8 @@ CREATE TABLE IF NOT EXISTS file_metadata (
   file_size integer,
   content_type text not null default '',
   status text default 'uploaded',
+  vector_id text, -- Vectorize id for the file's embeddings; set by persistFileTextChunks()
+  chunk_count integer, -- Number of RAG chunks stored for the file; set by persistFileTextChunks()
   content_summary text,
   key_topics text, -- JSON array of key topics/themes
   content_type_categories text, -- JSON array of content types e.g., ["map", "character", "adventure"]


### PR DESCRIPTION
Fourth and (per a full column diff) final bug in the upload chain. Found within minutes of the logging fix from #729 reaching production — this is the first error in this whole investigation that production actually reported on its own.

## The error

```
D1_ERROR: no such column: chunk_count: SQLITE_ERROR
  at _FileDAO.updateFileMetadata
  at persistFileTextChunks
  at LibraryRAGService.processFile
  at SyncQueueService.processSyncQueue
  at processPendingSyncQueueItems
  at runFastScheduledTasks
```

## Cause

`persistFileTextChunks()` always writes `chunk_count`, and `vector_id` whenever the caller supplies one:

```ts
const metadataUpdates: { vector_id?: string; chunk_count: number } = {
  chunk_count: chunks.length,
};
if (options?.vectorId) metadataUpdates.vector_id = options.vectorId;
await fileDAO.updateFileMetadata(fileKey, metadataUpdates);
```

Both columns are declared on the `FileMetadata` interface, but neither existed in the hosted databases **or** in `scripts/d1/d1-bootstrap.sql`. Unlike #727's drift, these columns were never created anywhere — the write failed on every install, hosted or fresh.

## Why it looks worse than it is

The failure lands *after* `replaceFileChunks()` has already persisted the chunks. For the file that surfaced this, production shows **56 chunks stored** — text extraction, embedding, and chunk persistence all succeeded on a 10.5 MB PDF. Indexing does the entire job and then dies updating a counter, leaving the file stuck in `syncing` with its chunks orphaned.

## Changes

- **`migrations/0027`** — add `vector_id text` and `chunk_count integer`, both nullable to match their optional declarations. Existing rows stay NULL until their next successful indexing pass.
- **`scripts/d1/d1-bootstrap.sql`** — add both at `CREATE TABLE` time, so fresh installs get them and skip the migration via the journal baseline.

## Verification

Rehearsed against a local SQLite replica of production's **current** DDL (post-`0026`): the exact `UPDATE` reproduces `no such column: chunk_count` before the migration and succeeds after.

I also diffed the whole `FileMetadata` interface against production rather than fixing one column at a time — this same bug class has now appeared three times. `vector_id` and `chunk_count` were the only two remaining gaps; `file_chunks` is complete.

`tsc --noEmit` clean; 1283 tests across 153 files passing.

## Deploying

Migration only — **no redeploy needed.** The running Worker already emits the correct UPDATE, exactly as with #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)