### PR TITLE
docs: Require branch + PR workflow and block direct commits to main

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,13 @@
+# Block commits directly on main; every change goes through a branch + PR.
+# Checked first so a wrong-branch commit fails instantly instead of after the slower gates below.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" = "main" ] && [ "$ALLOW_MAIN_COMMIT" != "1" ]; then
+  echo "✖ Direct commits to main are not allowed."
+  echo "  Create a branch:  git checkout -b <type>/<slug>"
+  echo "  Your staged changes carry over. Override (rare): ALLOW_MAIN_COMMIT=1 git commit ..."
+  exit 1
+fi
+
 # Format, lint, and typecheck staged files; gate complexity; then run tests for immediate feedback on failure.
 npx lint-staged
 npm run complexity:staged

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -212,12 +212,21 @@ refactor: Standardize imports to use @/ alias
 
 ### Making Changes
 
-1. **Create a branch**: `git checkout -b feature/your-feature-name`
-2. **Make incremental changes**: Small, focused commits
-3. **Follow linting rules**: Run `npm run check` before committing
+1. **Never commit to `main`**: All work happens on a branch and lands via pull request. A `.husky/pre-commit` hook fails commits made on `main`.
+2. **Create a branch** off an up-to-date `main`:
+
+   ```bash
+   git fetch origin
+   git checkout -b <type>/<issue#>-<slug> origin/main
+   ```
+
+   Use the same prefixes as commit messages — `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/` — and include the issue number when one exists (e.g. `fix/576-stuck-sync-queue`, `docs/tool-system-architecture`).
+
+3. **Make incremental changes**: Small, focused commits
+4. **Follow linting rules**: Run `npm run check` before committing
    - Keep functions at or below CCN 15; see [Code Complexity](./CODE_COMPLEXITY.md)
-4. **Write tests**: Add tests for new functionality
-5. **Update documentation**: Update relevant docs if needed
+5. **Write tests**: Add tests for new functionality
+6. **Update documentation**: Update relevant docs if needed
 
 ### Code Review Checklist
 
@@ -232,11 +241,13 @@ refactor: Standardize imports to use @/ alias
 
 ### Pull Request Process
 
-1. **Update branch**: Rebase on latest `main` branch
+1. **Update branch**: Rebase on latest `main` branch (rebase, don't merge `main` in — history stays linear)
 2. **Write clear description**: Explain what and why
 3. **Link related issues**: Reference any related issues
 4. **Request review**: Tag relevant maintainers
 5. **Address feedback**: Respond to review comments promptly
+6. **Wait for CI**: `ci.yml` (`npm run validate`, e2e) and `sanity-check.yml` (`npm run check`, build, tests) must be green
+7. **Squash-merge and delete the branch**: Merging to `main` triggers a production deploy via Cloudflare Workers Builds — see [DEPLOYMENT.md](DEPLOYMENT.md)
 
 ## File Organization
 


### PR DESCRIPTION
## Why

Nothing in this repo prevented commits landing directly on `main` — and since Cloudflare Workers Builds deploys production straight from `main` (see [DEPLOYMENT.md](docs/DEPLOYMENT.md)), a stray direct commit ships to prod with no PR and no CI gate.

Two supporting problems:

- `docs/CONTRIBUTING.md` prescribed `feature/your-feature-name`, which **none** of the repo's ~120 branches follow.
- Its Pull Request Process section never mentioned CI passing or the merge strategy, even though history is consistently squash-merged (1 merge commit in the last 100, every commit suffixed `(#NNN)`).

## What changed

**`.husky/pre-commit`** — a guard that hard-fails any commit made while `HEAD` is on `main`:

```
✖ Direct commits to main are not allowed.
  Create a branch:  git checkout -b <type>/<slug>
```

It runs **first**, ahead of `lint-staged`, the `complexity:staged` gate, and `vitest`, so a wrong-branch commit fails in ~19ms instead of after the full test suite. Rebased onto `main` to preserve the complexity gate added upstream. `ALLOW_MAIN_COMMIT=1` is a deliberate escape hatch, needed because `--no-verify` is forbidden by `.cursor/rules/no-verify-commits.mdc`.

**`docs/CONTRIBUTING.md`** — two targeted edits:

- Branch naming is now `<type>/<issue#>-<slug>` using the same prefixes as commit messages (`feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/`), plus an explicit "never commit to `main`" rule.
- PR process gained the two missing steps: CI (`ci.yml`, `sanity-check.yml`) must be green, and squash-merge then delete the branch, noting that merging deploys production.

## Deliberately not included

- **No `develop`/`release`/`hotfix` branches.** True GitFlow would require retargeting `ci.yml` and `sanity-check.yml` (both filtered to `branches: [main]`), Dependabot, and the Cloudflare integration. The repo is trunk-based; this documents that rather than changing it.
- **No `CLAUDE.md`.** The Claude-facing version of these rules lives at `.claude/CLAUDE.md`, which is gitignored by design (`.gitignore:145`) and intentionally stays out of this PR.

## Verification

- Guard blocks while `HEAD` is on `main`: exit 1 in 19ms, confirmed before `vitest` runs.
- Guard allows a normal branch: this branch's commit passed with 1258 tests green.
- `ALLOW_MAIN_COMMIT=1` correctly proceeds past the guard.
- `grep -rn "feature/your-feature-name" docs/ README.md` returns nothing.

One inherent caveat: the guard only protects `main` **after this merges**, since until then a `git checkout main` restores the previous 3-line hook. It was verified by running this branch's hook script while `HEAD` was genuinely on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)