### PR TITLE
feat: Add exportable GM session runsheet (#742)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -128,6 +128,7 @@ Welcome to the LoreSmith AI documentation! This directory contains comprehensive
 - **[Notification System](NOTIFICATION_SYSTEM.md)** - Real-time notifications
 - **[Assessment System](ASSESSMENT_SYSTEM.md)** - Campaign assessment features
 - **[Campaign Shard Flow](CAMPAIGN_SHARD_FLOW.md)** - Shard-based campaign system
+- **[Session Runsheet](SESSION_RUNSHEET.md)** - GM-only printable page assembled from digests, planning tasks, the entity graph and house rules
 - **[Shard Approval System](SHARD_APPROVAL_SYSTEM.md)** - Entity approval workflow
 - **[Shard UI Components](SHARD_UI_COMPONENTS.md)** - Shard UI implementation
 - **[Community Detection Memory](COMMUNITY_DETECTION_MEMORY.md)** - Community detection algorithms

--- a/docs/SESSION_RUNSHEET.md
+++ b/docs/SESSION_RUNSHEET.md
@@ -1,0 +1,128 @@
+# Session runsheet
+
+One GM-facing, exportable page to actually run a session from. Implements
+[issue #742](https://github.com/ofisk/loresmith-ai/issues/742).
+
+LoreSmith already produces session plans, digests, handouts and planning tasks —
+each in its own UI surface. A GM about to run a session needs several of them
+*simultaneously*. The runsheet assembles them into a single printable document.
+
+## What it is (and isn't)
+
+- **Assembly, not generation.** Every input already exists in D1. Building a
+  runsheet makes **no LLM calls** — it costs one round of database reads. See
+  `RunsheetAssemblyService`.
+- **A snapshot, not a live view.** Once generated, the content is frozen. The
+  plan must not shift under the GM mid-session. Regenerating writes a new
+  snapshot; hand-edits are persisted into the existing one and are never
+  overwritten by re-assembly.
+- **GM-only.** A runsheet is the campaign's secrets on one page. The
+  player-safe equivalent is handouts.
+
+## Composition
+
+| Section | Assembled from |
+| --- | --- |
+| Recap | `last_session_recap` of the source session digest |
+| This session's plan | `next_session_plan` of the source digest, plus open planning tasks scoped to this session (#699), plus the digest's `todo_checklist` |
+| Cast | `npcs_to_run` from the digest, enriched with `npcs` entities (goals, quirks, role, secrets) |
+| Encounters | `encounter_seeds` from the digest, enriched with `monsters` entities (CR/AC/HP/Speed) |
+| Loot | `treasure_and_rewards` from the digest, enriched with `items` entities (rarity, text) |
+| Rules to remember | Active house rules via `RulesContextService`, filtered to `source === "house"` |
+| Open threads | `open_threads` from the digest, plus recent `hooks` entities |
+| Notes | Freeform, always empty on generation; filled in by hand-editing |
+
+### Choosing the source digest
+
+A digest for session *N* holds both the recap **of** session *N* and the plan
+**for** session *N+1*. So a runsheet for upcoming session *N* is fed by the
+highest-numbered non-rejected digest **below** *N* — a single digest supplies
+both the recap and plan sections.
+
+### Name matching
+
+Digest fields such as `npcs_to_run` and `encounter_seeds` are free text the GM
+typed; they carry names, not entity ids. Name matching is therefore the only
+available join, and it is deliberately forgiving:
+
+- exact match on the normalized (lowercased, whitespace-collapsed) name, else
+- the longest indexed entity name contained in the text.
+
+Names shorter than 4 characters are never substring-matched — "Rat" or "Imp"
+would match half the prose in a campaign. An unmatched name still appears on the
+runsheet, just without enrichment, attributed to the digest rather than the graph.
+
+Sections with nothing in them are listed in `emptySections` and rendered with an
+explicit "nothing recorded" line. A silently omitted section reads as "nothing to
+prepare" rather than "nothing recorded yet".
+
+## Spoiler boundary
+
+This is the critical design constraint of the feature.
+
+- Every handler in `src/routes/runsheets.ts` gates on `requireCanSeeSpoilers`
+  (read/export) or `requireCanEdit` (generate/update/delete). Both exclude the
+  `editor_player` and `readonly_player` roles.
+- Runsheets are **not** reachable through the player-facing share flow
+  (`src/routes/campaign-share.ts`). Share links grant a player role; the role
+  checks above reject it.
+- The export endpoint carries no auth in its URL. The client fetches it with its
+  bearer token and opens the result as a blob — so no spoiler-bearing link ever
+  exists to leak. A token-in-URL export would have created exactly the shareable
+  secret URL this feature must not have.
+- The export response is sent `Cache-Control: no-store, private` and
+  `X-Robots-Tag: noindex, nofollow`.
+
+## Export
+
+`GET /api/campaigns/:campaignId/runsheets/:runsheetId/export.html` returns a
+standalone, print-friendly HTML document:
+
+- fully self-contained — inline CSS, no scripts, no fonts, no external requests.
+  A runsheet that needs wifi at the table defeats the point of printing it.
+- `@page` margins and `break-inside: avoid` per section, so a statblock does not
+  split across a page fold mid-combat.
+- prep and checklist items render as `☐` checkboxes.
+
+**PDF export is the browser's own "Print → Save as PDF."** Workers have no
+headless-browser binding, and a print stylesheet gets the GM the same artifact
+without shipping a PDF engine into the request path.
+
+All rendered values pass through `escapeHtml` — runsheet content is entirely
+user-authored prose.
+
+## API
+
+All routes require a user JWT. Roles as noted above.
+
+| Method | Path | Role | Purpose |
+| --- | --- | --- | --- |
+| `POST` | `/campaigns/:campaignId/runsheets` | edit | Generate a snapshot. Body: optional `sessionNumber`, `title`. Defaults to the campaign's next session number. |
+| `GET` | `/campaigns/:campaignId/runsheets` | spoilers | List snapshots (summaries only — no body). Optional `?sessionNumber=`. |
+| `GET` | `/campaigns/:campaignId/runsheets/:runsheetId` | spoilers | Get one snapshot with its full body. |
+| `PUT` | `/campaigns/:campaignId/runsheets/:runsheetId` | edit | Persist hand-edits. Body: `title` and/or `runsheetData`. |
+| `DELETE` | `/campaigns/:campaignId/runsheets/:runsheetId` | edit | Delete a snapshot. |
+| `GET` | `/campaigns/:campaignId/runsheets/:runsheetId/export.html` | spoilers | Print-friendly HTML document. |
+
+A runsheet id belonging to a different campaign answers `404`, not `403` — that
+avoids confirming the runsheet exists to someone probing ids.
+
+## Code map
+
+| Concern | File |
+| --- | --- |
+| Types + snapshot validation | `src/types/runsheet.ts` |
+| Persistence | `src/dao/runsheet-dao.ts`, `migrations/0028_campaign_runsheets.sql` |
+| Assembly | `src/services/campaign/runsheet-assembly-service.ts` |
+| Print rendering | `src/services/campaign/runsheet-html-service.ts` |
+| Handlers | `src/routes/runsheets.ts` |
+| Route registration | `src/routes/campaigns/runsheet-routes.ts` |
+| UI | `src/components/session/RunsheetPanel.tsx` (Runsheet tab in `CampaignDetailsModal`) |
+
+## Notes on the snapshot body
+
+`validateRunsheetData` is deliberately **shallow on prose**: the GM is free to
+rewrite any wording, but a document handed back missing a section (or with a
+section of the wrong type) is rejected, because the renderer indexes into every
+section. A stored snapshot that no longer parses raises rather than degrading to
+an empty page — unlike a digest, there is no form to re-fill a runsheet from.

--- a/migrations/0028_campaign_runsheets.sql
+++ b/migrations/0028_campaign_runsheets.sql
@@ -1,0 +1,22 @@
+-- Session runsheets: one GM-facing, print-friendly page assembled from existing
+-- campaign data (digest recap, planning tasks, entity graph, house rules).
+--
+-- Runsheets are SNAPSHOTS, not live views: once generated, the content is frozen
+-- so the plan cannot shift under the GM mid-session. Regenerating writes a new
+-- snapshot; hand-edits are persisted back into runsheet_data.
+CREATE TABLE IF NOT EXISTS campaign_runsheets (
+  id TEXT PRIMARY KEY,
+  campaign_id TEXT NOT NULL,
+  session_number INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  -- JSON snapshot conforming to RunsheetData in src/types/runsheet.ts
+  runsheet_data TEXT NOT NULL,
+  generated_at DATETIME NOT NULL DEFAULT current_timestamp,
+  created_at DATETIME NOT NULL DEFAULT current_timestamp,
+  updated_at DATETIME NOT NULL DEFAULT current_timestamp,
+  FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE
+);
+
+-- Listing is always scoped to a campaign, newest session first.
+CREATE INDEX IF NOT EXISTS idx_campaign_runsheets_campaign_session
+  ON campaign_runsheets(campaign_id, session_number DESC);

--- a/src/components/resource-side-panel/CampaignDetailsModal.tsx
+++ b/src/components/resource-side-panel/CampaignDetailsModal.tsx
@@ -7,6 +7,7 @@ import { PlayerCharacterRosterPanel } from "@/components/campaign/PlayerCharacte
 import { ShareCampaignModal } from "@/components/campaign/ShareCampaignModal";
 import { GraphVisualizationModal } from "@/components/graph/GraphVisualizationModal";
 import { Modal } from "@/components/modal/Modal";
+import { RunsheetPanel } from "@/components/session/RunsheetPanel";
 import { SessionDigestBulkImport } from "@/components/session/SessionDigestBulkImport";
 import { SessionDigestModal } from "@/components/session/SessionDigestModal";
 import { Tooltip } from "@/components/tooltip/Tooltip";
@@ -61,6 +62,66 @@ interface CampaignDetailsModalProps {
 	addLocalNotification?: (type: string, title: string, message: string) => void;
 }
 
+interface RunsheetTabProps {
+	isActive: boolean;
+	/** Runsheets are GM-only; player roles see the tab disabled. */
+	isPlayerRole: boolean;
+}
+
+/**
+ * Extracted from the modal body so the tab's disabled/active styling branches
+ * stay out of the (already large) render function.
+ */
+function RunsheetTabButton({
+	isActive,
+	isPlayerRole,
+	onSelect,
+}: RunsheetTabProps & { onSelect: () => void }) {
+	const stateClass = isPlayerRole
+		? "border-transparent text-neutral-400 dark:text-neutral-500 cursor-not-allowed"
+		: isActive
+			? "border-purple-600 text-purple-600 dark:border-purple-400 dark:text-purple-400"
+			: "border-transparent text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300";
+
+	return (
+		<button
+			type="button"
+			role="tab"
+			aria-selected={isActive}
+			aria-controls="tabpanel-runsheet"
+			id="tab-runsheet"
+			onClick={onSelect}
+			disabled={isPlayerRole}
+			title={
+				isPlayerRole ? "Runsheets are GM-only and contain spoilers" : undefined
+			}
+			className={`pb-3 px-1 text-sm font-medium border-b-2 transition-colors ${stateClass}`}
+		>
+			Runsheet
+		</button>
+	);
+}
+
+function RunsheetTabPanel({
+	isActive,
+	isPlayerRole,
+	campaignId,
+	canEdit,
+}: RunsheetTabProps & { campaignId: string; canEdit: boolean }) {
+	if (!isActive || isPlayerRole) return null;
+
+	return (
+		<div
+			role="tabpanel"
+			id="tabpanel-runsheet"
+			aria-labelledby="tab-runsheet"
+			className="mt-2"
+		>
+			<RunsheetPanel campaignId={campaignId} canEdit={canEdit} />
+		</div>
+	);
+}
+
 export function CampaignDetailsModal({
 	campaign,
 	isOpen,
@@ -82,7 +143,7 @@ export function CampaignDetailsModal({
 	);
 	const [isUpdating, setIsUpdating] = useState(false);
 	const [activeTab, setActiveTab] = useState<
-		"details" | "party" | "digests" | "nextSteps" | "resources"
+		"details" | "party" | "digests" | "nextSteps" | "runsheet" | "resources"
 	>("details");
 	const [isDigestModalOpen, setIsDigestModalOpen] = useState(false);
 	const [editingDigest, setEditingDigest] =
@@ -673,6 +734,11 @@ export function CampaignDetailsModal({
 							>
 								Next steps
 							</button>
+							<RunsheetTabButton
+								isActive={activeTab === "runsheet"}
+								isPlayerRole={isPlayerRole}
+								onSelect={() => setActiveTab("runsheet")}
+							/>
 							<button
 								type="button"
 								role="tab"
@@ -759,6 +825,13 @@ export function CampaignDetailsModal({
 								<PlanningTasksPanel campaignId={campaign.campaignId} />
 							</div>
 						)}
+
+						<RunsheetTabPanel
+							isActive={activeTab === "runsheet"}
+							isPlayerRole={isPlayerRole}
+							campaignId={campaign.campaignId}
+							canEdit={canShare}
+						/>
 
 						{activeTab === "resources" && (
 							<div

--- a/src/components/session/RunsheetPanel.tsx
+++ b/src/components/session/RunsheetPanel.tsx
@@ -1,0 +1,502 @@
+import {
+	ArrowClockwise,
+	FloppyDisk,
+	Printer,
+	Trash,
+} from "@phosphor-icons/react";
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/button/Button";
+import { useAuthenticatedRequest } from "@/hooks/useAuthenticatedRequest";
+import { API_CONFIG } from "@/shared-config";
+import type { RunsheetSummary, RunsheetWithData } from "@/types/runsheet";
+
+interface RunsheetPanelProps {
+	campaignId: string;
+	/** GM roles can generate, edit and delete; read-only GMs can only view/print. */
+	canEdit: boolean;
+}
+
+interface RunsheetListResponse {
+	runsheets: RunsheetSummary[];
+	nextSessionNumber: number;
+}
+
+function formatTimestamp(value: string): string {
+	const parsed = new Date(value.includes("T") ? value : `${value}Z`);
+	if (Number.isNaN(parsed.getTime())) return value;
+	return parsed.toLocaleString();
+}
+
+/** Renders a list section, or an explicit "nothing here" line so gaps are legible. */
+function Section({
+	title,
+	children,
+	isEmpty,
+	emptyMessage,
+}: {
+	title: string;
+	children?: React.ReactNode;
+	isEmpty: boolean;
+	emptyMessage: string;
+}) {
+	return (
+		<section className="mb-4">
+			<h4 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400 border-b border-neutral-200 dark:border-neutral-700 pb-1 mb-2">
+				{title}
+			</h4>
+			{isEmpty ? (
+				<p className="text-xs italic text-neutral-500 dark:text-neutral-400">
+					{emptyMessage}
+				</p>
+			) : (
+				children
+			)}
+		</section>
+	);
+}
+
+function BulletList({ items }: { items: string[] }) {
+	if (items.length === 0) return null;
+	return (
+		<ul className="list-disc pl-5 space-y-0.5 text-xs text-neutral-700 dark:text-neutral-300">
+			{items.map((item) => (
+				<li key={item}>{item}</li>
+			))}
+		</ul>
+	);
+}
+
+export function RunsheetPanel({ campaignId, canEdit }: RunsheetPanelProps) {
+	const { makeRequest, makeRequestWithData } = useAuthenticatedRequest();
+
+	const [runsheets, setRunsheets] = useState<RunsheetSummary[]>([]);
+	const [nextSessionNumber, setNextSessionNumber] = useState<number | null>(
+		null
+	);
+	const [selected, setSelected] = useState<RunsheetWithData | null>(null);
+	const [notesDraft, setNotesDraft] = useState("");
+	const [loading, setLoading] = useState(false);
+	const [busyAction, setBusyAction] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const loadRunsheets = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const data = await makeRequestWithData<RunsheetListResponse>(
+				API_CONFIG.buildUrl(
+					API_CONFIG.ENDPOINTS.CAMPAIGNS.RUNSHEETS.BASE(campaignId)
+				)
+			);
+			setRunsheets(data.runsheets ?? []);
+			setNextSessionNumber(data.nextSessionNumber ?? null);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to load runsheets");
+		} finally {
+			setLoading(false);
+		}
+	}, [campaignId, makeRequestWithData]);
+
+	useEffect(() => {
+		void loadRunsheets();
+	}, [loadRunsheets]);
+
+	const openRunsheet = async (runsheetId: string) => {
+		setBusyAction(`open:${runsheetId}`);
+		setError(null);
+		try {
+			const data = await makeRequestWithData<{ runsheet: RunsheetWithData }>(
+				API_CONFIG.buildUrl(
+					API_CONFIG.ENDPOINTS.CAMPAIGNS.RUNSHEETS.DETAILS(
+						campaignId,
+						runsheetId
+					)
+				)
+			);
+			setSelected(data.runsheet);
+			setNotesDraft(data.runsheet.runsheetData.notes ?? "");
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to open runsheet");
+		} finally {
+			setBusyAction(null);
+		}
+	};
+
+	const handleGenerate = async () => {
+		setBusyAction("generate");
+		setError(null);
+		try {
+			const data = await makeRequestWithData<{ runsheet: RunsheetWithData }>(
+				API_CONFIG.buildUrl(
+					API_CONFIG.ENDPOINTS.CAMPAIGNS.RUNSHEETS.BASE(campaignId)
+				),
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(
+						nextSessionNumber != null
+							? { sessionNumber: nextSessionNumber }
+							: {}
+					),
+				}
+			);
+			setSelected(data.runsheet);
+			setNotesDraft(data.runsheet.runsheetData.notes ?? "");
+			await loadRunsheets();
+		} catch (err) {
+			setError(
+				err instanceof Error ? err.message : "Failed to generate runsheet"
+			);
+		} finally {
+			setBusyAction(null);
+		}
+	};
+
+	const handleSaveNotes = async () => {
+		if (!selected) return;
+		setBusyAction("save");
+		setError(null);
+		try {
+			const data = await makeRequestWithData<{ runsheet: RunsheetWithData }>(
+				API_CONFIG.buildUrl(
+					API_CONFIG.ENDPOINTS.CAMPAIGNS.RUNSHEETS.DETAILS(
+						campaignId,
+						selected.id
+					)
+				),
+				{
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						runsheetData: { ...selected.runsheetData, notes: notesDraft },
+					}),
+				}
+			);
+			setSelected(data.runsheet);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to save notes");
+		} finally {
+			setBusyAction(null);
+		}
+	};
+
+	const handleDelete = async (runsheetId: string) => {
+		setBusyAction(`delete:${runsheetId}`);
+		setError(null);
+		try {
+			await makeRequest(
+				API_CONFIG.buildUrl(
+					API_CONFIG.ENDPOINTS.CAMPAIGNS.RUNSHEETS.DETAILS(
+						campaignId,
+						runsheetId
+					)
+				),
+				{ method: "DELETE" }
+			);
+			if (selected?.id === runsheetId) setSelected(null);
+			await loadRunsheets();
+		} catch (err) {
+			setError(
+				err instanceof Error ? err.message : "Failed to delete runsheet"
+			);
+		} finally {
+			setBusyAction(null);
+		}
+	};
+
+	/**
+	 * Fetch the export with our bearer token and hand it to a popup to print.
+	 *
+	 * We deliberately do not navigate to the export URL: it is bearer-authenticated
+	 * (navigation would 401), and a token-in-URL variant would create exactly the
+	 * shareable, spoiler-bearing link a GM-only document must never have.
+	 */
+	const handlePrint = async () => {
+		if (!selected) return;
+		setBusyAction("print");
+		setError(null);
+		try {
+			const response = await makeRequest(
+				API_CONFIG.buildUrl(
+					API_CONFIG.ENDPOINTS.CAMPAIGNS.RUNSHEETS.EXPORT_HTML(
+						campaignId,
+						selected.id
+					)
+				)
+			);
+			if (!response.ok) {
+				throw new Error("Failed to export runsheet");
+			}
+			const html = await response.text();
+			const printWindow = window.open("", "_blank", "noopener,noreferrer");
+			if (!printWindow) {
+				throw new Error(
+					"Your browser blocked the print window. Allow pop-ups for this site and try again."
+				);
+			}
+			printWindow.document.open();
+			printWindow.document.write(html);
+			printWindow.document.close();
+			printWindow.focus();
+			printWindow.print();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to print runsheet");
+		} finally {
+			setBusyAction(null);
+		}
+	};
+
+	const data = selected?.runsheetData;
+
+	return (
+		<div className="space-y-4">
+			<div className="flex flex-wrap items-start justify-between gap-2">
+				<div>
+					<p className="text-sm text-neutral-600 dark:text-neutral-400">
+						One page to run the session from — recap, plan, cast, encounters,
+						loot, house rules and open threads, assembled from what your
+						campaign already has.
+					</p>
+					<p className="mt-1 text-[11px] font-semibold uppercase tracking-wider text-amber-700 dark:text-amber-500">
+						GM only — contains spoilers. Never shown to players.
+					</p>
+				</div>
+				{canEdit && (
+					<Button
+						appearance="form"
+						onClick={handleGenerate}
+						loading={busyAction === "generate"}
+						disabled={busyAction !== null}
+						icon={<ArrowClockwise size={16} />}
+						data-testid="runsheet-generate"
+					>
+						{nextSessionNumber != null
+							? `Generate for session ${nextSessionNumber}`
+							: "Generate runsheet"}
+					</Button>
+				)}
+			</div>
+
+			{error && (
+				<p className="text-xs text-red-600 dark:text-red-400" role="alert">
+					{error}
+				</p>
+			)}
+
+			<div className="rounded-lg border border-neutral-200/60 dark:border-neutral-700/60 p-3">
+				<h3 className="text-sm font-semibold text-neutral-800 dark:text-neutral-100 mb-2">
+					Snapshots
+				</h3>
+				{loading ? (
+					<p className="text-xs text-neutral-500">Loading…</p>
+				) : runsheets.length === 0 ? (
+					<p className="text-xs text-neutral-500 dark:text-neutral-400">
+						No runsheets yet. Generate one when your prep for the next session
+						is ready.
+					</p>
+				) : (
+					<ul className="space-y-1">
+						{runsheets.map((runsheet) => (
+							<li
+								key={runsheet.id}
+								className={`flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs ${
+									selected?.id === runsheet.id
+										? "bg-purple-50 dark:bg-purple-950/40"
+										: "bg-neutral-50/60 dark:bg-neutral-900/70"
+								}`}
+							>
+								<button
+									type="button"
+									className="flex-1 min-w-0 text-left"
+									onClick={() => openRunsheet(runsheet.id)}
+									disabled={busyAction !== null}
+								>
+									<span className="font-medium text-neutral-800 dark:text-neutral-100">
+										{runsheet.title}
+									</span>
+									<span className="block text-[11px] text-neutral-500 dark:text-neutral-400">
+										Generated {formatTimestamp(runsheet.generatedAt)}
+									</span>
+								</button>
+								{canEdit && (
+									<button
+										type="button"
+										onClick={() => handleDelete(runsheet.id)}
+										disabled={busyAction !== null}
+										className="p-1.5 text-neutral-500 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+										title="Delete runsheet"
+									>
+										<Trash size={14} />
+									</button>
+								)}
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+
+			{selected && data && (
+				<div className="rounded-lg border border-neutral-200/60 dark:border-neutral-700/60 p-4">
+					<div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+						<div>
+							<h3 className="text-sm font-semibold text-neutral-800 dark:text-neutral-100">
+								{selected.title}
+							</h3>
+							<p className="text-[11px] text-neutral-500 dark:text-neutral-400">
+								Frozen snapshot — regenerate to pick up newer campaign data.
+							</p>
+						</div>
+						<Button
+							appearance="form"
+							onClick={handlePrint}
+							loading={busyAction === "print"}
+							disabled={busyAction !== null}
+							icon={<Printer size={16} />}
+							data-testid="runsheet-print"
+						>
+							Print / Save as PDF
+						</Button>
+					</div>
+
+					<Section
+						title={
+							data.recap.fromSessionNumber != null
+								? `Recap (session ${data.recap.fromSessionNumber})`
+								: "Recap"
+						}
+						isEmpty={data.emptySections.includes("recap")}
+						emptyMessage="No recap recorded. Add a session digest for the previous session."
+					>
+						<BulletList items={data.recap.keyEvents} />
+					</Section>
+
+					<Section
+						title="This session's plan"
+						isEmpty={data.emptySections.includes("plan")}
+						emptyMessage="No plan recorded. Add beats to the previous digest, or planning tasks for this session."
+					>
+						<BulletList items={data.plan.beats} />
+						<BulletList items={data.plan.objectives} />
+						{data.plan.openTasks.length > 0 && (
+							<ul className="mt-1 list-disc pl-5 space-y-0.5 text-xs text-neutral-700 dark:text-neutral-300">
+								{data.plan.openTasks.map((task) => (
+									<li key={task.source.id ?? task.title}>{task.title}</li>
+								))}
+							</ul>
+						)}
+					</Section>
+
+					<Section
+						title="Cast"
+						isEmpty={data.emptySections.includes("cast")}
+						emptyMessage="No NPCs listed for this session."
+					>
+						<ul className="space-y-1 text-xs">
+							{data.cast.map((member) => (
+								<li key={`${member.name}-${member.source.id ?? ""}`}>
+									<span className="font-medium text-neutral-800 dark:text-neutral-100">
+										{member.name}
+									</span>
+									{member.hook && (
+										<span className="text-neutral-600 dark:text-neutral-400">
+											{" "}
+											— {member.hook}
+										</span>
+									)}
+								</li>
+							))}
+						</ul>
+					</Section>
+
+					<Section
+						title="Encounters"
+						isEmpty={data.emptySections.includes("encounters")}
+						emptyMessage="No encounters prepared for this session."
+					>
+						<ul className="space-y-1 text-xs">
+							{data.encounters.map((encounter) => (
+								<li key={encounter.name}>
+									<span className="font-medium text-neutral-800 dark:text-neutral-100">
+										{encounter.name}
+									</span>
+									{Object.keys(encounter.statblock).length > 0 && (
+										<span className="ml-2 font-mono text-[10px] text-neutral-500 dark:text-neutral-400">
+											{Object.entries(encounter.statblock)
+												.map(([label, value]) => `${label} ${value}`)
+												.join(" · ")}
+										</span>
+									)}
+								</li>
+							))}
+						</ul>
+					</Section>
+
+					<Section
+						title="Loot"
+						isEmpty={data.emptySections.includes("loot")}
+						emptyMessage="No rewards prepared for this session."
+					>
+						<BulletList items={data.loot.map((item) => item.name)} />
+					</Section>
+
+					<Section
+						title="Rules to remember"
+						isEmpty={data.emptySections.includes("rules")}
+						emptyMessage="No active house rules recorded for this campaign."
+					>
+						<ul className="space-y-1 text-xs">
+							{data.rules.map((rule) => (
+								<li key={rule.name}>
+									<span className="font-medium text-neutral-800 dark:text-neutral-100">
+										{rule.name}
+									</span>
+									<span className="text-neutral-600 dark:text-neutral-400">
+										{" "}
+										— {rule.text}
+									</span>
+								</li>
+							))}
+						</ul>
+					</Section>
+
+					<Section
+						title="Open threads"
+						isEmpty={data.emptySections.includes("openThreads")}
+						emptyMessage="No open threads recorded."
+					>
+						<BulletList items={data.openThreads.map((thread) => thread.text)} />
+					</Section>
+
+					<section>
+						<h4 className="text-[11px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400 border-b border-neutral-200 dark:border-neutral-700 pb-1 mb-2">
+							Notes
+						</h4>
+						<textarea
+							value={notesDraft}
+							onChange={(event) => setNotesDraft(event.target.value)}
+							disabled={!canEdit}
+							rows={4}
+							placeholder="Anything else you want on the page at the table…"
+							className="w-full rounded-md border border-neutral-200/60 bg-white px-2 py-1.5 text-xs text-neutral-900 placeholder:text-neutral-400 focus-visible:outline-none focus-visible:border-blue-500 focus-visible:ring-1 focus-visible:ring-blue-500 disabled:opacity-60 dark:border-neutral-700/70 dark:bg-neutral-800 dark:text-neutral-100 dark:placeholder:text-neutral-500"
+						/>
+						{canEdit && (
+							<div className="mt-2 flex justify-end">
+								<Button
+									appearance="form"
+									onClick={handleSaveNotes}
+									loading={busyAction === "save"}
+									disabled={
+										busyAction !== null || notesDraft === (data.notes ?? "")
+									}
+									icon={<FloppyDisk size={16} />}
+								>
+									Save notes
+								</Button>
+							</div>
+						)}
+					</section>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -28,6 +28,7 @@ import { PlanningTaskDAO } from "./planning-task-dao";
 import { PlayerCharacterClaimDAO } from "./player-character-claim-dao";
 import { RebuildStatusDAO } from "./rebuild-status-dao";
 import { ResourceAddLogDAO } from "./resource-add-log-dao";
+import { RunsheetDAO } from "./runsheet-dao";
 import { SessionDigestDAO } from "./session-digest-dao";
 import { SessionDigestTemplateDAO } from "./session-digest-template-dao";
 import { SessionPlanReadoutChunkDAO } from "./session-plan-readout-chunk-dao";
@@ -79,6 +80,7 @@ export interface DAOFactory {
 	userCreditsDAO: UserCreditsDAO;
 	fileRetryUsageDAO: FileRetryUsageDAO;
 	resourceAddLogDAO: ResourceAddLogDAO;
+	runsheetDAO: RunsheetDAO;
 	entityGraphService: EntityGraphService;
 	entityImportanceService: EntityImportanceService;
 	rebuildTriggerService: RebuildTriggerService;
@@ -121,6 +123,7 @@ export class DAOFactoryImpl implements DAOFactory {
 	public readonly userCreditsDAO: UserCreditsDAO;
 	public readonly fileRetryUsageDAO: FileRetryUsageDAO;
 	public readonly resourceAddLogDAO: ResourceAddLogDAO;
+	public readonly runsheetDAO: RunsheetDAO;
 	private _entityGraphService: EntityGraphService | null = null;
 	private _entityImportanceService: EntityImportanceService | null = null;
 	private _rebuildTriggerService: RebuildTriggerService | null = null;
@@ -158,6 +161,7 @@ export class DAOFactoryImpl implements DAOFactory {
 		this.userCreditsDAO = new UserCreditsDAO(db);
 		this.fileRetryUsageDAO = new FileRetryUsageDAO(db);
 		this.resourceAddLogDAO = new ResourceAddLogDAO(db);
+		this.runsheetDAO = new RunsheetDAO(db);
 	}
 
 	async getStorageUsage(username: string): Promise<UserStorageUsage> {

--- a/src/dao/runsheet-dao.ts
+++ b/src/dao/runsheet-dao.ts
@@ -1,0 +1,195 @@
+import type {
+	CreateRunsheetInput,
+	RunsheetData,
+	RunsheetRecord,
+	RunsheetSummary,
+	RunsheetWithData,
+	UpdateRunsheetInput,
+} from "@/types/runsheet";
+import { validateRunsheetData } from "@/types/runsheet";
+import type { SqlParam } from "@/types/utils";
+import { BaseDAOClass } from "./base-dao";
+
+const FULL_COLUMNS = `
+      id,
+      campaign_id,
+      session_number,
+      title,
+      runsheet_data,
+      generated_at,
+      created_at,
+      updated_at
+`;
+
+/** Listing never needs the snapshot body, which can be tens of KB per row. */
+const SUMMARY_COLUMNS = `
+      id,
+      campaign_id,
+      session_number,
+      title,
+      generated_at,
+      created_at,
+      updated_at
+`;
+
+export class RunsheetDAO extends BaseDAOClass {
+	async createRunsheet(id: string, input: CreateRunsheetInput): Promise<void> {
+		let runsheetDataJson: string;
+		try {
+			runsheetDataJson = JSON.stringify(input.runsheetData);
+		} catch (error) {
+			throw new Error(
+				`Failed to serialize runsheet data: ${error instanceof Error ? error.message : "Unknown error"}`
+			);
+		}
+
+		const sql = `
+      INSERT INTO campaign_runsheets (
+        id,
+        campaign_id,
+        session_number,
+        title,
+        runsheet_data,
+        generated_at,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `;
+
+		await this.execute(sql, [
+			id,
+			input.campaignId,
+			input.sessionNumber,
+			input.title,
+			runsheetDataJson,
+		]);
+	}
+
+	async getRunsheetById(runsheetId: string): Promise<RunsheetWithData | null> {
+		const sql = `
+      SELECT ${FULL_COLUMNS}
+      FROM campaign_runsheets
+      WHERE id = ?
+    `;
+
+		const record = await this.queryFirst<RunsheetRecord>(sql, [runsheetId]);
+		return record ? this.mapRecord(record) : null;
+	}
+
+	/** Newest session first, then newest snapshot first within a session. */
+	async listRunsheetsByCampaign(
+		campaignId: string,
+		options: { sessionNumber?: number; limit?: number } = {}
+	): Promise<RunsheetSummary[]> {
+		const conditions = ["campaign_id = ?"];
+		const params: SqlParam[] = [campaignId];
+
+		if (typeof options.sessionNumber === "number") {
+			conditions.push("session_number = ?");
+			params.push(options.sessionNumber);
+		}
+
+		let sql = `
+      SELECT ${SUMMARY_COLUMNS}
+      FROM campaign_runsheets
+      WHERE ${conditions.join(" AND ")}
+      ORDER BY session_number DESC, generated_at DESC
+    `;
+
+		if (typeof options.limit === "number") {
+			sql += " LIMIT ?";
+			params.push(options.limit);
+		}
+
+		const records = await this.queryAll<Omit<RunsheetRecord, "runsheet_data">>(
+			sql,
+			params
+		);
+
+		return records.map((record) => ({
+			id: record.id,
+			campaignId: record.campaign_id,
+			sessionNumber: record.session_number,
+			title: record.title,
+			generatedAt: record.generated_at,
+			createdAt: record.created_at,
+			updatedAt: record.updated_at,
+		}));
+	}
+
+	async updateRunsheet(
+		runsheetId: string,
+		input: UpdateRunsheetInput
+	): Promise<void> {
+		const updates: string[] = [];
+		const params: SqlParam[] = [];
+
+		if (input.title !== undefined) {
+			updates.push("title = ?");
+			params.push(input.title);
+		}
+
+		if (input.runsheetData !== undefined) {
+			updates.push("runsheet_data = ?");
+			params.push(JSON.stringify(input.runsheetData));
+		}
+
+		if (updates.length === 0) {
+			return;
+		}
+
+		updates.push("updated_at = CURRENT_TIMESTAMP");
+		params.push(runsheetId);
+
+		const sql = `
+      UPDATE campaign_runsheets
+      SET ${updates.join(", ")}
+      WHERE id = ?
+    `;
+
+		await this.execute(sql, params);
+	}
+
+	async deleteRunsheet(runsheetId: string): Promise<void> {
+		await this.execute("DELETE FROM campaign_runsheets WHERE id = ?", [
+			runsheetId,
+		]);
+	}
+
+	/**
+	 * A runsheet whose stored JSON no longer parses is a corrupt snapshot, not an
+	 * empty one. Surfacing that as an error beats silently handing the GM a blank
+	 * page at the table — unlike a digest, there is no form to re-fill it from.
+	 */
+	private mapRecord(record: RunsheetRecord): RunsheetWithData {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(record.runsheet_data);
+		} catch (error) {
+			throw new Error(
+				`Runsheet ${record.id} has unparseable snapshot data: ${
+					error instanceof Error ? error.message : "Unknown error"
+				}`
+			);
+		}
+
+		if (!validateRunsheetData(parsed)) {
+			throw new Error(
+				`Runsheet ${record.id} has an invalid snapshot structure`
+			);
+		}
+
+		const runsheetData: RunsheetData = parsed;
+
+		return {
+			id: record.id,
+			campaignId: record.campaign_id,
+			sessionNumber: record.session_number,
+			title: record.title,
+			runsheetData,
+			generatedAt: record.generated_at,
+			createdAt: record.created_at,
+			updatedAt: record.updated_at,
+		};
+	}
+}

--- a/src/routes/campaigns/index.ts
+++ b/src/routes/campaigns/index.ts
@@ -7,6 +7,7 @@ import { registerCampaignEntitiesRoutes } from "./entities-routes";
 import { registerCampaignGraphRebuildRoutes } from "./graph-rebuild-routes";
 import { registerCampaignGraphragRoutes } from "./graphrag-routes";
 import { registerCampaignPlanningRoutes } from "./planning-routes";
+import { registerCampaignRunsheetRoutes } from "./runsheet-routes";
 import { registerCampaignSessionDigestsRoutes } from "./session-digests-routes";
 import { registerCampaignShareRoutes } from "./share-routes";
 import { registerCampaignWorldStateRoutes } from "./world-state-routes";
@@ -19,6 +20,7 @@ export function registerCampaignRoutes(
 	registerCampaignShareRoutes(app);
 	registerCampaignWorldStateRoutes(app);
 	registerCampaignSessionDigestsRoutes(app);
+	registerCampaignRunsheetRoutes(app);
 	registerCampaignEntitiesRoutes(app);
 	registerCampaignCommunitiesRoutes(app);
 	registerCampaignGraphragRoutes(app);

--- a/src/routes/campaigns/runsheet-routes.ts
+++ b/src/routes/campaigns/runsheet-routes.ts
@@ -1,0 +1,192 @@
+import type { OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute, z } from "@hono/zod-openapi";
+import type { Handler } from "hono";
+import type { RequestLogger } from "@/lib/logger";
+import { requireUserJwt } from "@/routes/auth";
+import { ENDPOINTS } from "@/routes/endpoints";
+import type { Env } from "@/routes/env";
+import { toApiRoutePath } from "@/routes/env";
+import {
+	handleDeleteRunsheet,
+	handleExportRunsheetHtml,
+	handleGenerateRunsheet,
+	handleGetRunsheet,
+	handleListRunsheets,
+	handleUpdateRunsheet,
+} from "@/routes/runsheets";
+import { CampaignIdParamSchema, ErrorSchema } from "@/routes/schemas/common";
+
+const Error401 = {
+	401: {
+		content: { "application/json": { schema: ErrorSchema } },
+		description: "Unauthorized",
+	},
+} as const;
+const Error403 = {
+	403: {
+		content: { "application/json": { schema: ErrorSchema } },
+		description: "Forbidden",
+	},
+} as const;
+const Error404 = {
+	404: {
+		content: { "application/json": { schema: ErrorSchema } },
+		description: "Not found",
+	},
+} as const;
+const Error500 = {
+	500: {
+		content: { "application/json": { schema: ErrorSchema } },
+		description: "Internal server error",
+	},
+} as const;
+
+const CampaignIdRunsheetIdParams = z
+	.object({
+		campaignId: z
+			.string()
+			.openapi({ param: { name: "campaignId", in: "path" } }),
+		runsheetId: z
+			.string()
+			.openapi({ param: { name: "runsheetId", in: "path" } }),
+	})
+	.openapi("CampaignIdRunsheetIdParams");
+
+const routeGenerateRunsheet = createRoute({
+	method: "post",
+	path: toApiRoutePath(ENDPOINTS.CAMPAIGNS.RUNSHEETS.BASE("{campaignId}")),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	description:
+		"Generate a GM-only session runsheet snapshot assembled from existing campaign data. Requires edit access; never available to player roles.",
+	request: {
+		params: CampaignIdParamSchema,
+		body: {
+			content: { "application/json": { schema: z.any() } },
+		},
+	},
+	responses: {
+		201: { description: "Runsheet generated" },
+		...Error401,
+		...Error403,
+		...Error404,
+		...Error500,
+	},
+});
+
+const routeListRunsheets = createRoute({
+	method: "get",
+	path: toApiRoutePath(ENDPOINTS.CAMPAIGNS.RUNSHEETS.BASE("{campaignId}")),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	description: "List runsheet snapshots for a campaign. GM roles only.",
+	request: { params: CampaignIdParamSchema },
+	responses: {
+		200: { description: "Runsheet list" },
+		...Error401,
+		...Error403,
+		...Error404,
+		...Error500,
+	},
+});
+
+const routeGetRunsheet = createRoute({
+	method: "get",
+	path: toApiRoutePath(
+		ENDPOINTS.CAMPAIGNS.RUNSHEETS.DETAILS("{campaignId}", "{runsheetId}")
+	),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	description:
+		"Get a runsheet snapshot, including its full body. GM roles only.",
+	request: { params: CampaignIdRunsheetIdParams },
+	responses: {
+		200: { description: "Runsheet details" },
+		...Error401,
+		...Error403,
+		...Error404,
+		...Error500,
+	},
+});
+
+const routeUpdateRunsheet = createRoute({
+	method: "put",
+	path: toApiRoutePath(
+		ENDPOINTS.CAMPAIGNS.RUNSHEETS.DETAILS("{campaignId}", "{runsheetId}")
+	),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	description:
+		"Persist hand-edits to a runsheet snapshot. Requires edit access.",
+	request: {
+		params: CampaignIdRunsheetIdParams,
+		body: {
+			content: { "application/json": { schema: z.any() } },
+		},
+	},
+	responses: {
+		200: { description: "Runsheet updated" },
+		...Error401,
+		...Error403,
+		...Error404,
+		...Error500,
+	},
+});
+
+const routeDeleteRunsheet = createRoute({
+	method: "delete",
+	path: toApiRoutePath(
+		ENDPOINTS.CAMPAIGNS.RUNSHEETS.DETAILS("{campaignId}", "{runsheetId}")
+	),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	description: "Delete a runsheet snapshot. Requires edit access.",
+	request: { params: CampaignIdRunsheetIdParams },
+	responses: {
+		200: { description: "Runsheet deleted" },
+		...Error401,
+		...Error403,
+		...Error404,
+		...Error500,
+	},
+});
+
+const routeExportRunsheetHtml = createRoute({
+	method: "get",
+	path: toApiRoutePath(
+		ENDPOINTS.CAMPAIGNS.RUNSHEETS.EXPORT_HTML("{campaignId}", "{runsheetId}")
+	),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	description:
+		"Export a runsheet as a standalone print-friendly HTML document. Print to PDF from the browser. GM roles only.",
+	request: { params: CampaignIdRunsheetIdParams },
+	responses: {
+		200: {
+			content: { "text/html": { schema: z.string() } },
+			description: "Print-friendly runsheet document",
+		},
+		...Error401,
+		...Error403,
+		...Error404,
+		...Error500,
+	},
+});
+
+export function registerCampaignRunsheetRoutes(
+	app: OpenAPIHono<{ Bindings: Env; Variables: { logger: RequestLogger } }>
+) {
+	app.openapi(
+		routeGenerateRunsheet,
+		handleGenerateRunsheet as unknown as Handler
+	);
+	app.openapi(routeListRunsheets, handleListRunsheets as unknown as Handler);
+	// Registered before the :runsheetId route so "export.html" is not swallowed.
+	app.openapi(
+		routeExportRunsheetHtml,
+		handleExportRunsheetHtml as unknown as Handler
+	);
+	app.openapi(routeGetRunsheet, handleGetRunsheet as unknown as Handler);
+	app.openapi(routeUpdateRunsheet, handleUpdateRunsheet as unknown as Handler);
+	app.openapi(routeDeleteRunsheet, handleDeleteRunsheet as unknown as Handler);
+}

--- a/src/routes/endpoints.ts
+++ b/src/routes/endpoints.ts
@@ -131,6 +131,14 @@ export const ENDPOINTS = {
 			DETAILS: (campaignId: string, templateId: string) =>
 				`/campaigns/${campaignId}/session-digest-templates/${templateId}`,
 		},
+		/** GM-only session runsheets. Never exposed through the player share flow. */
+		RUNSHEETS: {
+			BASE: (campaignId: string) => `/campaigns/${campaignId}/runsheets`,
+			DETAILS: (campaignId: string, runsheetId: string) =>
+				`/campaigns/${campaignId}/runsheets/${runsheetId}`,
+			EXPORT_HTML: (campaignId: string, runsheetId: string) =>
+				`/campaigns/${campaignId}/runsheets/${runsheetId}/export.html`,
+		},
 		PLANNING_TASKS: {
 			BASE: (campaignId: string) => `/campaigns/${campaignId}/planning-tasks`,
 			DETAILS: (campaignId: string, taskId: string) =>

--- a/src/routes/runsheets.ts
+++ b/src/routes/runsheets.ts
@@ -1,0 +1,305 @@
+import { generateId } from "ai";
+import { getDAOFactory } from "@/dao/dao-factory";
+import { CampaignAccessDeniedError } from "@/lib/errors";
+import {
+	type ContextWithAuth,
+	ensureCampaignAccess,
+	getUserAuth,
+	requireCanEdit,
+	requireCanSeeSpoilers,
+	requireParam,
+	verifyCampaignAccess,
+} from "@/lib/route-utils";
+import { RunsheetAssemblyService } from "@/services/campaign/runsheet-assembly-service";
+import { RunsheetHtmlService } from "@/services/campaign/runsheet-html-service";
+import type { RunsheetWithData, UpdateRunsheetInput } from "@/types/runsheet";
+import { validateRunsheetData } from "@/types/runsheet";
+
+/**
+ * Session runsheets (issue #742).
+ *
+ * Every handler here gates on `requireCanSeeSpoilers` or `requireCanEdit`, both
+ * of which exclude the player roles. A runsheet is the GM's secrets in one
+ * document, so it must never become reachable through the player-facing share
+ * flow (`src/routes/campaign-share.ts`) — the player-safe equivalent is handouts.
+ */
+
+function defaultRunsheetTitle(sessionNumber: number): string {
+	return `Session ${sessionNumber} runsheet`;
+}
+
+/**
+ * Load a runsheet and confirm it belongs to the campaign in the path.
+ *
+ * Answering 404 (not 403) for a cross-campaign id avoids confirming that the
+ * runsheet exists at all to someone probing ids from a campaign they can read.
+ */
+async function loadRunsheetForCampaign(
+	c: ContextWithAuth,
+	campaignId: string,
+	runsheetId: string
+): Promise<RunsheetWithData | Response> {
+	const daoFactory = getDAOFactory(c.env);
+	const runsheet = await daoFactory.runsheetDAO.getRunsheetById(runsheetId);
+
+	if (!runsheet || runsheet.campaignId !== campaignId) {
+		return c.json({ error: "Runsheet not found" }, 404);
+	}
+
+	return runsheet;
+}
+
+function handleError(
+	c: ContextWithAuth,
+	error: unknown,
+	fallbackMessage: string
+): Response {
+	if (error instanceof CampaignAccessDeniedError) {
+		return c.json({ error: "Access denied" }, 403);
+	}
+	return c.json(
+		{ error: fallbackMessage },
+		error instanceof Error && /required|must/i.test(error.message) ? 400 : 500
+	);
+}
+
+/** Generate a new runsheet snapshot for a session. */
+export async function handleGenerateRunsheet(c: ContextWithAuth) {
+	try {
+		const auth = getUserAuth(c);
+		const campaignId = requireParam(c, "campaignId");
+		if (campaignId instanceof Response) return campaignId;
+
+		const hasAccess = await ensureCampaignAccess(c, campaignId, auth.username);
+		if (!hasAccess) {
+			return c.json({ error: "Campaign not found" }, 404);
+		}
+		await requireCanEdit(c, campaignId);
+
+		const body = (await c.req.json().catch(() => ({}))) as {
+			sessionNumber?: number;
+			title?: string;
+		};
+
+		const daoFactory = getDAOFactory(c.env);
+		const sessionNumber =
+			typeof body.sessionNumber === "number" && body.sessionNumber >= 1
+				? body.sessionNumber
+				: await daoFactory.sessionDigestDAO.getNextSessionNumber(campaignId);
+
+		const runsheetData = await RunsheetAssemblyService.assemble(c.env, {
+			campaignId,
+			sessionNumber,
+		});
+
+		const title = body.title?.trim() || defaultRunsheetTitle(sessionNumber);
+		const runsheetId = generateId();
+
+		await daoFactory.runsheetDAO.createRunsheet(runsheetId, {
+			campaignId,
+			sessionNumber,
+			title,
+			runsheetData,
+		});
+
+		const created = await daoFactory.runsheetDAO.getRunsheetById(runsheetId);
+		if (!created) {
+			return c.json({ error: "Failed to retrieve created runsheet" }, 500);
+		}
+
+		return c.json({ runsheet: created }, 201);
+	} catch (error) {
+		return handleError(c, error, "Failed to generate runsheet");
+	}
+}
+
+/** List runsheet snapshots for a campaign (summaries only). */
+export async function handleListRunsheets(c: ContextWithAuth) {
+	try {
+		const auth = getUserAuth(c);
+		const campaignId = requireParam(c, "campaignId");
+		if (campaignId instanceof Response) return campaignId;
+
+		const hasAccess = await ensureCampaignAccess(c, campaignId, auth.username);
+		if (!hasAccess) {
+			return c.json({ error: "Campaign not found" }, 404);
+		}
+		await requireCanSeeSpoilers(c, campaignId);
+
+		const sessionNumberParam = c.req.query("sessionNumber");
+		const parsedSessionNumber = sessionNumberParam
+			? Number(sessionNumberParam)
+			: undefined;
+
+		const daoFactory = getDAOFactory(c.env);
+		const runsheets = await daoFactory.runsheetDAO.listRunsheetsByCampaign(
+			campaignId,
+			{
+				sessionNumber: Number.isInteger(parsedSessionNumber)
+					? parsedSessionNumber
+					: undefined,
+			}
+		);
+
+		const nextSessionNumber =
+			await daoFactory.sessionDigestDAO.getNextSessionNumber(campaignId);
+
+		return c.json({ runsheets, nextSessionNumber });
+	} catch (error) {
+		return handleError(c, error, "Failed to list runsheets");
+	}
+}
+
+/** Get a single runsheet snapshot, including its full body. */
+export async function handleGetRunsheet(c: ContextWithAuth) {
+	try {
+		const auth = getUserAuth(c);
+		const campaignId = requireParam(c, "campaignId");
+		if (campaignId instanceof Response) return campaignId;
+		const runsheetId = requireParam(c, "runsheetId");
+		if (runsheetId instanceof Response) return runsheetId;
+
+		const hasAccess = await ensureCampaignAccess(c, campaignId, auth.username);
+		if (!hasAccess) {
+			return c.json({ error: "Campaign not found" }, 404);
+		}
+		await requireCanSeeSpoilers(c, campaignId);
+
+		const runsheet = await loadRunsheetForCampaign(c, campaignId, runsheetId);
+		if (runsheet instanceof Response) return runsheet;
+
+		return c.json({ runsheet });
+	} catch (error) {
+		return handleError(c, error, "Failed to get runsheet");
+	}
+}
+
+/**
+ * Update a runsheet's title or body.
+ *
+ * This is how hand-editing is persisted. It never re-assembles: a snapshot the
+ * GM has edited must not be silently overwritten by fresher campaign data.
+ */
+export async function handleUpdateRunsheet(c: ContextWithAuth) {
+	try {
+		const auth = getUserAuth(c);
+		const campaignId = requireParam(c, "campaignId");
+		if (campaignId instanceof Response) return campaignId;
+		const runsheetId = requireParam(c, "runsheetId");
+		if (runsheetId instanceof Response) return runsheetId;
+
+		const hasAccess = await ensureCampaignAccess(c, campaignId, auth.username);
+		if (!hasAccess) {
+			return c.json({ error: "Campaign not found" }, 404);
+		}
+		await requireCanEdit(c, campaignId);
+
+		const existing = await loadRunsheetForCampaign(c, campaignId, runsheetId);
+		if (existing instanceof Response) return existing;
+
+		const body = (await c.req.json()) as {
+			title?: string;
+			runsheetData?: unknown;
+		};
+
+		const updates: UpdateRunsheetInput = {};
+
+		if (body.title !== undefined) {
+			const trimmed = body.title.trim();
+			if (!trimmed) {
+				return c.json({ error: "Title cannot be empty" }, 400);
+			}
+			updates.title = trimmed;
+		}
+
+		if (body.runsheetData !== undefined) {
+			if (!validateRunsheetData(body.runsheetData)) {
+				return c.json({ error: "Invalid runsheetData structure" }, 400);
+			}
+			updates.runsheetData = body.runsheetData;
+		}
+
+		if (Object.keys(updates).length === 0) {
+			return c.json({ error: "No fields to update" }, 400);
+		}
+
+		const daoFactory = getDAOFactory(c.env);
+		await daoFactory.runsheetDAO.updateRunsheet(runsheetId, updates);
+
+		const updated = await daoFactory.runsheetDAO.getRunsheetById(runsheetId);
+		if (!updated) {
+			return c.json({ error: "Failed to retrieve updated runsheet" }, 500);
+		}
+
+		return c.json({ runsheet: updated });
+	} catch (error) {
+		return handleError(c, error, "Failed to update runsheet");
+	}
+}
+
+/** Delete a runsheet snapshot. */
+export async function handleDeleteRunsheet(c: ContextWithAuth) {
+	try {
+		const auth = getUserAuth(c);
+		const campaignId = requireParam(c, "campaignId");
+		if (campaignId instanceof Response) return campaignId;
+		const runsheetId = requireParam(c, "runsheetId");
+		if (runsheetId instanceof Response) return runsheetId;
+
+		const hasAccess = await ensureCampaignAccess(c, campaignId, auth.username);
+		if (!hasAccess) {
+			return c.json({ error: "Campaign not found" }, 404);
+		}
+		await requireCanEdit(c, campaignId);
+
+		const existing = await loadRunsheetForCampaign(c, campaignId, runsheetId);
+		if (existing instanceof Response) return existing;
+
+		const daoFactory = getDAOFactory(c.env);
+		await daoFactory.runsheetDAO.deleteRunsheet(runsheetId);
+
+		return c.json({ success: true });
+	} catch (error) {
+		return handleError(c, error, "Failed to delete runsheet");
+	}
+}
+
+/**
+ * Export a runsheet as a standalone, print-friendly HTML document.
+ *
+ * The response carries no auth in its URL, so the caller must already hold a
+ * bearer token: the client fetches this and opens it as a blob rather than
+ * navigating to it, which means no spoiler-bearing link ever exists to leak.
+ */
+export async function handleExportRunsheetHtml(c: ContextWithAuth) {
+	try {
+		const auth = getUserAuth(c);
+		const campaignId = requireParam(c, "campaignId");
+		if (campaignId instanceof Response) return campaignId;
+		const runsheetId = requireParam(c, "runsheetId");
+		if (runsheetId instanceof Response) return runsheetId;
+
+		const campaign = await verifyCampaignAccess(c, campaignId, auth.username);
+		if (!campaign) {
+			return c.json({ error: "Campaign not found" }, 404);
+		}
+		await requireCanSeeSpoilers(c, campaignId);
+
+		const runsheet = await loadRunsheetForCampaign(c, campaignId, runsheetId);
+		if (runsheet instanceof Response) return runsheet;
+
+		const html = RunsheetHtmlService.render(runsheet, {
+			campaignName: campaign.name,
+		});
+
+		return c.body(html, 200, {
+			"Content-Type": "text/html; charset=utf-8",
+			"X-Content-Type-Options": "nosniff",
+			// GM-only content: never let a proxy or the browser retain it.
+			"Cache-Control": "no-store, private",
+			"X-Robots-Tag": "noindex, nofollow",
+		});
+	} catch (error) {
+		return handleError(c, error, "Failed to export runsheet");
+	}
+}

--- a/src/services/campaign/runsheet-assembly-service.ts
+++ b/src/services/campaign/runsheet-assembly-service.ts
@@ -1,0 +1,536 @@
+import { getDAOFactory } from "@/dao/dao-factory";
+import type { Entity } from "@/dao/entity-dao";
+import {
+	ENTITY_TYPE_HOOKS,
+	ENTITY_TYPE_ITEMS,
+	ENTITY_TYPE_MONSTERS,
+	ENTITY_TYPE_NPCS,
+} from "@/lib/entity/entity-type-constants";
+import { RulesContextService } from "@/services/campaign/rules-context-service";
+import type {
+	RunsheetCastMember,
+	RunsheetData,
+	RunsheetEncounter,
+	RunsheetLootItem,
+	RunsheetPlan,
+	RunsheetPlanItem,
+	RunsheetRecap,
+	RunsheetRule,
+	RunsheetSectionKey,
+	RunsheetThread,
+} from "@/types/runsheet";
+import type { SessionDigestWithData } from "@/types/session-digest";
+
+/**
+ * Entity rows loaded per type when enriching a runsheet. Campaigns rarely exceed
+ * this; the cap exists so one pathological campaign cannot blow the request up.
+ */
+const ENTITY_LOOKUP_LIMIT = 500;
+
+/** Hook entities appended to open threads beyond what the digest already lists. */
+const MAX_GRAPH_HOOKS = 10;
+
+/** Shard states whose entities are not yet (or no longer) part of the campaign. */
+const EXCLUDED_SHARD_STATUSES = ["staging", "rejected", "deleted"];
+
+function asText(value: unknown): string {
+	if (typeof value === "string") return value.trim();
+	if (typeof value === "number") return String(value);
+	if (Array.isArray(value)) {
+		return value
+			.map((item) => asText(item))
+			.filter(Boolean)
+			.join("; ");
+	}
+	return "";
+}
+
+function contentOf(entity: Entity): Record<string, unknown> {
+	if (
+		entity.content &&
+		typeof entity.content === "object" &&
+		!Array.isArray(entity.content)
+	) {
+		return entity.content as Record<string, unknown>;
+	}
+	return {};
+}
+
+/** First non-empty stringified field, in preference order. */
+function firstText(source: Record<string, unknown>, keys: string[]): string {
+	for (const key of keys) {
+		const text = asText(source[key]);
+		if (text) return text;
+	}
+	return "";
+}
+
+function normalizeName(name: string): string {
+	return name.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function dedupeStrings(values: string[]): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const value of values) {
+		const trimmed = value.trim();
+		if (!trimmed) continue;
+		const key = trimmed.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		result.push(trimmed);
+	}
+	return result;
+}
+
+/**
+ * Index entities by normalized name for name-based lookup.
+ *
+ * Digest fields such as `npcs_to_run` and `encounter_seeds` are free text the GM
+ * typed — they carry names, not entity ids. Name matching is therefore the only
+ * available join, and it is intentionally forgiving: an unmatched name still
+ * makes it onto the runsheet, just without the enrichment.
+ */
+function indexByName(entities: Entity[]): Map<string, Entity> {
+	const index = new Map<string, Entity>();
+	for (const entity of entities) {
+		const key = normalizeName(entity.name ?? "");
+		if (!key || index.has(key)) continue;
+		index.set(key, entity);
+	}
+	return index;
+}
+
+/** Exact name match, else the longest indexed name contained in the text. */
+function findEntityForText(
+	text: string,
+	index: Map<string, Entity>
+): Entity | null {
+	const normalized = normalizeName(text);
+	if (!normalized) return null;
+
+	const exact = index.get(normalized);
+	if (exact) return exact;
+
+	let best: Entity | null = null;
+	let bestLength = 0;
+	for (const [name, entity] of index) {
+		// Short names ("Rat") match too much free text to be worth guessing on.
+		if (name.length < 4 || name.length <= bestLength) continue;
+		if (normalized.includes(name)) {
+			best = entity;
+			bestLength = name.length;
+		}
+	}
+	return best;
+}
+
+/**
+ * Condense an NPC into the one line a GM can read mid-sentence: what they want,
+ * then how they sound, then whatever summary exists.
+ */
+function buildCastHook(entity: Entity | null): string {
+	if (!entity) return "";
+	const content = contentOf(entity);
+	const parts = [
+		firstText(content, ["goals", "motivation"]),
+		firstText(content, ["quirks", "voice", "mannerisms"]),
+	].filter(Boolean);
+
+	if (parts.length > 0) return parts.join(" — ");
+	return firstText(content, ["summary", "one_line", "description"]);
+}
+
+/** At-a-glance statblock numbers, in the order a GM reads them at the table. */
+function buildStatblock(entity: Entity | null): Record<string, string> {
+	if (!entity) return {};
+	const content = contentOf(entity);
+	const statblock: Record<string, string> = {};
+
+	const fields: Array<[string, string[]]> = [
+		["CR", ["cr", "challenge_rating"]],
+		["AC", ["ac", "armor_class"]],
+		["HP", ["hp", "hit_points"]],
+		["Speed", ["speed"]],
+	];
+
+	for (const [label, keys] of fields) {
+		const value = firstText(content, keys);
+		if (value) statblock[label] = value;
+	}
+
+	return statblock;
+}
+
+function buildRecap(
+	digest: SessionDigestWithData | null
+): [RunsheetRecap, boolean] {
+	if (!digest) {
+		return [
+			{
+				fromSessionNumber: null,
+				keyEvents: [],
+				stateChanges: { factions: [], locations: [], npcs: [] },
+				source: null,
+			},
+			true,
+		];
+	}
+
+	const recapData = digest.digestData.last_session_recap;
+	const recap: RunsheetRecap = {
+		fromSessionNumber: digest.sessionNumber,
+		keyEvents: dedupeStrings(recapData.key_events),
+		stateChanges: {
+			factions: dedupeStrings(recapData.state_changes.factions),
+			locations: dedupeStrings(recapData.state_changes.locations),
+			npcs: dedupeStrings(recapData.state_changes.npcs),
+		},
+		source: {
+			kind: "session_digest",
+			id: digest.id,
+			label: `Session ${digest.sessionNumber} digest`,
+		},
+	};
+
+	const isEmpty =
+		recap.keyEvents.length === 0 &&
+		recap.stateChanges.factions.length === 0 &&
+		recap.stateChanges.locations.length === 0 &&
+		recap.stateChanges.npcs.length === 0;
+
+	return [recap, isEmpty];
+}
+
+export interface AssembleRunsheetOptions {
+	campaignId: string;
+	/** The upcoming session this runsheet is for. */
+	sessionNumber: number;
+}
+
+/**
+ * Assembles a session runsheet from content that already exists: the previous
+ * session's digest, planning tasks scoped to this session, the entity graph, and
+ * the campaign's active house rules.
+ *
+ * This makes no LLM calls by design (issue #742): every input has already been
+ * generated and paid for, so the runsheet costs one round of D1 reads.
+ */
+export class RunsheetAssemblyService {
+	/**
+	 * The digest that describes the run-up to `sessionNumber`: the highest-numbered
+	 * digest below it. A digest for session N holds both the recap OF session N and
+	 * the plan FOR session N+1, so a single digest feeds both runsheet sections.
+	 *
+	 * Rejected digests are skipped — a GM who rejected a digest does not want it
+	 * reappearing as their session plan.
+	 */
+	static selectSourceDigest(
+		digests: SessionDigestWithData[],
+		sessionNumber: number
+	): SessionDigestWithData | null {
+		const candidates = digests
+			.filter((d) => d.status !== "rejected")
+			.filter((d) => d.sessionNumber < sessionNumber)
+			.sort((a, b) => b.sessionNumber - a.sessionNumber);
+
+		return candidates[0] ?? null;
+	}
+
+	static async assemble(
+		env: unknown,
+		options: AssembleRunsheetOptions
+	): Promise<RunsheetData> {
+		const { campaignId, sessionNumber } = options;
+		const daoFactory = getDAOFactory(env);
+		const entityDAO = daoFactory.entityDAO;
+
+		const [
+			digests,
+			openTasks,
+			npcEntities,
+			monsterEntities,
+			itemEntities,
+			hookEntities,
+			rules,
+		] = await Promise.all([
+			daoFactory.sessionDigestDAO.getSessionDigestsByCampaign(campaignId),
+			daoFactory.planningTaskDAO.listByCampaign(campaignId, {
+				status: ["pending", "in_progress"],
+				targetSessionNumber: sessionNumber,
+			}),
+			entityDAO.listEntitiesByCampaign(campaignId, {
+				entityType: ENTITY_TYPE_NPCS,
+				excludeShardStatuses: EXCLUDED_SHARD_STATUSES,
+				limit: ENTITY_LOOKUP_LIMIT,
+				orderBy: "name",
+			}),
+			entityDAO.listEntitiesByCampaign(campaignId, {
+				entityType: ENTITY_TYPE_MONSTERS,
+				excludeShardStatuses: EXCLUDED_SHARD_STATUSES,
+				limit: ENTITY_LOOKUP_LIMIT,
+				orderBy: "name",
+			}),
+			entityDAO.listEntitiesByCampaign(campaignId, {
+				entityType: ENTITY_TYPE_ITEMS,
+				excludeShardStatuses: EXCLUDED_SHARD_STATUSES,
+				limit: ENTITY_LOOKUP_LIMIT,
+				orderBy: "name",
+			}),
+			entityDAO.listEntitiesByCampaign(campaignId, {
+				entityType: ENTITY_TYPE_HOOKS,
+				excludeShardStatuses: EXCLUDED_SHARD_STATUSES,
+				limit: MAX_GRAPH_HOOKS,
+				orderBy: "updated_at",
+			}),
+			RulesContextService.getActiveRulesForCampaign(env, campaignId),
+		]);
+
+		const digest = RunsheetAssemblyService.selectSourceDigest(
+			digests,
+			sessionNumber
+		);
+
+		const [recap, recapIsEmpty] = buildRecap(digest);
+		const plan = RunsheetAssemblyService.buildPlan(digest, openTasks);
+		const cast = RunsheetAssemblyService.buildCast(digest, npcEntities);
+		const encounters = RunsheetAssemblyService.buildEncounters(
+			digest,
+			monsterEntities
+		);
+		const loot = RunsheetAssemblyService.buildLoot(digest, itemEntities);
+		const houseRules = RunsheetAssemblyService.buildRules(rules);
+		const openThreads = RunsheetAssemblyService.buildOpenThreads(
+			digest,
+			hookEntities
+		);
+
+		const emptySections: RunsheetSectionKey[] = [];
+		if (recapIsEmpty) emptySections.push("recap");
+		if (
+			plan.objectives.length === 0 &&
+			plan.beats.length === 0 &&
+			plan.openTasks.length === 0 &&
+			plan.probablePlayerGoals.length === 0 &&
+			plan.ifThenBranches.length === 0 &&
+			plan.todoChecklist.length === 0
+		) {
+			emptySections.push("plan");
+		}
+		if (cast.length === 0) emptySections.push("cast");
+		if (encounters.length === 0) emptySections.push("encounters");
+		if (loot.length === 0) emptySections.push("loot");
+		if (houseRules.length === 0) emptySections.push("rules");
+		if (openThreads.length === 0) emptySections.push("openThreads");
+
+		return {
+			recap,
+			plan,
+			cast,
+			encounters,
+			loot,
+			rules: houseRules,
+			openThreads,
+			notes: "",
+			emptySections,
+		};
+	}
+
+	static buildPlan(
+		digest: SessionDigestWithData | null,
+		tasks: Array<{
+			id: string;
+			title: string;
+			description: string | null;
+		}>
+	): RunsheetPlan {
+		const planData = digest?.digestData.next_session_plan;
+
+		const openTasks: RunsheetPlanItem[] = tasks.map((task) => ({
+			title: task.title,
+			detail: task.description,
+			source: {
+				kind: "planning_task",
+				id: task.id,
+				label: "Planning task",
+			},
+		}));
+
+		return {
+			objectives: dedupeStrings(planData?.objectives_dm ?? []),
+			probablePlayerGoals: dedupeStrings(planData?.probable_player_goals ?? []),
+			beats: dedupeStrings(planData?.beats ?? []),
+			ifThenBranches: dedupeStrings(planData?.if_then_branches ?? []),
+			openTasks,
+			todoChecklist: dedupeStrings(digest?.digestData.todo_checklist ?? []),
+			source: digest
+				? {
+						kind: "session_digest",
+						id: digest.id,
+						label: `Session ${digest.sessionNumber} digest`,
+					}
+				: null,
+		};
+	}
+
+	static buildCast(
+		digest: SessionDigestWithData | null,
+		npcEntities: Entity[]
+	): RunsheetCastMember[] {
+		const names = dedupeStrings(digest?.digestData.npcs_to_run ?? []);
+		if (names.length === 0) return [];
+
+		const index = indexByName(npcEntities);
+
+		return names.map((name) => {
+			const entity = findEntityForText(name, index);
+			const content = entity ? contentOf(entity) : {};
+
+			return {
+				name: entity?.name ?? name,
+				hook: buildCastHook(entity),
+				role: firstText(content, ["role", "occupation"]) || null,
+				secrets: firstText(content, ["secrets"]) || null,
+				source: entity
+					? { kind: "entity", id: entity.id, label: "Entity graph" }
+					: {
+							kind: "session_digest",
+							id: digest?.id ?? null,
+							label: "Session digest",
+						},
+			};
+		});
+	}
+
+	static buildEncounters(
+		digest: SessionDigestWithData | null,
+		monsterEntities: Entity[]
+	): RunsheetEncounter[] {
+		const seeds = dedupeStrings(digest?.digestData.encounter_seeds ?? []);
+		if (seeds.length === 0) return [];
+
+		const index = indexByName(monsterEntities);
+
+		return seeds.map((seed) => {
+			const entity = findEntityForText(seed, index);
+			const content = entity ? contentOf(entity) : {};
+			const monsterSummary = firstText(content, ["summary", "one_line"]);
+
+			return {
+				// The seed is the GM's own phrasing of the encounter; keep it as the
+				// heading and let the matched statblock enrich rather than replace it.
+				name: seed,
+				summary: monsterSummary,
+				statblock: buildStatblock(entity),
+				source: entity
+					? {
+							kind: "entity",
+							id: entity.id,
+							label: `Statblock: ${entity.name}`,
+						}
+					: {
+							kind: "session_digest",
+							id: digest?.id ?? null,
+							label: "Encounter seed",
+						},
+			};
+		});
+	}
+
+	static buildLoot(
+		digest: SessionDigestWithData | null,
+		itemEntities: Entity[]
+	): RunsheetLootItem[] {
+		const rewards = dedupeStrings(
+			digest?.digestData.treasure_and_rewards ?? []
+		);
+		if (rewards.length === 0) return [];
+
+		const index = indexByName(itemEntities);
+
+		return rewards.map((reward) => {
+			const entity = findEntityForText(reward, index);
+			const content = entity ? contentOf(entity) : {};
+			const rarity = firstText(content, ["rarity"]);
+			const text = firstText(content, ["text", "summary", "description"]);
+			const detail = [rarity ? `(${rarity})` : "", text]
+				.filter(Boolean)
+				.join(" ")
+				.trim();
+
+			return {
+				name: reward,
+				detail,
+				source: entity
+					? { kind: "entity", id: entity.id, label: `Item: ${entity.name}` }
+					: {
+							kind: "session_digest",
+							id: digest?.id ?? null,
+							label: "Prepared reward",
+						},
+			};
+		});
+	}
+
+	/**
+	 * Only house rules make the runsheet. Core-book rules are what the GM already
+	 * owns a book for; the ones worth a line at the table are the table's own.
+	 */
+	static buildRules(
+		rules: Array<{
+			id: string;
+			name: string;
+			category: string;
+			text: string;
+			source: string;
+			active: boolean;
+		}>
+	): RunsheetRule[] {
+		return rules
+			.filter((rule) => rule.source === "house" && rule.active)
+			.map((rule) => ({
+				name: rule.name,
+				category: rule.category,
+				text: rule.text,
+				source: { kind: "house_rule", id: rule.id, label: "House rule" },
+			}));
+	}
+
+	static buildOpenThreads(
+		digest: SessionDigestWithData | null,
+		hookEntities: Entity[]
+	): RunsheetThread[] {
+		const threads: RunsheetThread[] = [];
+		const seen = new Set<string>();
+
+		for (const text of dedupeStrings(
+			digest?.digestData.last_session_recap.open_threads ?? []
+		)) {
+			seen.add(text.toLowerCase());
+			threads.push({
+				text,
+				source: {
+					kind: "session_digest",
+					id: digest?.id ?? null,
+					label: digest ? `Session ${digest.sessionNumber} digest` : null,
+				},
+			});
+		}
+
+		for (const entity of hookEntities) {
+			const text = firstText(contentOf(entity), ["text", "summary"]);
+			if (!text || seen.has(text.toLowerCase())) continue;
+			seen.add(text.toLowerCase());
+			threads.push({
+				text,
+				source: {
+					kind: "entity",
+					id: entity.id,
+					label: entity.name ? `Hook: ${entity.name}` : "Hook",
+				},
+			});
+		}
+
+		return threads;
+	}
+}

--- a/src/services/campaign/runsheet-html-service.ts
+++ b/src/services/campaign/runsheet-html-service.ts
@@ -1,0 +1,358 @@
+import type {
+	RunsheetCastMember,
+	RunsheetData,
+	RunsheetEncounter,
+	RunsheetLootItem,
+	RunsheetRule,
+	RunsheetThread,
+	RunsheetWithData,
+} from "@/types/runsheet";
+
+/**
+ * Escape every value interpolated into the exported document.
+ *
+ * Runsheet content is entirely user-authored (digest prose, entity names, GM
+ * notes), so this is the single chokepoint all interpolation goes through.
+ */
+export function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+/**
+ * Print stylesheet. Inlined deliberately: a runsheet that needs a CDN at the
+ * table defeats the point of printing it (issue #742 — "no battery, no wifi").
+ */
+const RUNSHEET_STYLES = `
+:root { color-scheme: light; }
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  padding: 2rem 1.5rem 4rem;
+  background: #fff;
+  color: #111;
+  font-family: Georgia, "Iowan Old Style", "Times New Roman", serif;
+  font-size: 11.5pt;
+  line-height: 1.45;
+  max-width: 46rem;
+  margin-inline: auto;
+}
+header.runsheet-header { border-bottom: 3px double #111; padding-bottom: 0.75rem; margin-bottom: 1.5rem; }
+h1 { font-size: 1.6rem; margin: 0 0 0.25rem; letter-spacing: 0.01em; }
+.runsheet-campaign { font-size: 0.95rem; color: #444; margin: 0; }
+.runsheet-meta { font-size: 0.8rem; color: #555; margin: 0.4rem 0 0; }
+.spoiler-warning {
+  margin: 0.75rem 0 0;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #111;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+section.runsheet-section { break-inside: avoid; page-break-inside: avoid; margin-bottom: 1.5rem; }
+h2 {
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  border-bottom: 1px solid #999;
+  padding-bottom: 0.2rem;
+  margin: 0 0 0.6rem;
+}
+h3 { font-size: 0.95rem; margin: 0.9rem 0 0.3rem; }
+h3:first-child { margin-top: 0; }
+ul, ol { margin: 0.3rem 0 0.6rem; padding-left: 1.25rem; }
+li { margin-bottom: 0.2rem; }
+ul.checklist { list-style: none; padding-left: 0.2rem; }
+ul.checklist li::before { content: "\\2610"; margin-right: 0.5rem; }
+p { margin: 0.3rem 0; }
+.entry { margin-bottom: 0.7rem; break-inside: avoid; page-break-inside: avoid; }
+.entry-name { font-weight: 700; }
+.entry-detail { display: block; }
+.muted { color: #555; }
+.small { font-size: 0.82rem; }
+.statblock {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+  border: 1px solid #bbb;
+  padding: 0.15rem 0.4rem;
+  display: inline-block;
+  margin-top: 0.15rem;
+}
+.statblock span + span::before { content: " \\00b7 "; color: #888; }
+.rule-category {
+  display: block;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #555;
+}
+.empty-note { font-style: italic; color: #666; font-size: 0.85rem; }
+.notes-area { border: 1px solid #bbb; min-height: 7rem; padding: 0.5rem; white-space: pre-wrap; }
+footer.runsheet-footer { border-top: 1px solid #ccc; margin-top: 2rem; padding-top: 0.5rem; font-size: 0.72rem; color: #666; }
+
+@media print {
+  @page { margin: 1.6cm; }
+  body { padding: 0; max-width: none; font-size: 10.5pt; }
+  .no-print { display: none !important; }
+  a { text-decoration: none; color: inherit; }
+}
+`;
+
+function renderList(items: string[], className = ""): string {
+	if (items.length === 0) return "";
+	const attr = className ? ` class="${className}"` : "";
+	const entries = items
+		.map((item) => `<li>${escapeHtml(item)}</li>`)
+		.join("\n      ");
+	return `<ul${attr}>\n      ${entries}\n    </ul>`;
+}
+
+function renderSubsection(title: string, items: string[]): string {
+	if (items.length === 0) return "";
+	return `<h3>${escapeHtml(title)}</h3>\n    ${renderList(items)}`;
+}
+
+function emptyNote(message: string): string {
+	return `<p class="empty-note">${escapeHtml(message)}</p>`;
+}
+
+function renderRecap(data: RunsheetData): string {
+	const { recap } = data;
+	const heading =
+		recap.fromSessionNumber != null
+			? `Recap — where we left off (session ${recap.fromSessionNumber})`
+			: "Recap — where we left off";
+
+	const body = [
+		renderSubsection("Key events", recap.keyEvents),
+		renderSubsection("Factions changed", recap.stateChanges.factions),
+		renderSubsection("Locations changed", recap.stateChanges.locations),
+		renderSubsection("NPCs changed", recap.stateChanges.npcs),
+	]
+		.filter(Boolean)
+		.join("\n    ");
+
+	return `<section class="runsheet-section">
+    <h2>${escapeHtml(heading)}</h2>
+    ${body || emptyNote("No recap recorded. Add a session digest for the previous session.")}
+  </section>`;
+}
+
+function renderPlan(data: RunsheetData): string {
+	const { plan } = data;
+
+	const taskItems = plan.openTasks.map((task) =>
+		task.detail ? `${task.title} — ${task.detail}` : task.title
+	);
+
+	const body = [
+		renderSubsection("Beats", plan.beats),
+		renderSubsection("Your objectives", plan.objectives),
+		renderSubsection("Probable player goals", plan.probablePlayerGoals),
+		renderSubsection("If / then", plan.ifThenBranches),
+		taskItems.length > 0
+			? `<h3>Open prep</h3>\n    ${renderList(taskItems, "checklist")}`
+			: "",
+		plan.todoChecklist.length > 0
+			? `<h3>Checklist</h3>\n    ${renderList(plan.todoChecklist, "checklist")}`
+			: "",
+	]
+		.filter(Boolean)
+		.join("\n    ");
+
+	return `<section class="runsheet-section">
+    <h2>This session's plan</h2>
+    ${body || emptyNote("No plan recorded. Add beats to the previous session's digest, or planning tasks for this session.")}
+  </section>`;
+}
+
+function renderCast(cast: RunsheetCastMember[]): string {
+	const body =
+		cast.length === 0
+			? emptyNote("No NPCs listed for this session.")
+			: cast
+					.map((member) => {
+						const roleSuffix = member.role
+							? ` <span class="muted small">(${escapeHtml(member.role)})</span>`
+							: "";
+						const hook = member.hook
+							? `<span class="entry-detail">${escapeHtml(member.hook)}</span>`
+							: "";
+						const secrets = member.secrets
+							? `<span class="entry-detail small muted">Secret: ${escapeHtml(member.secrets)}</span>`
+							: "";
+						return `<div class="entry">
+      <span class="entry-name">${escapeHtml(member.name)}</span>${roleSuffix}
+      ${hook}
+      ${secrets}
+    </div>`;
+					})
+					.join("\n    ");
+
+	return `<section class="runsheet-section">
+    <h2>Cast</h2>
+    ${body}
+  </section>`;
+}
+
+function renderStatblock(statblock: Record<string, string>): string {
+	const entries = Object.entries(statblock);
+	if (entries.length === 0) return "";
+	const spans = entries
+		.map(
+			([label, value]) =>
+				`<span>${escapeHtml(label)} ${escapeHtml(value)}</span>`
+		)
+		.join("");
+	return `<span class="entry-detail"><span class="statblock">${spans}</span></span>`;
+}
+
+function renderEncounters(encounters: RunsheetEncounter[]): string {
+	const body =
+		encounters.length === 0
+			? emptyNote("No encounters prepared for this session.")
+			: encounters
+					.map((encounter) => {
+						const summary = encounter.summary
+							? `<span class="entry-detail">${escapeHtml(encounter.summary)}</span>`
+							: "";
+						return `<div class="entry">
+      <span class="entry-name">${escapeHtml(encounter.name)}</span>
+      ${summary}
+      ${renderStatblock(encounter.statblock)}
+    </div>`;
+					})
+					.join("\n    ");
+
+	return `<section class="runsheet-section">
+    <h2>Encounters</h2>
+    ${body}
+  </section>`;
+}
+
+function renderLoot(loot: RunsheetLootItem[]): string {
+	const body =
+		loot.length === 0
+			? emptyNote("No rewards prepared for this session.")
+			: loot
+					.map((item) => {
+						const detail = item.detail
+							? `<span class="entry-detail small">${escapeHtml(item.detail)}</span>`
+							: "";
+						return `<div class="entry">
+      <span class="entry-name">${escapeHtml(item.name)}</span>
+      ${detail}
+    </div>`;
+					})
+					.join("\n    ");
+
+	return `<section class="runsheet-section">
+    <h2>Loot</h2>
+    ${body}
+  </section>`;
+}
+
+function renderRules(rules: RunsheetRule[]): string {
+	const body =
+		rules.length === 0
+			? emptyNote("No active house rules recorded for this campaign.")
+			: rules
+					.map(
+						(rule) => `<div class="entry">
+      <span class="entry-name">${escapeHtml(rule.name)}</span>
+      <span class="rule-category">${escapeHtml(rule.category)}</span>
+      <span class="entry-detail">${escapeHtml(rule.text)}</span>
+    </div>`
+					)
+					.join("\n    ");
+
+	return `<section class="runsheet-section">
+    <h2>Rules to remember</h2>
+    ${body}
+  </section>`;
+}
+
+function renderOpenThreads(threads: RunsheetThread[]): string {
+	const body =
+		threads.length === 0
+			? emptyNote("No open threads recorded.")
+			: renderList(threads.map((thread) => thread.text));
+
+	return `<section class="runsheet-section">
+    <h2>Open threads</h2>
+    ${body}
+  </section>`;
+}
+
+function renderNotes(notes: string): string {
+	return `<section class="runsheet-section">
+    <h2>Notes</h2>
+    <div class="notes-area">${escapeHtml(notes)}</div>
+  </section>`;
+}
+
+export interface RenderRunsheetOptions {
+	/** Campaign display name, shown above the runsheet title. */
+	campaignName: string;
+}
+
+/**
+ * Render a runsheet as a standalone, print-friendly HTML document.
+ *
+ * PDF export is deliberately the browser's own "Print → Save as PDF": Workers
+ * have no headless browser binding, and a print stylesheet gets the GM the same
+ * artifact without shipping a PDF engine into the request path.
+ */
+export class RunsheetHtmlService {
+	static render(
+		runsheet: RunsheetWithData,
+		options: RenderRunsheetOptions
+	): string {
+		const { runsheetData: data } = runsheet;
+		const title = `${options.campaignName} — ${runsheet.title}`;
+
+		const sections = [
+			renderRecap(data),
+			renderPlan(data),
+			renderCast(data.cast),
+			renderEncounters(data.encounters),
+			renderLoot(data.loot),
+			renderRules(data.rules),
+			renderOpenThreads(data.openThreads),
+			renderNotes(data.notes),
+		].join("\n  ");
+
+		return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <title>${escapeHtml(title)}</title>
+  <style>${RUNSHEET_STYLES}</style>
+</head>
+<body>
+  <header class="runsheet-header">
+    <p class="runsheet-campaign">${escapeHtml(options.campaignName)}</p>
+    <h1>${escapeHtml(runsheet.title)}</h1>
+    <p class="runsheet-meta">Snapshot generated ${escapeHtml(runsheet.generatedAt)}</p>
+    <p class="spoiler-warning">GM only — contains spoilers. Do not share with players.</p>
+  </header>
+  ${sections}
+  <footer class="runsheet-footer">
+    Generated by LoreSmith from your campaign's session digest, planning tasks, entity graph, and house rules.
+  </footer>
+</body>
+</html>`;
+	}
+}

--- a/src/types/runsheet.ts
+++ b/src/types/runsheet.ts
@@ -1,0 +1,240 @@
+/**
+ * Session runsheet: a single GM-facing page assembled from content that already
+ * exists elsewhere in the campaign (session digests, planning tasks, the entity
+ * graph, house rules). See issue #742.
+ *
+ * A runsheet is a SNAPSHOT. It is assembled once, frozen, and then hand-editable.
+ * It is never a live view — the plan must not shift under the GM mid-session.
+ *
+ * Runsheets are full of secrets and are GM-only. They must never be reachable
+ * through the player-facing share flow (`src/routes/campaign-share.ts`); the
+ * player-safe equivalent is handouts.
+ */
+
+/** Where a piece of runsheet content came from, so the GM can go fix it at the source. */
+export type RunsheetSourceKind =
+	| "session_digest"
+	| "planning_task"
+	| "entity"
+	| "house_rule"
+	| "manual";
+
+export interface RunsheetSourceRef {
+	kind: RunsheetSourceKind;
+	/** Id of the originating record, when it has one. */
+	id?: string | null;
+	/** Human-readable origin, e.g. "Session 4 digest". */
+	label?: string | null;
+}
+
+/** "Where we left off", taken from the most recent prior session digest. */
+export interface RunsheetRecap {
+	/** Session the recap describes (the one before this runsheet's session). */
+	fromSessionNumber: number | null;
+	keyEvents: string[];
+	stateChanges: {
+		factions: string[];
+		locations: string[];
+		npcs: string[];
+	};
+	source: RunsheetSourceRef | null;
+}
+
+/** A single prep item the GM still needs to do, or a beat to hit. */
+export interface RunsheetPlanItem {
+	title: string;
+	detail?: string | null;
+	source: RunsheetSourceRef;
+}
+
+/** This session's plan: beats from the digest plus planning tasks scoped to it. */
+export interface RunsheetPlan {
+	objectives: string[];
+	probablePlayerGoals: string[];
+	beats: string[];
+	ifThenBranches: string[];
+	/** Open planning tasks targeting this session (issue #699 scopes these). */
+	openTasks: RunsheetPlanItem[];
+	/** Unfinished prep from the digest's own checklist. */
+	todoChecklist: string[];
+	source: RunsheetSourceRef | null;
+}
+
+/** An NPC likely to appear, with a one-line voice/motivation hook. */
+export interface RunsheetCastMember {
+	name: string;
+	/** One-line hook: what they want / how they sound. Empty when unknown. */
+	hook: string;
+	role?: string | null;
+	/** GM-only. Never rendered on any player-facing surface. */
+	secrets?: string | null;
+	source: RunsheetSourceRef;
+}
+
+/** An encounter seed, enriched with a statblock summary when the monster is known. */
+export interface RunsheetEncounter {
+	name: string;
+	summary: string;
+	/** Statblock at-a-glance, e.g. { CR: "5", AC: "17", HP: "94" }. */
+	statblock: Record<string, string>;
+	source: RunsheetSourceRef;
+}
+
+/** A prepared reward, enriched from the item entity when one matches. */
+export interface RunsheetLootItem {
+	name: string;
+	detail: string;
+	source: RunsheetSourceRef;
+}
+
+/** An active house rule for this campaign. */
+export interface RunsheetRule {
+	name: string;
+	category: string;
+	text: string;
+	source: RunsheetSourceRef;
+}
+
+/** An unresolved hook or thread carried into this session. */
+export interface RunsheetThread {
+	text: string;
+	source: RunsheetSourceRef;
+}
+
+/** The frozen snapshot persisted in `campaign_runsheets.runsheet_data`. */
+export interface RunsheetData {
+	recap: RunsheetRecap;
+	plan: RunsheetPlan;
+	cast: RunsheetCastMember[];
+	encounters: RunsheetEncounter[];
+	loot: RunsheetLootItem[];
+	rules: RunsheetRule[];
+	openThreads: RunsheetThread[];
+	/** Freeform GM notes. Always empty on generation; filled in by hand-editing. */
+	notes: string;
+	/**
+	 * Sections that had no content at assembly time, so the UI can explain the
+	 * gap ("no house rules recorded") instead of silently omitting the section.
+	 */
+	emptySections: RunsheetSectionKey[];
+}
+
+export const RUNSHEET_SECTION_KEYS = [
+	"recap",
+	"plan",
+	"cast",
+	"encounters",
+	"loot",
+	"rules",
+	"openThreads",
+] as const;
+
+export type RunsheetSectionKey = (typeof RUNSHEET_SECTION_KEYS)[number];
+
+/** Database row shape for `campaign_runsheets`. */
+export interface RunsheetRecord {
+	id: string;
+	campaign_id: string;
+	session_number: number;
+	title: string;
+	runsheet_data: string;
+	generated_at: string;
+	created_at: string;
+	updated_at: string;
+}
+
+/** Runsheet with `runsheet_data` parsed, as exposed to the rest of the app. */
+export interface RunsheetWithData {
+	id: string;
+	campaignId: string;
+	sessionNumber: number;
+	title: string;
+	runsheetData: RunsheetData;
+	generatedAt: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+/** Summary row for list views — omits the (large) snapshot body. */
+export interface RunsheetSummary {
+	id: string;
+	campaignId: string;
+	sessionNumber: number;
+	title: string;
+	generatedAt: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface CreateRunsheetInput {
+	campaignId: string;
+	sessionNumber: number;
+	title: string;
+	runsheetData: RunsheetData;
+}
+
+export interface UpdateRunsheetInput {
+	title?: string;
+	runsheetData?: RunsheetData;
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Every key on the given object must hold an array of strings. */
+function hasStringArrays(
+	source: Record<string, unknown>,
+	keys: string[]
+): boolean {
+	return keys.every((key) => isStringArray(source[key]));
+}
+
+/** Every key on the given object must hold an array (entries unchecked). */
+function hasArrays(source: Record<string, unknown>, keys: string[]): boolean {
+	return keys.every((key) => Array.isArray(source[key]));
+}
+
+function isValidRecap(value: unknown): boolean {
+	if (!isObject(value)) return false;
+	if (!isStringArray(value.keyEvents)) return false;
+	if (!isObject(value.stateChanges)) return false;
+	return hasStringArrays(value.stateChanges, ["factions", "locations", "npcs"]);
+}
+
+function isValidPlan(value: unknown): boolean {
+	if (!isObject(value)) return false;
+	const listFields = [
+		"objectives",
+		"probablePlayerGoals",
+		"beats",
+		"ifThenBranches",
+		"todoChecklist",
+	];
+	return hasStringArrays(value, listFields) && Array.isArray(value.openTasks);
+}
+
+/**
+ * Structural validation for a hand-edited runsheet body.
+ *
+ * Deliberately shallow on the list entries: the GM is allowed to edit prose
+ * freely, so we check the shape of the document rather than the wording inside
+ * it. Anything that would break rendering (a missing section, a section of the
+ * wrong type) is rejected.
+ */
+export function validateRunsheetData(data: unknown): data is RunsheetData {
+	if (!isObject(data)) return false;
+	if (!isValidRecap(data.recap)) return false;
+	if (!isValidPlan(data.plan)) return false;
+	if (
+		!hasArrays(data, ["cast", "encounters", "loot", "rules", "openThreads"])
+	) {
+		return false;
+	}
+	if (typeof data.notes !== "string") return false;
+	return isStringArray(data.emptySections);
+}

--- a/tests/dao/runsheet-dao.test.ts
+++ b/tests/dao/runsheet-dao.test.ts
@@ -1,0 +1,195 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { beforeEach, describe, expect, it, type vi } from "vitest";
+import { RunsheetDAO } from "@/dao/runsheet-dao";
+import type { RunsheetData } from "@/types/runsheet";
+import { createMockD1, createMockStmt } from "./helpers";
+
+const validRunsheetData: RunsheetData = {
+	recap: {
+		fromSessionNumber: 2,
+		keyEvents: ["The bridge fell"],
+		stateChanges: { factions: [], locations: [], npcs: [] },
+		source: null,
+	},
+	plan: {
+		objectives: [],
+		probablePlayerGoals: [],
+		beats: ["Open in the ruined chapel"],
+		ifThenBranches: [],
+		openTasks: [],
+		todoChecklist: [],
+		source: null,
+	},
+	cast: [],
+	encounters: [],
+	loot: [],
+	rules: [],
+	openThreads: [],
+	notes: "",
+	emptySections: ["cast", "encounters", "loot", "rules", "openThreads"],
+};
+
+function runsheetRow(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "runsheet-1",
+		campaign_id: "campaign-1",
+		session_number: 3,
+		title: "Session 3 runsheet",
+		runsheet_data: JSON.stringify(validRunsheetData),
+		generated_at: "2026-07-01 12:00:00",
+		created_at: "2026-07-01 12:00:00",
+		updated_at: "2026-07-01 12:00:00",
+		...overrides,
+	};
+}
+
+describe("RunsheetDAO", () => {
+	let dao: RunsheetDAO;
+	let mockDB: D1Database;
+	let mockStmt: ReturnType<typeof createMockStmt>;
+
+	beforeEach(() => {
+		mockStmt = createMockStmt();
+		mockDB = createMockD1(mockStmt);
+		dao = new RunsheetDAO(mockDB);
+	});
+
+	describe("createRunsheet", () => {
+		it("inserts the runsheet with serialized snapshot data", async () => {
+			expect.hasAssertions();
+
+			await dao.createRunsheet("runsheet-1", {
+				campaignId: "campaign-1",
+				sessionNumber: 3,
+				title: "Session 3 runsheet",
+				runsheetData: validRunsheetData,
+			});
+
+			expect(mockDB.prepare).toHaveBeenCalled();
+			expect(mockStmt.run).toHaveBeenCalled();
+			const boundArgs = mockStmt.bind.mock.calls[0];
+			expect(boundArgs).toContain("runsheet-1");
+			expect(boundArgs).toContain("campaign-1");
+			expect(boundArgs).toContain(JSON.stringify(validRunsheetData));
+		});
+	});
+
+	describe("getRunsheetById", () => {
+		it("returns null when no row exists", async () => {
+			expect.hasAssertions();
+
+			mockStmt.first.mockResolvedValue(null);
+
+			await expect(dao.getRunsheetById("missing")).resolves.toBeNull();
+		});
+
+		it("parses the snapshot body into camelCase fields", async () => {
+			expect.hasAssertions();
+
+			mockStmt.first.mockResolvedValue(runsheetRow());
+
+			const runsheet = await dao.getRunsheetById("runsheet-1");
+
+			expect(runsheet).not.toBeNull();
+			expect(runsheet?.campaignId).toBe("campaign-1");
+			expect(runsheet?.sessionNumber).toBe(3);
+			expect(runsheet?.runsheetData.recap.keyEvents).toEqual([
+				"The bridge fell",
+			]);
+		});
+
+		// A blank page at the table is worse than a loud failure: unlike a digest,
+		// there is no form the GM can re-fill a corrupt runsheet from.
+		it("throws rather than returning an empty runsheet when JSON is corrupt", async () => {
+			expect.hasAssertions();
+
+			mockStmt.first.mockResolvedValue(
+				runsheetRow({ runsheet_data: "{not json" })
+			);
+
+			await expect(dao.getRunsheetById("runsheet-1")).rejects.toThrow(
+				/unparseable snapshot data/
+			);
+		});
+
+		it("throws when the snapshot is valid JSON but the wrong shape", async () => {
+			expect.hasAssertions();
+
+			mockStmt.first.mockResolvedValue(
+				runsheetRow({ runsheet_data: JSON.stringify({ recap: {} }) })
+			);
+
+			await expect(dao.getRunsheetById("runsheet-1")).rejects.toThrow(
+				/invalid snapshot structure/
+			);
+		});
+	});
+
+	describe("listRunsheetsByCampaign", () => {
+		it("returns summaries without loading the snapshot body", async () => {
+			expect.hasAssertions();
+
+			const { runsheet_data: _omitted, ...summaryRow } = runsheetRow();
+			mockStmt.all.mockResolvedValue({ results: [summaryRow] });
+
+			const runsheets = await dao.listRunsheetsByCampaign("campaign-1");
+
+			expect(runsheets).toHaveLength(1);
+			expect(runsheets[0]).toEqual({
+				id: "runsheet-1",
+				campaignId: "campaign-1",
+				sessionNumber: 3,
+				title: "Session 3 runsheet",
+				generatedAt: "2026-07-01 12:00:00",
+				createdAt: "2026-07-01 12:00:00",
+				updatedAt: "2026-07-01 12:00:00",
+			});
+			const sql = (mockDB.prepare as ReturnType<typeof vi.fn>).mock
+				.calls[0][0] as string;
+			expect(sql).not.toContain("runsheet_data");
+		});
+
+		it("filters by session number when provided", async () => {
+			expect.hasAssertions();
+
+			mockStmt.all.mockResolvedValue({ results: [] });
+
+			await dao.listRunsheetsByCampaign("campaign-1", { sessionNumber: 3 });
+
+			expect(mockStmt.bind).toHaveBeenCalledWith("campaign-1", 3);
+		});
+	});
+
+	describe("updateRunsheet", () => {
+		it("is a no-op when there is nothing to update", async () => {
+			expect.hasAssertions();
+
+			await dao.updateRunsheet("runsheet-1", {});
+
+			expect(mockDB.prepare).not.toHaveBeenCalled();
+		});
+
+		it("updates only the fields provided", async () => {
+			expect.hasAssertions();
+
+			await dao.updateRunsheet("runsheet-1", { title: "Renamed" });
+
+			const sql = (mockDB.prepare as ReturnType<typeof vi.fn>).mock
+				.calls[0][0] as string;
+			expect(sql).toContain("title = ?");
+			expect(sql).not.toContain("runsheet_data = ?");
+			expect(mockStmt.bind).toHaveBeenCalledWith("Renamed", "runsheet-1");
+		});
+	});
+
+	describe("deleteRunsheet", () => {
+		it("deletes by id", async () => {
+			expect.hasAssertions();
+
+			await dao.deleteRunsheet("runsheet-1");
+
+			expect(mockStmt.bind).toHaveBeenCalledWith("runsheet-1");
+			expect(mockStmt.run).toHaveBeenCalled();
+		});
+	});
+});

--- a/tests/routes/runsheets.test.ts
+++ b/tests/routes/runsheets.test.ts
@@ -1,0 +1,499 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CampaignAccessDeniedError } from "@/lib/errors";
+import type { RunsheetData } from "@/types/runsheet";
+
+const getRunsheetById = vi.fn();
+const listRunsheetsByCampaign = vi.fn();
+const createRunsheet = vi.fn();
+const updateRunsheet = vi.fn();
+const deleteRunsheet = vi.fn();
+const getNextSessionNumber = vi.fn();
+
+const ensureCampaignAccess = vi.fn();
+const requireCanEdit = vi.fn();
+const requireCanSeeSpoilers = vi.fn();
+const verifyCampaignAccess = vi.fn();
+const assemble = vi.fn();
+
+vi.mock("@/dao/dao-factory", () => ({
+	getDAOFactory: () => ({
+		runsheetDAO: {
+			getRunsheetById,
+			listRunsheetsByCampaign,
+			createRunsheet,
+			updateRunsheet,
+			deleteRunsheet,
+		},
+		sessionDigestDAO: { getNextSessionNumber },
+	}),
+}));
+
+vi.mock("@/lib/route-utils", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/route-utils")>(
+			"@/lib/route-utils"
+		);
+	return {
+		...actual,
+		ensureCampaignAccess: (...args: unknown[]) => ensureCampaignAccess(...args),
+		requireCanEdit: (...args: unknown[]) => requireCanEdit(...args),
+		requireCanSeeSpoilers: (...args: unknown[]) =>
+			requireCanSeeSpoilers(...args),
+		verifyCampaignAccess: (...args: unknown[]) => verifyCampaignAccess(...args),
+		getUserAuth: () => ({ username: "gm-user" }),
+	};
+});
+
+vi.mock("@/services/campaign/runsheet-assembly-service", () => ({
+	RunsheetAssemblyService: {
+		assemble: (...args: unknown[]) => assemble(...args),
+	},
+}));
+
+const {
+	handleDeleteRunsheet,
+	handleExportRunsheetHtml,
+	handleGenerateRunsheet,
+	handleGetRunsheet,
+	handleListRunsheets,
+	handleUpdateRunsheet,
+} = await import("@/routes/runsheets");
+
+const emptyRunsheetData: RunsheetData = {
+	recap: {
+		fromSessionNumber: null,
+		keyEvents: [],
+		stateChanges: { factions: [], locations: [], npcs: [] },
+		source: null,
+	},
+	plan: {
+		objectives: [],
+		probablePlayerGoals: [],
+		beats: [],
+		ifThenBranches: [],
+		openTasks: [],
+		todoChecklist: [],
+		source: null,
+	},
+	cast: [],
+	encounters: [],
+	loot: [],
+	rules: [],
+	openThreads: [],
+	notes: "",
+	emptySections: [],
+};
+
+const storedRunsheet = {
+	id: "runsheet-1",
+	campaignId: "campaign-1",
+	sessionNumber: 3,
+	title: "Session 3 runsheet",
+	runsheetData: emptyRunsheetData,
+	generatedAt: "2026-07-01 12:00:00",
+	createdAt: "2026-07-01 12:00:00",
+	updatedAt: "2026-07-01 12:00:00",
+};
+
+/**
+ * Minimal Hono-shaped context that records what the handler responded with.
+ *
+ * `json`/`body` return real `Response` objects because the handlers rely on
+ * `instanceof Response` to distinguish an early error response from loaded data.
+ */
+function createContext(
+	params: Record<string, string>,
+	options: { body?: unknown; query?: Record<string, string> } = {}
+) {
+	const captured: {
+		status?: number;
+		payload?: unknown;
+		body?: string;
+		headers?: Record<string, string>;
+	} = {};
+	return {
+		captured,
+		context: {
+			req: {
+				param: (name: string) => params[name],
+				query: (name: string) => options.query?.[name],
+				json: async () => options.body ?? {},
+			},
+			env: { DB: {} },
+			json: (payload: unknown, status = 200) => {
+				captured.payload = payload;
+				captured.status = status;
+				return new Response(JSON.stringify(payload), {
+					status,
+					headers: { "content-type": "application/json" },
+				});
+			},
+			body: (body: string, status = 200, headers?: Record<string, string>) => {
+				captured.body = body;
+				captured.status = status;
+				captured.headers = headers;
+				return new Response(body, { status, headers });
+			},
+		} as never,
+	};
+}
+
+describe("runsheet routes", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		ensureCampaignAccess.mockResolvedValue(true);
+		requireCanEdit.mockResolvedValue("owner");
+		requireCanSeeSpoilers.mockResolvedValue("owner");
+		verifyCampaignAccess.mockResolvedValue({
+			campaignId: "campaign-1",
+			name: "Ashen Coast",
+			campaignRagBasePath: "campaigns/campaign-1",
+			role: "owner",
+		});
+		getRunsheetById.mockResolvedValue(storedRunsheet);
+		listRunsheetsByCampaign.mockResolvedValue([]);
+		getNextSessionNumber.mockResolvedValue(3);
+		assemble.mockResolvedValue(emptyRunsheetData);
+	});
+
+	// The whole point of the spoiler boundary: player roles are rejected by
+	// requireCanSeeSpoilers / requireCanEdit, which throw CampaignAccessDeniedError.
+	describe("spoiler boundary", () => {
+		it.each([
+			["get", handleGetRunsheet, requireCanSeeSpoilers],
+			["list", handleListRunsheets, requireCanSeeSpoilers],
+			["export", handleExportRunsheetHtml, requireCanSeeSpoilers],
+			["generate", handleGenerateRunsheet, requireCanEdit],
+			["update", handleUpdateRunsheet, requireCanEdit],
+			["delete", handleDeleteRunsheet, requireCanEdit],
+		])("returns 403 from %s for a role without access", async (_name, handler, guard) => {
+			expect.hasAssertions();
+
+			(guard as ReturnType<typeof vi.fn>).mockRejectedValue(
+				new CampaignAccessDeniedError()
+			);
+
+			const { context, captured } = createContext({
+				campaignId: "campaign-1",
+				runsheetId: "runsheet-1",
+			});
+
+			await handler(context);
+
+			expect(captured.status).toBe(403);
+			expect(captured.payload).toEqual({ error: "Access denied" });
+		});
+
+		it("gates every read path on spoiler access, not merely campaign access", async () => {
+			expect.hasAssertions();
+
+			const { context } = createContext({
+				campaignId: "campaign-1",
+				runsheetId: "runsheet-1",
+			});
+
+			await handleGetRunsheet(context);
+			await handleExportRunsheetHtml(context);
+
+			expect(requireCanSeeSpoilers).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("handleGenerateRunsheet", () => {
+		it("assembles a snapshot for the next session by default", async () => {
+			expect.hasAssertions();
+
+			const { context, captured } = createContext({ campaignId: "campaign-1" });
+
+			await handleGenerateRunsheet(context);
+
+			expect(assemble).toHaveBeenCalledWith(expect.anything(), {
+				campaignId: "campaign-1",
+				sessionNumber: 3,
+			});
+			expect(createRunsheet).toHaveBeenCalled();
+			expect(captured.status).toBe(201);
+		});
+
+		it("honours an explicit session number", async () => {
+			expect.hasAssertions();
+
+			const { context } = createContext(
+				{ campaignId: "campaign-1" },
+				{ body: { sessionNumber: 9 } }
+			);
+
+			await handleGenerateRunsheet(context);
+
+			expect(assemble).toHaveBeenCalledWith(expect.anything(), {
+				campaignId: "campaign-1",
+				sessionNumber: 9,
+			});
+		});
+
+		it("titles the runsheet after its session when no title is given", async () => {
+			expect.hasAssertions();
+
+			const { context } = createContext({ campaignId: "campaign-1" });
+
+			await handleGenerateRunsheet(context);
+
+			expect(createRunsheet).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ title: "Session 3 runsheet" })
+			);
+		});
+
+		it("404s when the campaign is not visible to the user", async () => {
+			expect.hasAssertions();
+
+			ensureCampaignAccess.mockResolvedValue(false);
+			const { context, captured } = createContext({ campaignId: "campaign-1" });
+
+			await handleGenerateRunsheet(context);
+
+			expect(captured.status).toBe(404);
+			expect(createRunsheet).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("handleGetRunsheet", () => {
+		it("returns the stored snapshot", async () => {
+			expect.hasAssertions();
+
+			const { context, captured } = createContext({
+				campaignId: "campaign-1",
+				runsheetId: "runsheet-1",
+			});
+
+			await handleGetRunsheet(context);
+
+			expect(captured.payload).toEqual({ runsheet: storedRunsheet });
+		});
+
+		// Answering 404 avoids confirming the runsheet exists to someone probing ids.
+		it("404s for a runsheet belonging to another campaign", async () => {
+			expect.hasAssertions();
+
+			getRunsheetById.mockResolvedValue({
+				...storedRunsheet,
+				campaignId: "other-campaign",
+			});
+			const { context, captured } = createContext({
+				campaignId: "campaign-1",
+				runsheetId: "runsheet-1",
+			});
+
+			await handleGetRunsheet(context);
+
+			expect(captured.status).toBe(404);
+			expect(captured.payload).toEqual({ error: "Runsheet not found" });
+		});
+
+		it("404s when the runsheet does not exist", async () => {
+			expect.hasAssertions();
+
+			getRunsheetById.mockResolvedValue(null);
+			const { context, captured } = createContext({
+				campaignId: "campaign-1",
+				runsheetId: "missing",
+			});
+
+			await handleGetRunsheet(context);
+
+			expect(captured.status).toBe(404);
+		});
+	});
+
+	describe("handleUpdateRunsheet", () => {
+		it("persists hand-edited runsheet data", async () => {
+			expect.hasAssertions();
+
+			const edited = { ...emptyRunsheetData, notes: "Remember the bell" };
+			const { context } = createContext(
+				{ campaignId: "campaign-1", runsheetId: "runsheet-1" },
+				{ body: { runsheetData: edited } }
+			);
+
+			await handleUpdateRunsheet(context);
+
+			expect(updateRunsheet).toHaveBeenCalledWith("runsheet-1", {
+				runsheetData: edited,
+			});
+		});
+
+		it("rejects a body that is not a valid runsheet", async () => {
+			expect.hasAssertions();
+
+			const { context, captured } = createContext(
+				{ campaignId: "campaign-1", runsheetId: "runsheet-1" },
+				{ body: { runsheetData: { recap: {} } } }
+			);
+
+			await handleUpdateRunsheet(context);
+
+			expect(captured.status).toBe(400);
+			expect(updateRunsheet).not.toHaveBeenCalled();
+		});
+
+		it("rejects an empty title", async () => {
+			expect.hasAssertions();
+
+			const { context, captured } = createContext(
+				{ campaignId: "campaign-1", runsheetId: "runsheet-1" },
+				{ body: { title: "   " } }
+			);
+
+			await handleUpdateRunsheet(context);
+
+			expect(captured.status).toBe(400);
+			expect(updateRunsheet).not.toHaveBeenCalled();
+		});
+
+		it("rejects a request with no updatable fields", async () => {
+			expect.hasAssertions();
+
+			const { context, captured } = createContext(
+				{ campaignId: "campaign-1", runsheetId: "runsheet-1" },
+				{ body: {} }
+			);
+
+			await handleUpdateRunsheet(context);
+
+			expect(captured.status).toBe(400);
+			expect(captured.payload).toEqual({ error: "No fields to update" });
+		});
+
+		// A snapshot the GM has edited must not be overwritten by fresher data.
+		it("never re-assembles on update", async () => {
+			expect.hasAssertions();
+
+			const { context } = createContext(
+				{ campaignId: "campaign-1", runsheetId: "runsheet-1" },
+				{ body: { title: "My runsheet" } }
+			);
+
+			await handleUpdateRunsheet(context);
+
+			expect(assemble).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("handleDeleteRunsheet", () => {
+		it("deletes an existing runsheet", async () => {
+			expect.hasAssertions();
+
+			const { context, captured } = createContext({
+				campaignId: "campaign-1",
+				runsheetId: "runsheet-1",
+			});
+
+			await handleDeleteRunsheet(context);
+
+			expect(deleteRunsheet).toHaveBeenCalledWith("runsheet-1");
+			expect(captured.payload).toEqual({ success: true });
+		});
+
+		it("does not delete across campaigns", async () => {
+			expect.hasAssertions();
+
+			getRunsheetById.mockResolvedValue({
+				...storedRunsheet,
+				campaignId: "other-campaign",
+			});
+			const { context, captured } = createContext({
+				campaignId: "campaign-1",
+				runsheetId: "runsheet-1",
+			});
+
+			await handleDeleteRunsheet(context);
+
+			expect(captured.status).toBe(404);
+			expect(deleteRunsheet).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("handleExportRunsheetHtml", () => {
+		it("returns a print-friendly HTML document", async () => {
+			expect.hasAssertions();
+
+			const { context, captured } = createContext({
+				campaignId: "campaign-1",
+				runsheetId: "runsheet-1",
+			});
+
+			await handleExportRunsheetHtml(context);
+
+			expect(captured.status).toBe(200);
+			expect(captured.body?.startsWith("<!DOCTYPE html>")).toBe(true);
+			expect(captured.body).toContain("Ashen Coast");
+			expect(captured.body).toContain("GM only — contains spoilers");
+		});
+
+		it("marks the response un-cacheable and un-indexable", async () => {
+			expect.hasAssertions();
+
+			const { context, captured } = createContext({
+				campaignId: "campaign-1",
+				runsheetId: "runsheet-1",
+			});
+
+			await handleExportRunsheetHtml(context);
+
+			expect(captured.headers?.["Content-Type"]).toBe(
+				"text/html; charset=utf-8"
+			);
+			expect(captured.headers?.["Cache-Control"]).toBe("no-store, private");
+			expect(captured.headers?.["X-Robots-Tag"]).toBe("noindex, nofollow");
+			expect(captured.headers?.["X-Content-Type-Options"]).toBe("nosniff");
+		});
+	});
+
+	describe("handleListRunsheets", () => {
+		it("returns summaries plus the next session number", async () => {
+			expect.hasAssertions();
+
+			listRunsheetsByCampaign.mockResolvedValue([
+				{ id: "runsheet-1", sessionNumber: 3 },
+			]);
+			const { context, captured } = createContext({ campaignId: "campaign-1" });
+
+			await handleListRunsheets(context);
+
+			expect(captured.payload).toEqual({
+				runsheets: [{ id: "runsheet-1", sessionNumber: 3 }],
+				nextSessionNumber: 3,
+			});
+		});
+
+		it("filters by session number when the query param is present", async () => {
+			expect.hasAssertions();
+
+			const { context } = createContext(
+				{ campaignId: "campaign-1" },
+				{ query: { sessionNumber: "5" } }
+			);
+
+			await handleListRunsheets(context);
+
+			expect(listRunsheetsByCampaign).toHaveBeenCalledWith("campaign-1", {
+				sessionNumber: 5,
+			});
+		});
+
+		it("ignores a non-numeric session filter", async () => {
+			expect.hasAssertions();
+
+			const { context } = createContext(
+				{ campaignId: "campaign-1" },
+				{ query: { sessionNumber: "abc" } }
+			);
+
+			await handleListRunsheets(context);
+
+			expect(listRunsheetsByCampaign).toHaveBeenCalledWith("campaign-1", {
+				sessionNumber: undefined,
+			});
+		});
+	});
+});

--- a/tests/services/runsheet-assembly-service.test.ts
+++ b/tests/services/runsheet-assembly-service.test.ts
@@ -1,0 +1,575 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Entity } from "@/dao/entity-dao";
+import { RunsheetAssemblyService } from "@/services/campaign/runsheet-assembly-service";
+import type {
+	SessionDigestData,
+	SessionDigestWithData,
+} from "@/types/session-digest";
+
+const listEntitiesByCampaign = vi.fn();
+const getSessionDigestsByCampaign = vi.fn();
+const listPlanningTasks = vi.fn();
+const getActiveRulesForCampaign = vi.fn();
+
+vi.mock("@/dao/dao-factory", () => ({
+	getDAOFactory: () => ({
+		entityDAO: { listEntitiesByCampaign },
+		sessionDigestDAO: { getSessionDigestsByCampaign },
+		planningTaskDAO: { listByCampaign: listPlanningTasks },
+	}),
+}));
+
+vi.mock("@/services/campaign/rules-context-service", () => ({
+	RulesContextService: {
+		getActiveRulesForCampaign: (...args: unknown[]) =>
+			getActiveRulesForCampaign(...args),
+	},
+}));
+
+function digestData(
+	overrides: Partial<SessionDigestData> = {}
+): SessionDigestData {
+	return {
+		last_session_recap: {
+			key_events: [],
+			state_changes: { factions: [], locations: [], npcs: [] },
+			open_threads: [],
+		},
+		next_session_plan: {
+			objectives_dm: [],
+			probable_player_goals: [],
+			beats: [],
+			if_then_branches: [],
+		},
+		npcs_to_run: [],
+		locations_in_focus: [],
+		encounter_seeds: [],
+		clues_and_revelations: [],
+		treasure_and_rewards: [],
+		todo_checklist: [],
+		...overrides,
+	};
+}
+
+function digest(
+	sessionNumber: number,
+	data: SessionDigestData,
+	overrides: Partial<SessionDigestWithData> = {}
+): SessionDigestWithData {
+	return {
+		id: `digest-${sessionNumber}`,
+		campaignId: "campaign-1",
+		sessionNumber,
+		sessionDate: null,
+		digestData: data,
+		status: "approved",
+		qualityScore: null,
+		reviewNotes: null,
+		generatedByAi: false,
+		templateId: null,
+		sourceType: "manual",
+		createdAt: "2026-07-01",
+		updatedAt: "2026-07-01",
+		...overrides,
+	};
+}
+
+function entity(
+	id: string,
+	entityType: string,
+	name: string,
+	content: Record<string, unknown>
+): Entity {
+	return {
+		id,
+		campaignId: "campaign-1",
+		entityType,
+		name,
+		content,
+		createdAt: "2026-07-01",
+		updatedAt: "2026-07-01",
+	};
+}
+
+/** Route each entity-type query to the right fixture list. */
+function stubEntities(byType: Record<string, Entity[]>) {
+	listEntitiesByCampaign.mockImplementation(
+		(_campaignId: string, options: { entityType?: string }) =>
+			Promise.resolve(byType[options.entityType ?? ""] ?? [])
+	);
+}
+
+describe("RunsheetAssemblyService", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getSessionDigestsByCampaign.mockResolvedValue([]);
+		listPlanningTasks.mockResolvedValue([]);
+		getActiveRulesForCampaign.mockResolvedValue([]);
+		stubEntities({});
+	});
+
+	describe("selectSourceDigest", () => {
+		// A digest for session N holds the recap OF N and the plan FOR N+1, so the
+		// runsheet for session N+1 is fed by the digest immediately below it.
+		it("picks the highest-numbered digest below the target session", () => {
+			expect.hasAssertions();
+
+			const digests = [
+				digest(1, digestData()),
+				digest(3, digestData()),
+				digest(2, digestData()),
+			];
+
+			const selected = RunsheetAssemblyService.selectSourceDigest(digests, 4);
+
+			expect(selected?.sessionNumber).toBe(3);
+		});
+
+		it("ignores digests at or above the target session", () => {
+			expect.hasAssertions();
+
+			const digests = [digest(4, digestData()), digest(5, digestData())];
+
+			expect(RunsheetAssemblyService.selectSourceDigest(digests, 4)).toBeNull();
+		});
+
+		it("skips rejected digests so a rejected plan cannot resurface", () => {
+			expect.hasAssertions();
+
+			const digests = [
+				digest(2, digestData()),
+				digest(3, digestData(), { status: "rejected" }),
+			];
+
+			const selected = RunsheetAssemblyService.selectSourceDigest(digests, 4);
+
+			expect(selected?.sessionNumber).toBe(2);
+		});
+
+		it("returns null when the campaign has no digests at all", () => {
+			expect.hasAssertions();
+
+			expect(RunsheetAssemblyService.selectSourceDigest([], 1)).toBeNull();
+		});
+	});
+
+	describe("buildCast", () => {
+		it("builds a one-line hook from goals and quirks", () => {
+			expect.hasAssertions();
+
+			const npc = entity("npc-1", "npcs", "Vex Ashford", {
+				role: "Harbormaster",
+				goals: "Buy back her brother's debt",
+				quirks: "Speaks only in questions",
+				secrets: "She already sold the ledger",
+				summary: "A tired official.",
+			});
+
+			const cast = RunsheetAssemblyService.buildCast(
+				digest(2, digestData({ npcs_to_run: ["Vex Ashford"] })),
+				[npc]
+			);
+
+			expect(cast).toHaveLength(1);
+			expect(cast[0].hook).toBe(
+				"Buy back her brother's debt — Speaks only in questions"
+			);
+			expect(cast[0].role).toBe("Harbormaster");
+			expect(cast[0].secrets).toBe("She already sold the ledger");
+			expect(cast[0].source.kind).toBe("entity");
+		});
+
+		it("falls back to the summary when there is no goal or quirk", () => {
+			expect.hasAssertions();
+
+			const npc = entity("npc-1", "npcs", "Bell", {
+				summary: "A nervous courier.",
+			});
+
+			const cast = RunsheetAssemblyService.buildCast(
+				digest(2, digestData({ npcs_to_run: ["Bell"] })),
+				[npc]
+			);
+
+			expect(cast[0].hook).toBe("A nervous courier.");
+		});
+
+		// The digest lists names the GM typed; an unmatched name is still someone
+		// they need on the page.
+		it("keeps NPCs with no matching entity, attributed to the digest", () => {
+			expect.hasAssertions();
+
+			const cast = RunsheetAssemblyService.buildCast(
+				digest(2, digestData({ npcs_to_run: ["Someone Unrecorded"] })),
+				[]
+			);
+
+			expect(cast).toHaveLength(1);
+			expect(cast[0].name).toBe("Someone Unrecorded");
+			expect(cast[0].hook).toBe("");
+			expect(cast[0].source.kind).toBe("session_digest");
+		});
+
+		it("matches entity names case-insensitively", () => {
+			expect.hasAssertions();
+
+			const npc = entity("npc-1", "npcs", "Vex Ashford", {
+				summary: "Harbormaster.",
+			});
+
+			const cast = RunsheetAssemblyService.buildCast(
+				digest(2, digestData({ npcs_to_run: ["  vex   ashford "] })),
+				[npc]
+			);
+
+			expect(cast[0].name).toBe("Vex Ashford");
+			expect(cast[0].source.kind).toBe("entity");
+		});
+
+		it("returns nothing when the digest lists no NPCs", () => {
+			expect.hasAssertions();
+
+			expect(
+				RunsheetAssemblyService.buildCast(digest(2, digestData()), [])
+			).toEqual([]);
+		});
+	});
+
+	describe("buildEncounters", () => {
+		it("attaches a statblock summary when a monster name appears in the seed", () => {
+			expect.hasAssertions();
+
+			const monster = entity("mon-1", "monsters", "Bone Naga", {
+				summary: "A serpentine undead spellcaster.",
+				cr: "4",
+				ac: "15",
+				hp: "58",
+			});
+
+			const encounters = RunsheetAssemblyService.buildEncounters(
+				digest(
+					2,
+					digestData({
+						encounter_seeds: ["A Bone Naga guards the flooded stair"],
+					})
+				),
+				[monster]
+			);
+
+			expect(encounters).toHaveLength(1);
+			expect(encounters[0].name).toBe("A Bone Naga guards the flooded stair");
+			expect(encounters[0].summary).toBe("A serpentine undead spellcaster.");
+			expect(encounters[0].statblock).toEqual({
+				CR: "4",
+				AC: "15",
+				HP: "58",
+			});
+		});
+
+		it("keeps an unmatched seed with an empty statblock", () => {
+			expect.hasAssertions();
+
+			const encounters = RunsheetAssemblyService.buildEncounters(
+				digest(2, digestData({ encounter_seeds: ["Something in the fog"] })),
+				[]
+			);
+
+			expect(encounters[0].statblock).toEqual({});
+			expect(encounters[0].source.kind).toBe("session_digest");
+		});
+
+		// "Rat" or "Imp" would match half the prose in a campaign.
+		it("does not guess from very short monster names", () => {
+			expect.hasAssertions();
+
+			const monster = entity("mon-1", "monsters", "Rat", { cr: "0" });
+
+			const encounters = RunsheetAssemblyService.buildEncounters(
+				digest(
+					2,
+					digestData({ encounter_seeds: ["The party negotiates a truce"] })
+				),
+				[monster]
+			);
+
+			expect(encounters[0].statblock).toEqual({});
+		});
+
+		it("prefers the longest matching monster name", () => {
+			expect.hasAssertions();
+
+			const shortName = entity("mon-1", "monsters", "Naga", { cr: "8" });
+			const longName = entity("mon-2", "monsters", "Bone Naga", { cr: "4" });
+
+			const encounters = RunsheetAssemblyService.buildEncounters(
+				digest(2, digestData({ encounter_seeds: ["The Bone Naga awakens"] })),
+				[shortName, longName]
+			);
+
+			expect(encounters[0].statblock.CR).toBe("4");
+		});
+	});
+
+	describe("buildLoot", () => {
+		it("enriches a reward with the matching item's rarity and text", () => {
+			expect.hasAssertions();
+
+			const item = entity("item-1", "items", "Sunblade", {
+				rarity: "rare",
+				text: "A hilt that projects a blade of light.",
+			});
+
+			const loot = RunsheetAssemblyService.buildLoot(
+				digest(2, digestData({ treasure_and_rewards: ["Sunblade"] })),
+				[item]
+			);
+
+			expect(loot[0].detail).toBe(
+				"(rare) A hilt that projects a blade of light."
+			);
+			expect(loot[0].source.kind).toBe("entity");
+		});
+
+		it("keeps rewards that match no item entity", () => {
+			expect.hasAssertions();
+
+			const loot = RunsheetAssemblyService.buildLoot(
+				digest(2, digestData({ treasure_and_rewards: ["300 gp in old coin"] })),
+				[]
+			);
+
+			expect(loot).toHaveLength(1);
+			expect(loot[0].detail).toBe("");
+		});
+	});
+
+	describe("buildRules", () => {
+		// Core-book rules are what the GM already owns a book for.
+		it("keeps only active house rules", () => {
+			expect.hasAssertions();
+
+			const rules = RunsheetAssemblyService.buildRules([
+				{
+					id: "r1",
+					name: "Flanking",
+					category: "combat",
+					text: "Flanking grants advantage.",
+					source: "house",
+					active: true,
+				},
+				{
+					id: "r2",
+					name: "Retired rule",
+					category: "combat",
+					text: "No longer used.",
+					source: "house",
+					active: false,
+				},
+				{
+					id: "r3",
+					name: "Grappling",
+					category: "combat",
+					text: "From the core book.",
+					source: "source",
+					active: true,
+				},
+			]);
+
+			expect(rules).toHaveLength(1);
+			expect(rules[0].name).toBe("Flanking");
+			expect(rules[0].source.kind).toBe("house_rule");
+		});
+	});
+
+	describe("buildOpenThreads", () => {
+		it("combines digest threads with hook entities", () => {
+			expect.hasAssertions();
+
+			const hook = entity("hook-1", "hooks", "The sealed vault", {
+				text: "Nobody has opened the vault beneath the guildhall.",
+			});
+
+			const threads = RunsheetAssemblyService.buildOpenThreads(
+				digest(
+					2,
+					digestData({
+						last_session_recap: {
+							key_events: [],
+							state_changes: { factions: [], locations: [], npcs: [] },
+							open_threads: ["Who paid the assassin?"],
+						},
+					})
+				),
+				[hook]
+			);
+
+			expect(threads).toHaveLength(2);
+			expect(threads[0].source.kind).toBe("session_digest");
+			expect(threads[1].source.kind).toBe("entity");
+		});
+
+		it("does not repeat a hook already listed in the digest", () => {
+			expect.hasAssertions();
+
+			const hook = entity("hook-1", "hooks", "Assassin", {
+				text: "Who paid the assassin?",
+			});
+
+			const threads = RunsheetAssemblyService.buildOpenThreads(
+				digest(
+					2,
+					digestData({
+						last_session_recap: {
+							key_events: [],
+							state_changes: { factions: [], locations: [], npcs: [] },
+							open_threads: ["Who paid the assassin?"],
+						},
+					})
+				),
+				[hook]
+			);
+
+			expect(threads).toHaveLength(1);
+		});
+	});
+
+	describe("assemble", () => {
+		it("assembles a full runsheet from existing campaign data", async () => {
+			expect.hasAssertions();
+
+			getSessionDigestsByCampaign.mockResolvedValue([
+				digest(
+					2,
+					digestData({
+						last_session_recap: {
+							key_events: ["The bridge fell"],
+							state_changes: {
+								factions: ["Guild weakened"],
+								locations: [],
+								npcs: [],
+							},
+							open_threads: ["Who paid the assassin?"],
+						},
+						next_session_plan: {
+							objectives_dm: ["Reveal the ledger"],
+							probable_player_goals: ["Find the harbormaster"],
+							beats: ["Open in the ruined chapel"],
+							if_then_branches: ["If they split up, cut between them"],
+						},
+						npcs_to_run: ["Vex Ashford"],
+						encounter_seeds: ["A Bone Naga guards the stair"],
+						treasure_and_rewards: ["Sunblade"],
+						todo_checklist: ["Print the map"],
+					})
+				),
+			]);
+			listPlanningTasks.mockResolvedValue([
+				{ id: "task-1", title: "Statblock the naga", description: null },
+			]);
+			getActiveRulesForCampaign.mockResolvedValue([
+				{
+					id: "r1",
+					name: "Flanking",
+					category: "combat",
+					text: "Flanking grants advantage.",
+					source: "house",
+					active: true,
+				},
+			]);
+			stubEntities({
+				npcs: [
+					entity("npc-1", "npcs", "Vex Ashford", {
+						goals: "Buy back the debt",
+					}),
+				],
+				monsters: [entity("mon-1", "monsters", "Bone Naga", { cr: "4" })],
+				items: [entity("item-1", "items", "Sunblade", { rarity: "rare" })],
+				hooks: [],
+			});
+
+			const runsheet = await RunsheetAssemblyService.assemble({} as never, {
+				campaignId: "campaign-1",
+				sessionNumber: 3,
+			});
+
+			expect(runsheet.recap.fromSessionNumber).toBe(2);
+			expect(runsheet.recap.keyEvents).toEqual(["The bridge fell"]);
+			expect(runsheet.plan.beats).toEqual(["Open in the ruined chapel"]);
+			expect(runsheet.plan.openTasks).toHaveLength(1);
+			expect(runsheet.plan.todoChecklist).toEqual(["Print the map"]);
+			expect(runsheet.cast[0].hook).toBe("Buy back the debt");
+			expect(runsheet.encounters[0].statblock).toEqual({ CR: "4" });
+			expect(runsheet.loot[0].detail).toBe("(rare)");
+			expect(runsheet.rules).toHaveLength(1);
+			expect(runsheet.openThreads).toHaveLength(1);
+			expect(runsheet.notes).toBe("");
+			expect(runsheet.emptySections).toEqual([]);
+		});
+
+		it("scopes planning tasks to the runsheet's session and open statuses", async () => {
+			expect.hasAssertions();
+
+			await RunsheetAssemblyService.assemble({} as never, {
+				campaignId: "campaign-1",
+				sessionNumber: 7,
+			});
+
+			expect(listPlanningTasks).toHaveBeenCalledWith("campaign-1", {
+				status: ["pending", "in_progress"],
+				targetSessionNumber: 7,
+			});
+		});
+
+		// The point of the feature is that assembly is free; a fresh generation would
+		// undo that.
+		it("makes no LLM call — every input is read from the database", async () => {
+			expect.hasAssertions();
+
+			await RunsheetAssemblyService.assemble({} as never, {
+				campaignId: "campaign-1",
+				sessionNumber: 3,
+			});
+
+			expect(getSessionDigestsByCampaign).toHaveBeenCalledWith("campaign-1");
+			expect(listEntitiesByCampaign).toHaveBeenCalled();
+			expect(getActiveRulesForCampaign).toHaveBeenCalled();
+		});
+
+		it("reports every empty section for a campaign with no data", async () => {
+			expect.hasAssertions();
+
+			const runsheet = await RunsheetAssemblyService.assemble({} as never, {
+				campaignId: "campaign-1",
+				sessionNumber: 1,
+			});
+
+			expect(runsheet.emptySections).toEqual([
+				"recap",
+				"plan",
+				"cast",
+				"encounters",
+				"loot",
+				"rules",
+				"openThreads",
+			]);
+			expect(runsheet.recap.source).toBeNull();
+		});
+
+		it("excludes staged and rejected entities from enrichment lookups", async () => {
+			expect.hasAssertions();
+
+			await RunsheetAssemblyService.assemble({} as never, {
+				campaignId: "campaign-1",
+				sessionNumber: 3,
+			});
+
+			for (const call of listEntitiesByCampaign.mock.calls) {
+				expect(call[1].excludeShardStatuses).toEqual([
+					"staging",
+					"rejected",
+					"deleted",
+				]);
+			}
+		});
+	});
+});

--- a/tests/services/runsheet-html-service.test.ts
+++ b/tests/services/runsheet-html-service.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest";
+import {
+	escapeHtml,
+	RunsheetHtmlService,
+} from "@/services/campaign/runsheet-html-service";
+import type { RunsheetData, RunsheetWithData } from "@/types/runsheet";
+
+function runsheetData(overrides: Partial<RunsheetData> = {}): RunsheetData {
+	return {
+		recap: {
+			fromSessionNumber: 2,
+			keyEvents: [],
+			stateChanges: { factions: [], locations: [], npcs: [] },
+			source: null,
+		},
+		plan: {
+			objectives: [],
+			probablePlayerGoals: [],
+			beats: [],
+			ifThenBranches: [],
+			openTasks: [],
+			todoChecklist: [],
+			source: null,
+		},
+		cast: [],
+		encounters: [],
+		loot: [],
+		rules: [],
+		openThreads: [],
+		notes: "",
+		emptySections: [],
+		...overrides,
+	};
+}
+
+function runsheet(data: RunsheetData): RunsheetWithData {
+	return {
+		id: "runsheet-1",
+		campaignId: "campaign-1",
+		sessionNumber: 3,
+		title: "Session 3 runsheet",
+		runsheetData: data,
+		generatedAt: "2026-07-01 12:00:00",
+		createdAt: "2026-07-01 12:00:00",
+		updatedAt: "2026-07-01 12:00:00",
+	};
+}
+
+function render(data: RunsheetData, campaignName = "Ashen Coast"): string {
+	return RunsheetHtmlService.render(runsheet(data), { campaignName });
+}
+
+describe("escapeHtml", () => {
+	it("escapes every character that could break out of markup", () => {
+		expect.hasAssertions();
+
+		expect(escapeHtml(`<script>"x" & 'y'</script>`)).toBe(
+			"&lt;script&gt;&quot;x&quot; &amp; &#39;y&#39;&lt;/script&gt;"
+		);
+	});
+
+	it("escapes ampersands before the entities it introduces", () => {
+		expect.hasAssertions();
+
+		expect(escapeHtml("&lt;")).toBe("&amp;lt;");
+	});
+});
+
+describe("RunsheetHtmlService.render", () => {
+	it("produces a standalone document with no external resources", () => {
+		expect.hasAssertions();
+
+		const html = render(runsheetData());
+
+		expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+		expect(html).toContain("<style>");
+		// A runsheet that needs wifi at the table defeats the point of printing it.
+		expect(html).not.toMatch(/<script/i);
+		expect(html).not.toMatch(/<link[^>]+href/i);
+		expect(html).not.toMatch(/https?:\/\//);
+	});
+
+	it("carries a print stylesheet that keeps sections off page folds", () => {
+		expect.hasAssertions();
+
+		const html = render(runsheetData());
+
+		expect(html).toContain("@media print");
+		expect(html).toContain("@page");
+		expect(html).toContain("page-break-inside: avoid");
+	});
+
+	it("warns on the page itself that the document is GM-only", () => {
+		expect.hasAssertions();
+
+		const html = render(runsheetData());
+
+		expect(html).toContain("GM only — contains spoilers");
+	});
+
+	it("renders every section heading", () => {
+		expect.hasAssertions();
+
+		const html = render(runsheetData());
+
+		for (const heading of [
+			"Recap",
+			"This session's plan",
+			"Cast",
+			"Encounters",
+			"Loot",
+			"Rules to remember",
+			"Open threads",
+			"Notes",
+		]) {
+			expect(html).toContain(heading);
+		}
+	});
+
+	// Every field on a runsheet is user-authored prose.
+	it("escapes campaign and runsheet content rather than emitting it raw", () => {
+		expect.hasAssertions();
+
+		const html = RunsheetHtmlService.render(
+			runsheet(
+				runsheetData({
+					cast: [
+						{
+							name: `<img src=x onerror="alert(1)">`,
+							hook: "wants <b>everything</b>",
+							role: null,
+							secrets: null,
+							source: { kind: "entity", id: "e1", label: null },
+						},
+					],
+					notes: `</style><script>alert(2)</script>`,
+				})
+			),
+			{ campaignName: `<svg onload="alert(3)">` }
+		);
+
+		expect(html).not.toContain("<img src=x");
+		expect(html).not.toContain("<svg onload");
+		expect(html).not.toContain("<script>alert(2)</script>");
+		expect(html).toContain("&lt;img src=x");
+		expect(html).toContain("&lt;svg onload");
+	});
+
+	it("renders cast hooks, statblocks, rules and threads", () => {
+		expect.hasAssertions();
+
+		const html = render(
+			runsheetData({
+				cast: [
+					{
+						name: "Vex Ashford",
+						hook: "Buy back the debt",
+						role: "Harbormaster",
+						secrets: "Already sold the ledger",
+						source: { kind: "entity", id: "e1", label: null },
+					},
+				],
+				encounters: [
+					{
+						name: "A Bone Naga guards the stair",
+						summary: "Serpentine undead.",
+						statblock: { CR: "4", AC: "15" },
+						source: { kind: "entity", id: "m1", label: null },
+					},
+				],
+				rules: [
+					{
+						name: "Flanking",
+						category: "combat",
+						text: "Flanking grants advantage.",
+						source: { kind: "house_rule", id: "r1", label: null },
+					},
+				],
+				openThreads: [
+					{
+						text: "Who paid the assassin?",
+						source: { kind: "session_digest", id: "d1", label: null },
+					},
+				],
+			})
+		);
+
+		expect(html).toContain("Vex Ashford");
+		expect(html).toContain("Harbormaster");
+		expect(html).toContain("Already sold the ledger");
+		expect(html).toContain("CR 4");
+		expect(html).toContain("AC 15");
+		expect(html).toContain("Flanking grants advantage.");
+		expect(html).toContain("Who paid the assassin?");
+	});
+
+	it("renders prep and checklist items as printable checkboxes", () => {
+		expect.hasAssertions();
+
+		const html = render(
+			runsheetData({
+				plan: {
+					objectives: [],
+					probablePlayerGoals: [],
+					beats: [],
+					ifThenBranches: [],
+					openTasks: [
+						{
+							title: "Statblock the naga",
+							detail: "CR 4",
+							source: { kind: "planning_task", id: "t1", label: null },
+						},
+					],
+					todoChecklist: ["Print the map"],
+					source: null,
+				},
+			})
+		);
+
+		expect(html).toContain('class="checklist"');
+		expect(html).toContain("Statblock the naga — CR 4");
+		expect(html).toContain("Print the map");
+	});
+
+	// A silently omitted section reads as "nothing to prepare" rather than
+	// "nothing recorded yet".
+	it("explains empty sections instead of omitting them", () => {
+		expect.hasAssertions();
+
+		const html = render(runsheetData());
+
+		expect(html).toContain("No active house rules recorded for this campaign.");
+		expect(html).toContain("No NPCs listed for this session.");
+		expect(html).toContain("No encounters prepared for this session.");
+		expect(html).toContain("No open threads recorded.");
+	});
+
+	it("titles the document with the campaign and runsheet name", () => {
+		expect.hasAssertions();
+
+		const html = render(runsheetData());
+
+		expect(html).toContain("<title>Ashen Coast — Session 3 runsheet</title>");
+	});
+
+	it("labels the recap with the session it came from", () => {
+		expect.hasAssertions();
+
+		const html = render(
+			runsheetData({
+				recap: {
+					fromSessionNumber: 2,
+					keyEvents: ["The bridge fell"],
+					stateChanges: { factions: [], locations: [], npcs: [] },
+					source: null,
+				},
+			})
+		);
+
+		expect(html).toContain("Recap — where we left off (session 2)");
+		expect(html).toContain("The bridge fell");
+	});
+});


### PR DESCRIPTION
Closes #742.

One GM-facing, exportable page to actually run a session from — assembled from content the campaign already has.

## What it does

Generates a **runsheet**: recap, this session's plan, cast, encounters, loot, rules to remember, and open threads on a single printable page, plus a freeform notes block.

| Section | Assembled from |
| --- | --- |
| Recap | `last_session_recap` of the source digest |
| This session's plan | `next_session_plan`, open planning tasks scoped to this session (#699), and the digest's `todo_checklist` |
| Cast | `npcs_to_run`, enriched with `npcs` entities (goals, quirks, role, secrets) |
| Encounters | `encounter_seeds`, enriched with `monsters` entities (CR/AC/HP/Speed) |
| Loot | `treasure_and_rewards`, enriched with `items` entities (rarity, text) |
| Rules to remember | Active house rules via `RulesContextService`, filtered to `source === "house"` |
| Open threads | Digest `open_threads` plus recent `hooks` entities |

## Design decisions from the issue

**Assembly, not generation.** No LLM calls — a runsheet costs one round of D1 reads. A test asserts this directly.

**Snapshot, not a live view.** Content is frozen at generation so the plan can't shift under the GM mid-session. `PUT` persists hand-edits and never re-assembles, so fresher campaign data can't silently overwrite an edited page.

**Spoiler boundary.** This was the critical constraint. Every handler gates on `requireCanSeeSpoilers` (read/export) or `requireCanEdit` (generate/update/delete) — both exclude player roles, so runsheets are unreachable through the player share flow. The export endpoint carries no auth in its URL: the client fetches it with its bearer token and opens it as a blob, so **no spoiler-bearing link ever exists to leak**. A token-in-URL export would have created exactly the shareable secret URL this feature must not have. Responses are sent `no-store, private` + `noindex, nofollow`. A cross-campaign runsheet id answers `404`, not `403`.

**Print, and PDF via print.** The export is a standalone HTML document — inline CSS, no scripts, no fonts, no external requests (a runsheet that needs wifi at the table defeats the point). `@page` margins and `break-inside: avoid` per section keep a statblock off a page fold mid-combat. PDF is the browser's own Print → Save as PDF: Workers have no headless-browser binding, and a print stylesheet gets the same artifact without shipping a PDF engine into the request path.

## Notable implementation detail

Digest fields like `npcs_to_run` and `encounter_seeds` are free text the GM typed — they carry names, not entity ids — so name matching is the only available join. It's deliberately forgiving: exact normalized match, else the longest indexed entity name contained in the text, with names under 4 characters never substring-matched ("Rat" would match half a campaign). An unmatched name still reaches the page, just unenriched and attributed to the digest. Empty sections are listed in `emptySections` and rendered with an explicit "nothing recorded" line, so a gap doesn't read as "nothing to prepare".

## Testing

- **71 new tests** across the DAO, assembly service, HTML renderer, and routes.
- Assembly: source-digest selection (including skipping rejected digests), enrichment and fallbacks, house-rule filtering, thread dedupe, empty-section reporting.
- Renderer: XSS escaping of user-authored prose, self-containment, print CSS.
- Routes: the spoiler boundary is table-tested across all six handlers; cross-campaign 404s; update validation.
- Full suite green: **1354 tests, 157 files**. `npm run check` exits 0, `npm run build` succeeds.
- Migration verified against SQLite: applies cleanly, defaults populate, `ON DELETE CASCADE` removes runsheets with their campaign.

## Notes for review

- Migration is `0028` — `origin/main` already has up to `0027`.
- Docs: `docs/SESSION_RUNSHEET.md`, linked from `docs/README.md`.
- Two things the issue listed that I did **not** wire in, because they have no persisted store to read from — encounter/loot output currently lives in chat tool responses, not a table. The runsheet reads the digest's `encounter_seeds` / `treasure_and_rewards` instead and enriches from the entity graph. Persisting encounter-builder and loot-agent output would be a natural follow-up.
- I left `skills-lock.json` (modified in the working tree) out of the commit — it looked unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)