### PR TITLE
feat: Add campaign continuity checker (#744)

### DIFF
--- a/docs/CONTINUITY_CHECKER.md
+++ b/docs/CONTINUITY_CHECKER.md
@@ -1,0 +1,180 @@
+# Campaign Continuity Checker
+
+Long campaigns accumulate contradictions. An NPC killed in session 12 gets
+referenced as alive in session 19. A location's ruler changes without anyone
+noting it. A house rule contradicts a ruling made three months ago.
+
+LoreSmith already holds every input needed to catch this — session digests,
+world state changes, the entity graph, timeline data, house rules. The
+continuity checker is the feature that actually looks.
+
+## What it detects
+
+| Type | Signal | Data source |
+| --- | --- | --- |
+| `state_contradiction` | Entity recorded dead/destroyed/departed, then referenced as present | `world_state_changelog` × `session_digests` |
+| `timeline_contradiction` | Session dates that run backwards against session numbers; an entity named before the session that introduces it | `session_digests`, `world_state_changelog` |
+| `relationship_contradiction` | Allied factions later described as hostile (or the reverse) with no intervening session recording why | `world_state_changelog.relationship_updates` |
+| `rules_contradiction` | A ruling recorded in a digest that clashes with an active house rule | `session_digests` × campaign rules |
+| `dangling_thread` | A hook introduced and never picked up again. Not an error — a planning prompt | `session_digests.open_threads` |
+
+## Design constraint: false positives destroy this feature
+
+A checker that cries wolf gets switched off after one use. Fiction is *full* of
+legitimate apparent contradictions — resurrection, disguise, unreliable
+narrators, deliberate retcon, players being lied to by NPCs.
+
+Five mechanisms enforce this:
+
+1. **Restoration clears the mark.** `collectOpenStatusMarks` walks the changelog
+   in order and *deletes* an entity's death mark when a later status reads
+   "resurrected", "returned", "rebuilt", etc. Resurrections never reach a model.
+2. **Both prompt tiers are biased toward silence.** They share an explicit list
+   of innocent explanations (disguise, faked death, flashback, shared names,
+   memorials) and are told that missing a real problem is cheaper than raising a
+   false one.
+3. **Every finding cites both sides.** `evidence` is `NOT NULL` and every
+   candidate carries at least two entries with deep-linkable reference ids, so
+   the GM adjudicates in seconds rather than investigating.
+4. **Findings are questions, never errors.** *"Session 12 recorded Vane's death;
+   session 19 references him. Intentional?"* A GM who deliberately faked a death
+   should think the tool is sharp, not broken.
+5. **Dismissals are permanent.** See below.
+
+### Dismissals never resurface
+
+Every candidate carries a `fingerprint` — a stable FNV-1a hash over the
+normalized facts that produced it. `continuity_findings` has
+`UNIQUE(campaign_id, fingerprint)` and inserts use `INSERT OR IGNORE`.
+
+Re-detection therefore produces the same fingerprint and the insert is a no-op,
+whatever the existing row's status. There is no separate dismissal list to keep
+in sync. A scan also subtracts known fingerprints *before* spending a model
+token, so dismissed findings cost nothing on later runs.
+
+## Cost model
+
+Naive implementation is combinatorial: every entity against every digest, over
+history that only grows. Four things keep it bounded.
+
+**Incremental by default.** `continuity_scan_state` holds a per-campaign
+watermark. An incremental scan only treats sessions *newer* than the watermark
+as the later side of a contradiction, so routine checks cost O(new sessions).
+Full scans are explicit (`mode: "full"`).
+
+**Narrow deterministically before calling a model.** All five detectors are pure
+functions over an in-memory corpus loaded in three queries. Candidate volume
+scales with *recorded state changes*, not entity count — an entity nobody ever
+killed is never a candidate.
+
+**Cheap tier triages, quality tier adjudicates.** Triage runs on
+`PIPELINE_ANALYSIS` (Haiku on Anthropic) to shortlist; only survivors reach
+`PIPELINE_STRUCTURED` (Sonnet). Dangling threads skip adjudication entirely —
+they are planning prompts, not conflicts.
+
+**Batched and capped.** Triage batches 12 candidates per call, adjudication 5.
+`maxCandidates` (default 60) caps a single run; when it bites, the scan reports
+`truncated: true` and says how many candidates went unreviewed rather than
+silently pretending it covered everything.
+
+## Architecture
+
+```
+src/services/continuity/
+  continuity-corpus.ts                    load digests + changelog + graph (3 queries)
+  continuity-text-utils.ts                name matching, token overlap, fingerprints
+  continuity-vocabulary.ts                free-text status → coarse buckets
+  detect-state-contradictions.ts          ─┐
+  detect-relationship-contradictions.ts    │ deterministic detectors
+  detect-timeline-contradictions.ts        │ (pure, no LLM, no I/O)
+  detect-dangling-threads.ts               │
+  detect-rules-contradictions.ts          ─┘
+  continuity-adjudication-service.ts      triage (cheap) → adjudicate (quality)
+  continuity-checker-service.ts           orchestration, dedupe, persistence
+```
+
+Flow:
+
+```
+loadContinuityCorpus
+  → detectors                    (deterministic candidates)
+  → subtract known fingerprints  (dismissal memory, free)
+  → sort + cap                   (state > relationship > timeline > rules > threads)
+  → triage        [Haiku]        (shortlist)
+  → adjudicate    [Sonnet]       (verdict + confidence + phrasing)
+  → filter by minConfidence
+  → INSERT OR IGNORE
+  → record watermark
+```
+
+## API
+
+All endpoints are GM-only (`requireCanEdit`).
+
+### `POST /campaigns/:campaignId/continuity/scan`
+
+```jsonc
+{
+  "mode": "incremental",        // or "full"
+  "types": ["state_contradiction"],   // optional subset
+  "minConfidence": "medium",    // lowest confidence to persist
+  "maxCandidates": 60
+}
+```
+
+Returns a `scan` object with counts (`candidatesGenerated`,
+`candidatesAlreadyKnown`, `findingsCreated`), `truncated`, `warnings` and the
+findings created.
+
+### `GET /campaigns/:campaignId/continuity/findings`
+
+Query params: `status` (default `open`), `types`, `limit`, `minConfidence`
+(**default `high`** — the report is trusted precisely because it is quiet).
+
+### `POST /campaigns/:campaignId/continuity/findings/:findingId/resolve`
+
+```jsonc
+{
+  "action": "confirm" | "dismiss" | "correct",
+  "note": "Vane faked his death on purpose.",
+  "correctedEntityId": "camp-1_vane",   // 'correct' only; defaults to the subject
+  "correctedStatus": "alive",           // 'correct' only; required
+  "campaignSessionId": 19
+}
+```
+
+`correct` additionally writes a `world_state_changelog` entry setting the
+corrected status, tagged `source: "continuity_correction"` with the originating
+finding id. The fix therefore flows into the graph on the next rebuild rather
+than living only in the report.
+
+## Agent tools
+
+Registered in `campaignContextToolsBundle` (GM-only — not in the player bundle):
+
+- `checkCampaignContinuityTool` — run a scan
+- `listContinuityFindingsTool` — list findings, high-confidence only by default
+- `resolveContinuityFindingTool` — confirm / dismiss / correct
+
+## Schema
+
+`migrations/0029_continuity_findings.sql`
+
+- `continuity_findings` — findings, with `UNIQUE(campaign_id, fingerprint)`
+- `continuity_scan_state` — per-campaign incremental watermark
+
+Both are mirrored in `scripts/d1/d1-bootstrap.sql`.
+
+## Tuning
+
+| Constant | File | Purpose |
+| --- | --- | --- |
+| `MIN_SINGLE_WORD_NAME_LENGTH`, `AMBIGUOUS_SINGLE_WORD_NAMES` | `continuity-text-utils.ts` | Reject collision-prone names before matching |
+| `RESOLUTION_OVERLAP_THRESHOLD`, `MIN_SESSIONS_DANGLING` | `detect-dangling-threads.ts` | How forgiving thread-resolution detection is |
+| `SUBJECT_OVERLAP_THRESHOLD` | `detect-rules-contradictions.ts` | When a digest ruling and a house rule count as the same subject |
+| `TRIAGE_BATCH_SIZE`, `ADJUDICATION_BATCH_SIZE` | `continuity-adjudication-service.ts` | Cost/attention trade-off per model call |
+| `DEFAULT_MAX_CANDIDATES` | `continuity-checker-service.ts` | Per-scan ceiling |
+
+When tuning, prefer the direction that produces **fewer** findings. A missed
+contradiction is a silent gap; a false one costs the GM's trust in the whole
+report.

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,12 @@ Welcome to the LoreSmith AI documentation! This directory contains comprehensive
 
 - **[Library entity pipeline](LIBRARY_ENTITY_PIPELINE.md)** - Library-scoped discovery, campaign copy, API fields, retries, and schema notes
 
+- **[Campaign Continuity Checker](CONTINUITY_CHECKER.md)** - Finding contradictions across digests, world state and entities
+  - Detection types and data sources
+  - False-positive controls and dismissal memory
+  - Incremental scans and the two-tier cost model
+  - API, agent tools and tuning constants
+
 - **[Authentication Flow](AUTHENTICATION_FLOW.md)** - Authentication system documentation
   - JWT-based authentication
   - API key management

--- a/migrations/0029_continuity_findings.sql
+++ b/migrations/0029_continuity_findings.sql
@@ -1,0 +1,62 @@
+-- Campaign continuity checker (issue #744)
+--
+-- continuity_findings stores GM-facing questions about likely contradictions
+-- across session digests, world state changelog entries and the entity graph.
+--
+-- The UNIQUE(campaign_id, fingerprint) constraint is what makes "a dismissed
+-- finding must never resurface" work: re-detection computes the same stable
+-- fingerprint and the insert is skipped when a row already exists, regardless
+-- of its status.
+CREATE TABLE IF NOT EXISTS continuity_findings (
+  id TEXT PRIMARY KEY,
+  campaign_id TEXT NOT NULL,
+  fingerprint TEXT NOT NULL,
+  finding_type TEXT NOT NULL CHECK (finding_type IN (
+    'state_contradiction',
+    'timeline_contradiction',
+    'relationship_contradiction',
+    'rules_contradiction',
+    'dangling_thread'
+  )),
+  confidence TEXT NOT NULL CHECK (confidence IN ('high', 'medium', 'low')),
+  question TEXT NOT NULL,
+  detail TEXT,
+  evidence TEXT NOT NULL, -- JSON array of ContinuityEvidence (both sides, always)
+  subject_entity_id TEXT,
+  subject_name TEXT,
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN (
+    'open',
+    'confirmed',
+    'dismissed',
+    'corrected'
+  )),
+  resolution_note TEXT,
+  resolved_by TEXT,
+  resolved_at DATETIME,
+  scan_id TEXT,
+  detected_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE,
+  UNIQUE (campaign_id, fingerprint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_continuity_findings_campaign_status
+  ON continuity_findings(campaign_id, status, detected_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_continuity_findings_campaign_type
+  ON continuity_findings(campaign_id, finding_type);
+
+CREATE INDEX IF NOT EXISTS idx_continuity_findings_scan
+  ON continuity_findings(scan_id);
+
+-- Watermark for incremental scans. A scan only treats digests newer than
+-- last_scanned_session as the "later reference" side of a contradiction, so
+-- routine ingest-time checks stay O(new sessions) rather than O(campaign).
+CREATE TABLE IF NOT EXISTS continuity_scan_state (
+  campaign_id TEXT PRIMARY KEY,
+  last_scanned_session INTEGER,
+  last_scan_id TEXT,
+  last_scan_mode TEXT,
+  last_scan_at DATETIME,
+  FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE
+);

--- a/scripts/d1/d1-bootstrap.sql
+++ b/scripts/d1/d1-bootstrap.sql
@@ -827,6 +827,56 @@ CREATE INDEX IF NOT EXISTS idx_communities_parent ON communities(parent_communit
 
 CREATE INDEX IF NOT EXISTS idx_entity_dedup_campaign_status ON entity_deduplication_pending(campaign_id, status);
 
+-- Campaign continuity checker findings and scan watermark (0029)
+CREATE TABLE IF NOT EXISTS continuity_findings (
+  id TEXT PRIMARY KEY,
+  campaign_id TEXT NOT NULL,
+  fingerprint TEXT NOT NULL,
+  finding_type TEXT NOT NULL CHECK (finding_type IN (
+    'state_contradiction',
+    'timeline_contradiction',
+    'relationship_contradiction',
+    'rules_contradiction',
+    'dangling_thread'
+  )),
+  confidence TEXT NOT NULL CHECK (confidence IN ('high', 'medium', 'low')),
+  question TEXT NOT NULL,
+  detail TEXT,
+  evidence TEXT NOT NULL, -- JSON array of ContinuityEvidence (both sides, always)
+  subject_entity_id TEXT,
+  subject_name TEXT,
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN (
+    'open',
+    'confirmed',
+    'dismissed',
+    'corrected'
+  )),
+  resolution_note TEXT,
+  resolved_by TEXT,
+  resolved_at DATETIME,
+  scan_id TEXT,
+  detected_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE,
+  UNIQUE (campaign_id, fingerprint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_continuity_findings_campaign_status
+  ON continuity_findings(campaign_id, status, detected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_continuity_findings_campaign_type
+  ON continuity_findings(campaign_id, finding_type);
+CREATE INDEX IF NOT EXISTS idx_continuity_findings_scan
+  ON continuity_findings(scan_id);
+
+CREATE TABLE IF NOT EXISTS continuity_scan_state (
+  campaign_id TEXT PRIMARY KEY,
+  last_scanned_session INTEGER,
+  last_scan_id TEXT,
+  last_scan_mode TEXT,
+  last_scan_at DATETIME,
+  FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE
+);
+
 -- Create a view for easy querying of analyzed files
 CREATE VIEW IF NOT EXISTS analyzed_files AS
 select 

--- a/src/dao/continuity-finding-dao.ts
+++ b/src/dao/continuity-finding-dao.ts
@@ -1,0 +1,262 @@
+import type {
+	ContinuityConfidence,
+	ContinuityEvidence,
+	ContinuityFinding,
+	ContinuityFindingRecord,
+	ContinuityFindingStatus,
+	ContinuityFindingType,
+	ContinuityScanMode,
+	ContinuityScanState,
+	CreateContinuityFindingInput,
+} from "@/types/continuity";
+import type { SqlParam } from "@/types/utils";
+import { BaseDAOClass } from "./base-dao";
+import { D1_IN_LIST_CHUNK_SIZE } from "./d1-limits";
+
+export interface ListContinuityFindingsOptions {
+	status?: ContinuityFindingStatus | ContinuityFindingStatus[];
+	types?: ContinuityFindingType[];
+	scanId?: string;
+	limit?: number;
+	offset?: number;
+}
+
+interface ScanStateRecord {
+	campaign_id: string;
+	last_scanned_session: number | null;
+	last_scan_id: string | null;
+	last_scan_mode: string | null;
+	last_scan_at: string | null;
+}
+
+export class ContinuityFindingDAO extends BaseDAOClass {
+	/**
+	 * Insert a finding, ignoring the row when an identical fingerprint already
+	 * exists for the campaign. This is how a dismissed finding stays dismissed:
+	 * re-detection produces the same fingerprint and the insert is a no-op.
+	 *
+	 * @returns true when a new row was written.
+	 */
+	async createFinding(input: CreateContinuityFindingInput): Promise<boolean> {
+		const sql = `
+      INSERT OR IGNORE INTO continuity_findings (
+        id,
+        campaign_id,
+        fingerprint,
+        finding_type,
+        confidence,
+        question,
+        detail,
+        evidence,
+        subject_entity_id,
+        subject_name,
+        status,
+        scan_id,
+        detected_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `;
+
+		const changes = await this.executeReturningChanges(sql, [
+			input.id,
+			input.campaignId,
+			input.fingerprint,
+			input.findingType,
+			input.confidence,
+			input.question,
+			input.detail ?? null,
+			JSON.stringify(input.evidence),
+			input.subjectEntityId ?? null,
+			input.subjectName ?? null,
+			input.scanId ?? null,
+		]);
+
+		return changes > 0;
+	}
+
+	async getFindingById(findingId: string): Promise<ContinuityFinding | null> {
+		const record = await this.queryFirst<ContinuityFindingRecord>(
+			"SELECT * FROM continuity_findings WHERE id = ?",
+			[findingId]
+		);
+		return record ? this.mapRecord(record) : null;
+	}
+
+	async listFindingsForCampaign(
+		campaignId: string,
+		options: ListContinuityFindingsOptions = {}
+	): Promise<ContinuityFinding[]> {
+		const conditions: string[] = ["campaign_id = ?"];
+		const params: SqlParam[] = [campaignId];
+
+		const statuses = options.status
+			? Array.isArray(options.status)
+				? options.status
+				: [options.status]
+			: [];
+		if (statuses.length > 0) {
+			conditions.push(`status IN (${statuses.map(() => "?").join(", ")})`);
+			params.push(...statuses);
+		}
+
+		if (options.types?.length) {
+			conditions.push(
+				`finding_type IN (${options.types.map(() => "?").join(", ")})`
+			);
+			params.push(...options.types);
+		}
+
+		if (options.scanId) {
+			conditions.push("scan_id = ?");
+			params.push(options.scanId);
+		}
+
+		let sql = `
+      SELECT * FROM continuity_findings
+      WHERE ${conditions.join(" AND ")}
+      ORDER BY
+        CASE confidence WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END,
+        detected_at DESC
+    `;
+
+		if (typeof options.limit === "number") {
+			sql += " LIMIT ?";
+			params.push(options.limit);
+		}
+		if (typeof options.offset === "number") {
+			sql += " OFFSET ?";
+			params.push(options.offset);
+		}
+
+		const records = await this.queryAll<ContinuityFindingRecord>(sql, params);
+		return records.map((record) => this.mapRecord(record));
+	}
+
+	/**
+	 * Fingerprints already recorded for a campaign, whatever their status.
+	 * The scanner subtracts these before spending a single model token.
+	 */
+	async getKnownFingerprints(campaignId: string): Promise<Set<string>> {
+		const records = await this.queryAll<{ fingerprint: string }>(
+			"SELECT fingerprint FROM continuity_findings WHERE campaign_id = ?",
+			[campaignId]
+		);
+		return new Set(records.map((record) => record.fingerprint));
+	}
+
+	async countOpenFindings(campaignId: string): Promise<number> {
+		const record = await this.queryFirst<{ count: number }>(
+			"SELECT COUNT(*) as count FROM continuity_findings WHERE campaign_id = ? AND status = 'open'",
+			[campaignId]
+		);
+		return record?.count ?? 0;
+	}
+
+	async updateFindingStatus(
+		findingId: string,
+		status: ContinuityFindingStatus,
+		options: { resolutionNote?: string | null; resolvedBy?: string | null } = {}
+	): Promise<void> {
+		await this.execute(
+			`UPDATE continuity_findings
+       SET status = ?,
+           resolution_note = ?,
+           resolved_by = ?,
+           resolved_at = CURRENT_TIMESTAMP,
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = ?`,
+			[
+				status,
+				options.resolutionNote ?? null,
+				options.resolvedBy ?? null,
+				findingId,
+			]
+		);
+	}
+
+	async deleteFindingsForCampaign(campaignId: string): Promise<void> {
+		await this.execute(
+			"DELETE FROM continuity_findings WHERE campaign_id = ?",
+			[campaignId]
+		);
+	}
+
+	async deleteFindings(findingIds: string[]): Promise<void> {
+		if (!findingIds.length) return;
+		for (let i = 0; i < findingIds.length; i += D1_IN_LIST_CHUNK_SIZE) {
+			const chunk = findingIds.slice(i, i + D1_IN_LIST_CHUNK_SIZE);
+			const placeholders = chunk.map(() => "?").join(", ");
+			await this.execute(
+				`DELETE FROM continuity_findings WHERE id IN (${placeholders})`,
+				chunk
+			);
+		}
+	}
+
+	async getScanState(campaignId: string): Promise<ContinuityScanState | null> {
+		const record = await this.queryFirst<ScanStateRecord>(
+			"SELECT * FROM continuity_scan_state WHERE campaign_id = ?",
+			[campaignId]
+		);
+		if (!record) return null;
+		return {
+			campaignId: record.campaign_id,
+			lastScannedSession: record.last_scanned_session,
+			lastScanId: record.last_scan_id,
+			lastScanMode: (record.last_scan_mode as ContinuityScanMode) ?? null,
+			lastScanAt: record.last_scan_at,
+		};
+	}
+
+	async recordScan(input: {
+		campaignId: string;
+		scanId: string;
+		mode: ContinuityScanMode;
+		lastScannedSession: number | null;
+	}): Promise<void> {
+		await this.execute(
+			`INSERT INTO continuity_scan_state (
+         campaign_id, last_scanned_session, last_scan_id, last_scan_mode, last_scan_at
+       ) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+       ON CONFLICT(campaign_id) DO UPDATE SET
+         last_scanned_session = MAX(
+           COALESCE(excluded.last_scanned_session, -1),
+           COALESCE(continuity_scan_state.last_scanned_session, -1)
+         ),
+         last_scan_id = excluded.last_scan_id,
+         last_scan_mode = excluded.last_scan_mode,
+         last_scan_at = CURRENT_TIMESTAMP`,
+			[input.campaignId, input.lastScannedSession, input.scanId, input.mode]
+		);
+	}
+
+	private mapRecord(record: ContinuityFindingRecord): ContinuityFinding {
+		let evidence: ContinuityEvidence[] = [];
+		try {
+			const parsed = JSON.parse(record.evidence);
+			if (Array.isArray(parsed)) evidence = parsed as ContinuityEvidence[];
+		} catch (_error) {
+			evidence = [];
+		}
+
+		return {
+			id: record.id,
+			campaignId: record.campaign_id,
+			fingerprint: record.fingerprint,
+			findingType: record.finding_type as ContinuityFindingType,
+			confidence: record.confidence as ContinuityConfidence,
+			question: record.question,
+			detail: record.detail,
+			evidence,
+			subjectEntityId: record.subject_entity_id,
+			subjectName: record.subject_name,
+			status: record.status as ContinuityFindingStatus,
+			resolutionNote: record.resolution_note,
+			resolvedBy: record.resolved_by,
+			resolvedAt: record.resolved_at,
+			scanId: record.scan_id,
+			detectedAt: record.detected_at,
+			updatedAt: record.updated_at,
+		};
+	}
+}

--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -17,6 +17,7 @@ import { CharacterSheetDAO } from "./character-sheet-dao";
 import { ChecklistStatusDAO } from "./checklist-status-dao";
 import { CommunityDAO } from "./community-dao";
 import { CommunitySummaryDAO } from "./community-summary-dao";
+import { ContinuityFindingDAO } from "./continuity-finding-dao";
 import { EntityDAO } from "./entity-dao";
 import { EntityImportanceDAO } from "./entity-importance-dao";
 import { FileDAO } from "./file/file-dao";
@@ -61,6 +62,7 @@ export interface DAOFactory {
 	llmUsageDAO: LLMUsageDAO;
 	communityDAO: CommunityDAO;
 	communitySummaryDAO: CommunitySummaryDAO;
+	continuityFindingDAO: ContinuityFindingDAO;
 	entityImportanceDAO: EntityImportanceDAO;
 	sessionDigestDAO: SessionDigestDAO;
 	sessionDigestTemplateDAO: SessionDigestTemplateDAO;
@@ -104,6 +106,7 @@ export class DAOFactoryImpl implements DAOFactory {
 	public readonly llmUsageDAO: LLMUsageDAO;
 	public readonly communityDAO: CommunityDAO;
 	public readonly communitySummaryDAO: CommunitySummaryDAO;
+	public readonly continuityFindingDAO: ContinuityFindingDAO;
 	public readonly entityImportanceDAO: EntityImportanceDAO;
 	public readonly sessionDigestDAO: SessionDigestDAO;
 	public readonly sessionDigestTemplateDAO: SessionDigestTemplateDAO;
@@ -142,6 +145,7 @@ export class DAOFactoryImpl implements DAOFactory {
 		this.llmUsageDAO = new LLMUsageDAO(db);
 		this.communityDAO = new CommunityDAO(db);
 		this.communitySummaryDAO = new CommunitySummaryDAO(db);
+		this.continuityFindingDAO = new ContinuityFindingDAO(db);
 		this.entityImportanceDAO = new EntityImportanceDAO(db);
 		this.sessionDigestDAO = new SessionDigestDAO(db);
 		this.sessionDigestTemplateDAO = new SessionDigestTemplateDAO(db);

--- a/src/lib/prompts/continuity-prompts.ts
+++ b/src/lib/prompts/continuity-prompts.ts
@@ -1,0 +1,149 @@
+/**
+ * Prompts for the campaign continuity checker (issue #744).
+ *
+ * Both tiers are written around one premise: fiction is *full* of legitimate
+ * apparent contradictions. A checker that cries wolf gets switched off after
+ * one use, so both prompts are biased toward silence.
+ */
+
+import type { ContinuityCandidate } from "@/types/continuity";
+
+/**
+ * Reasons an apparent contradiction is usually fine. Shared by both tiers so
+ * the cheap pass and the expensive pass reject the same things.
+ */
+const LEGITIMATE_EXPLANATIONS = `Apparent contradictions are normal in fiction. Do NOT flag something when it is plausibly explained by:
+- Resurrection, undeath, or divine restoration
+- Disguise, shapeshifting, impersonation, or a body double
+- An unreliable narrator: a character, rumour, or NPC lying to the players
+- A faked death, staged destruction, or a deliberate deception
+- Deliberate GM retcon, or a correction the GM already made
+- Flashbacks, prophecy, dreams, visions, or planar/time travel
+- A name shared by more than one person, place, or thing
+- A memorial, legacy, epitaph, or reference to someone in the past tense
+- Plans that reference a character's absence rather than their presence`;
+
+function formatEvidence(candidate: ContinuityCandidate): string {
+	return candidate.evidence
+		.map((item, index) => `  ${index + 1}. [${item.label}] ${item.excerpt}`)
+		.join("\n");
+}
+
+function formatCandidate(
+	candidate: ContinuityCandidate,
+	index: number
+): string {
+	return `#${index}
+Type: ${candidate.type}
+Subject: ${candidate.subjectName ?? "n/a"}
+Detector rationale: ${candidate.rationale}
+Evidence:
+${formatEvidence(candidate)}`;
+}
+
+/**
+ * Cheap triage pass: shortlist candidates worth spending a quality-tier call
+ * on. Runs on the analysis (fast/cheap) model tier.
+ */
+export function formatContinuityTriagePrompt(
+	candidates: ContinuityCandidate[]
+): string {
+	return `You are triaging possible continuity problems in a tabletop RPG campaign. Each item below was flagged by a mechanical detector that only compares recorded facts — it does not understand the story.
+
+For each item decide whether it is worth a game master's attention.
+
+${LEGITIMATE_EXPLANATIONS}
+
+Mark an item worthKeeping only when the two pieces of evidence genuinely appear to disagree and no explanation above obviously applies. When in doubt, drop it. Missing a real problem is much cheaper than raising a false one.
+
+Candidates:
+${candidates.map((candidate, index) => formatCandidate(candidate, index)).join("\n\n")}
+
+Return ONLY JSON:
+{
+  "verdicts": [
+    { "index": 0, "worthKeeping": true, "reason": "one short sentence" }
+  ]
+}
+Include exactly one verdict per candidate, using the #index shown above.`;
+}
+
+/**
+ * Quality pass: decide whether a shortlisted candidate is a real contradiction,
+ * how confident to be, and how to phrase the question for the GM.
+ */
+export function formatContinuityAdjudicationPrompt(
+	candidates: ContinuityCandidate[]
+): string {
+	return `You are helping a tabletop RPG game master check a long campaign for continuity problems. Each item below survived a first-pass filter. Decide, carefully, whether it is a real problem.
+
+${LEGITIMATE_EXPLANATIONS}
+
+For each item return:
+- isContradiction: true only if the recorded facts genuinely conflict.
+- confidence:
+  - "high": the two records directly contradict each other and no in-fiction explanation is apparent.
+  - "medium": they probably conflict, but an explanation above is plausible.
+  - "low": likely fine; explained by normal storytelling.
+- question: how to raise this with the GM. Phrase it as a QUESTION, never an accusation. Name both sessions and both facts, then ask whether it was intentional. A GM who deliberately faked a death should read your question and think the tool is sharp, not broken. Maximum two sentences.
+- detail: one or two sentences on what to check, including the most likely innocent explanation.
+
+Candidates:
+${candidates.map((candidate, index) => formatCandidate(candidate, index)).join("\n\n")}
+
+Return ONLY JSON:
+{
+  "verdicts": [
+    {
+      "index": 0,
+      "isContradiction": true,
+      "confidence": "high",
+      "question": "...",
+      "detail": "..."
+    }
+  ]
+}
+Include exactly one verdict per candidate, using the #index shown above.`;
+}
+
+/** JSON schema string for the triage tier's structured output. */
+export const CONTINUITY_TRIAGE_SCHEMA = JSON.stringify({
+	type: "object",
+	properties: {
+		verdicts: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					index: { type: "number" },
+					worthKeeping: { type: "boolean" },
+					reason: { type: "string" },
+				},
+				required: ["index", "worthKeeping"],
+			},
+		},
+	},
+	required: ["verdicts"],
+});
+
+/** JSON schema string for the adjudication tier's structured output. */
+export const CONTINUITY_ADJUDICATION_SCHEMA = JSON.stringify({
+	type: "object",
+	properties: {
+		verdicts: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					index: { type: "number" },
+					isContradiction: { type: "boolean" },
+					confidence: { type: "string", enum: ["high", "medium", "low"] },
+					question: { type: "string" },
+					detail: { type: "string" },
+				},
+				required: ["index", "isContradiction", "confidence", "question"],
+			},
+		},
+	},
+	required: ["verdicts"],
+});

--- a/src/routes/campaigns/continuity-routes.ts
+++ b/src/routes/campaigns/continuity-routes.ts
@@ -1,0 +1,110 @@
+import type { OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute, z } from "@hono/zod-openapi";
+import type { Handler } from "hono";
+import type { RequestLogger } from "@/lib/logger";
+import { requireUserJwt } from "@/routes/auth";
+import {
+	handleGetContinuityFindings,
+	handleResolveContinuityFinding,
+	handleScanCampaignContinuity,
+} from "@/routes/continuity";
+import { ENDPOINTS } from "@/routes/endpoints";
+import type { Env } from "@/routes/env";
+import { toApiRoutePath } from "@/routes/env";
+import { CampaignIdParamSchema, ErrorSchema } from "@/routes/schemas/common";
+
+const ErrorResponses = {
+	400: {
+		content: { "application/json": { schema: ErrorSchema } },
+		description: "Bad request",
+	},
+	401: {
+		content: { "application/json": { schema: ErrorSchema } },
+		description: "Unauthorized",
+	},
+	403: {
+		content: { "application/json": { schema: ErrorSchema } },
+		description: "Forbidden",
+	},
+	404: {
+		content: { "application/json": { schema: ErrorSchema } },
+		description: "Not found",
+	},
+	500: {
+		content: { "application/json": { schema: ErrorSchema } },
+		description: "Internal server error",
+	},
+} as const;
+
+const CampaignIdFindingIdParams = z
+	.object({
+		campaignId: z
+			.string()
+			.openapi({ param: { name: "campaignId", in: "path" } }),
+		findingId: z.string().openapi({ param: { name: "findingId", in: "path" } }),
+	})
+	.openapi("CampaignIdFindingIdParams");
+
+const routeScanContinuity = createRoute({
+	method: "post",
+	path: toApiRoutePath(ENDPOINTS.CAMPAIGNS.CONTINUITY.SCAN("{campaignId}")),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	request: {
+		params: CampaignIdParamSchema,
+		body: { content: { "application/json": { schema: z.any() } } },
+	},
+	responses: {
+		200: { description: "Continuity scan completed" },
+		...ErrorResponses,
+	},
+});
+
+const routeGetContinuityFindings = createRoute({
+	method: "get",
+	path: toApiRoutePath(ENDPOINTS.CAMPAIGNS.CONTINUITY.FINDINGS("{campaignId}")),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	request: { params: CampaignIdParamSchema },
+	responses: {
+		200: { description: "Continuity findings list" },
+		...ErrorResponses,
+	},
+});
+
+const routeResolveContinuityFinding = createRoute({
+	method: "post",
+	path: toApiRoutePath(
+		ENDPOINTS.CAMPAIGNS.CONTINUITY.RESOLVE_FINDING(
+			"{campaignId}",
+			"{findingId}"
+		)
+	),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	request: {
+		params: CampaignIdFindingIdParams,
+		body: { content: { "application/json": { schema: z.any() } } },
+	},
+	responses: {
+		200: { description: "Continuity finding resolved" },
+		...ErrorResponses,
+	},
+});
+
+export function registerCampaignContinuityRoutes(
+	app: OpenAPIHono<{ Bindings: Env; Variables: { logger: RequestLogger } }>
+) {
+	app.openapi(
+		routeScanContinuity,
+		handleScanCampaignContinuity as unknown as Handler
+	);
+	app.openapi(
+		routeGetContinuityFindings,
+		handleGetContinuityFindings as unknown as Handler
+	);
+	app.openapi(
+		routeResolveContinuityFinding,
+		handleResolveContinuityFinding as unknown as Handler
+	);
+}

--- a/src/routes/campaigns/index.ts
+++ b/src/routes/campaigns/index.ts
@@ -2,6 +2,7 @@ import type { OpenAPIHono } from "@hono/zod-openapi";
 import type { RequestLogger } from "@/lib/logger";
 import type { Env } from "@/routes/env";
 import { registerCampaignCommunitiesRoutes } from "./communities-routes";
+import { registerCampaignContinuityRoutes } from "./continuity-routes";
 import { registerCampaignCoreRoutes } from "./core-routes";
 import { registerCampaignEntitiesRoutes } from "./entities-routes";
 import { registerCampaignGraphRebuildRoutes } from "./graph-rebuild-routes";
@@ -21,6 +22,7 @@ export function registerCampaignRoutes(
 	registerCampaignWorldStateRoutes(app);
 	registerCampaignSessionDigestsRoutes(app);
 	registerCampaignRunsheetRoutes(app);
+	registerCampaignContinuityRoutes(app);
 	registerCampaignEntitiesRoutes(app);
 	registerCampaignCommunitiesRoutes(app);
 	registerCampaignGraphragRoutes(app);

--- a/src/routes/continuity.ts
+++ b/src/routes/continuity.ts
@@ -1,0 +1,213 @@
+import { getDAOFactory } from "@/dao/dao-factory";
+import { CampaignAccessDeniedError } from "@/lib/errors";
+import {
+	type ContextWithAuth,
+	ensureCampaignAccess,
+	getUserAuth,
+	requireCanEdit,
+	requireParam,
+} from "@/lib/route-utils";
+import { ContinuityCheckerService } from "@/services/continuity/continuity-checker-service";
+import type {
+	ContinuityConfidence,
+	ContinuityFindingStatus,
+	ContinuityFindingType,
+	ContinuityResolutionAction,
+	ContinuityScanMode,
+} from "@/types/continuity";
+import { isContinuityFindingType, meetsConfidence } from "@/types/continuity";
+
+const RESOLUTION_ACTIONS = new Set(["confirm", "dismiss", "correct"]);
+const FINDING_STATUSES = new Set([
+	"open",
+	"confirmed",
+	"dismissed",
+	"corrected",
+]);
+const CONFIDENCE_LEVELS = new Set(["high", "medium", "low"]);
+
+/** Continuity is a GM tool end to end — players never see draft findings. */
+async function requireGmAccess(
+	c: ContextWithAuth,
+	campaignId: string
+): Promise<Response | null> {
+	const auth = getUserAuth(c);
+	const hasAccess = await ensureCampaignAccess(c, campaignId, auth.username);
+	if (!hasAccess) {
+		return c.json({ error: "Campaign not found" }, 404);
+	}
+	await requireCanEdit(c, campaignId);
+	return null;
+}
+
+function parseTypes(raw: unknown): ContinuityFindingType[] | undefined {
+	const values = Array.isArray(raw)
+		? raw
+		: typeof raw === "string" && raw.length > 0
+			? raw.split(",")
+			: null;
+	if (!values) return undefined;
+
+	const types = values
+		.map((value) => String(value).trim())
+		.filter(isContinuityFindingType);
+	return types.length > 0 ? types : undefined;
+}
+
+function handleError(c: ContextWithAuth, error: unknown, fallback: string) {
+	if (error instanceof CampaignAccessDeniedError) {
+		return c.json({ error: "Access denied" }, 403);
+	}
+	const message = error instanceof Error ? error.message : "Unknown error";
+	if (/not found/i.test(message)) {
+		return c.json({ error: message }, 404);
+	}
+	if (/requires|invalid|must/i.test(message)) {
+		return c.json({ error: message }, 400);
+	}
+	return c.json({ error: fallback, message }, 500);
+}
+
+/** POST /campaigns/:campaignId/continuity/scan */
+export async function handleScanCampaignContinuity(c: ContextWithAuth) {
+	try {
+		const campaignId = requireParam(c, "campaignId");
+		if (campaignId instanceof Response) return campaignId;
+		const denied = await requireGmAccess(c, campaignId);
+		if (denied) return denied;
+
+		if (!c.env.DB) {
+			return c.json({ error: "Database not configured" }, 500);
+		}
+
+		const body = (await c.req.json().catch(() => ({}))) as {
+			mode?: string;
+			types?: unknown;
+			maxCandidates?: number;
+			minConfidence?: string;
+		};
+
+		const service = new ContinuityCheckerService({
+			db: c.env.DB,
+			env: c.env as unknown as Record<string, unknown>,
+		});
+		const result = await service.scan(campaignId, {
+			mode: (body.mode === "full"
+				? "full"
+				: "incremental") as ContinuityScanMode,
+			types: parseTypes(body.types),
+			maxCandidates:
+				typeof body.maxCandidates === "number" ? body.maxCandidates : undefined,
+			minConfidence: CONFIDENCE_LEVELS.has(String(body.minConfidence))
+				? (body.minConfidence as ContinuityConfidence)
+				: undefined,
+		});
+
+		return c.json({ scan: result });
+	} catch (error) {
+		return handleError(c, error, "Failed to scan campaign continuity");
+	}
+}
+
+/** GET /campaigns/:campaignId/continuity/findings */
+export async function handleGetContinuityFindings(c: ContextWithAuth) {
+	try {
+		const campaignId = requireParam(c, "campaignId");
+		if (campaignId instanceof Response) return campaignId;
+		const denied = await requireGmAccess(c, campaignId);
+		if (denied) return denied;
+
+		const statusParam = c.req.query("status");
+		const status = FINDING_STATUSES.has(String(statusParam))
+			? (statusParam as ContinuityFindingStatus)
+			: "open";
+		const limitParam = Number.parseInt(c.req.query("limit") ?? "", 10);
+		const minConfidenceParam = c.req.query("minConfidence");
+		// Default to high only: the report is trusted precisely because it is quiet.
+		const minConfidence: ContinuityConfidence = CONFIDENCE_LEVELS.has(
+			String(minConfidenceParam)
+		)
+			? (minConfidenceParam as ContinuityConfidence)
+			: "high";
+
+		const daoFactory = getDAOFactory(c.env);
+		const findings =
+			await daoFactory.continuityFindingDAO.listFindingsForCampaign(
+				campaignId,
+				{
+					status,
+					types: parseTypes(c.req.query("types")),
+					limit: Number.isFinite(limitParam) ? limitParam : 50,
+				}
+			);
+		const visible = findings.filter((finding) =>
+			meetsConfidence(finding.confidence, minConfidence)
+		);
+
+		return c.json({
+			findings: visible,
+			total: findings.length,
+			status,
+			minConfidence,
+			openCount:
+				await daoFactory.continuityFindingDAO.countOpenFindings(campaignId),
+		});
+	} catch (error) {
+		return handleError(c, error, "Failed to list continuity findings");
+	}
+}
+
+/** POST /campaigns/:campaignId/continuity/findings/:findingId/resolve */
+export async function handleResolveContinuityFinding(c: ContextWithAuth) {
+	try {
+		const campaignId = requireParam(c, "campaignId");
+		if (campaignId instanceof Response) return campaignId;
+		const findingId = requireParam(c, "findingId");
+		if (findingId instanceof Response) return findingId;
+
+		const auth = getUserAuth(c);
+		const denied = await requireGmAccess(c, campaignId);
+		if (denied) return denied;
+
+		if (!c.env.DB) {
+			return c.json({ error: "Database not configured" }, 500);
+		}
+
+		const body = (await c.req.json()) as {
+			action?: string;
+			note?: string;
+			correctedEntityId?: string;
+			correctedStatus?: string;
+			campaignSessionId?: number;
+		};
+
+		if (!body.action || !RESOLUTION_ACTIONS.has(body.action)) {
+			return c.json(
+				{ error: "action must be one of: confirm, dismiss, correct" },
+				400
+			);
+		}
+
+		const service = new ContinuityCheckerService({
+			db: c.env.DB,
+			env: c.env as unknown as Record<string, unknown>,
+		});
+		const result = await service.resolveFinding(campaignId, findingId, {
+			action: body.action as ContinuityResolutionAction,
+			note: body.note ?? null,
+			resolvedBy: auth.username,
+			correction: {
+				entityId: body.correctedEntityId ?? null,
+				status: body.correctedStatus ?? null,
+				campaignSessionId: body.campaignSessionId ?? null,
+			},
+		});
+
+		return c.json({
+			finding: result.finding,
+			changelogEntryId: result.changelogEntryId,
+		});
+	} catch (error) {
+		return handleError(c, error, "Failed to resolve continuity finding");
+	}
+}

--- a/src/routes/endpoints.ts
+++ b/src/routes/endpoints.ts
@@ -125,6 +125,13 @@ export const ENDPOINTS = {
 			REJECT: (campaignId: string, digestId: string) =>
 				`/campaigns/${campaignId}/session-digests/${digestId}/reject`,
 		},
+		CONTINUITY: {
+			SCAN: (campaignId: string) => `/campaigns/${campaignId}/continuity/scan`,
+			FINDINGS: (campaignId: string) =>
+				`/campaigns/${campaignId}/continuity/findings`,
+			RESOLVE_FINDING: (campaignId: string, findingId: string) =>
+				`/campaigns/${campaignId}/continuity/findings/${findingId}/resolve`,
+		},
 		SESSION_DIGEST_TEMPLATES: {
 			BASE: (campaignId: string) =>
 				`/campaigns/${campaignId}/session-digest-templates`,

--- a/src/services/continuity/continuity-adjudication-service.ts
+++ b/src/services/continuity/continuity-adjudication-service.ts
@@ -1,0 +1,171 @@
+import {
+	CONTINUITY_ADJUDICATION_SCHEMA,
+	CONTINUITY_TRIAGE_SCHEMA,
+	formatContinuityAdjudicationPrompt,
+	formatContinuityTriagePrompt,
+} from "@/lib/prompts/continuity-prompts";
+import type { LLMProvider } from "@/services/llm/llm-provider";
+import { createProviderForTier } from "@/services/llm/llm-provider-utils";
+import type {
+	ContinuityCandidate,
+	ContinuityConfidence,
+} from "@/types/continuity";
+
+/**
+ * Candidates per triage call. Large enough that the shared instructions are
+ * amortised, small enough that the model keeps every item in view.
+ */
+const TRIAGE_BATCH_SIZE = 12;
+
+/** Adjudication batches stay small — this tier is asked to reason carefully. */
+const ADJUDICATION_BATCH_SIZE = 5;
+
+const TRIAGE_MAX_TOKENS = 2000;
+const ADJUDICATION_MAX_TOKENS = 3000;
+
+export interface AdjudicatedCandidate {
+	candidate: ContinuityCandidate;
+	confidence: ContinuityConfidence;
+	/** Refined GM-facing phrasing; falls back to the detector's question. */
+	question: string;
+	detail: string | null;
+}
+
+interface TriageVerdict {
+	index?: number;
+	worthKeeping?: boolean;
+	reason?: string;
+}
+
+interface AdjudicationVerdict {
+	index?: number;
+	isContradiction?: boolean;
+	confidence?: string;
+	question?: string;
+	detail?: string;
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+	const batches: T[][] = [];
+	for (let i = 0; i < items.length; i += size) {
+		batches.push(items.slice(i, i + size));
+	}
+	return batches;
+}
+
+function normalizeConfidence(value: unknown): ContinuityConfidence {
+	return value === "high" || value === "medium" || value === "low"
+		? value
+		: "low";
+}
+
+export interface ContinuityAdjudicationServiceOptions {
+	apiKey: string;
+	/** Injected in tests; production builds both tiers from MODEL_CONFIG. */
+	triageProvider?: LLMProvider;
+	adjudicationProvider?: LLMProvider;
+}
+
+/**
+ * The two model tiers of the continuity checker.
+ *
+ * Triage runs on PIPELINE_ANALYSIS (cheap) to shortlist; adjudication runs on
+ * PIPELINE_STRUCTURED (quality) only on survivors. That split is what keeps a
+ * scan affordable as campaign history grows.
+ */
+export class ContinuityAdjudicationService {
+	private readonly triageProvider: LLMProvider;
+	private readonly adjudicationProvider: LLMProvider;
+
+	constructor(options: ContinuityAdjudicationServiceOptions) {
+		this.triageProvider =
+			options.triageProvider ??
+			createProviderForTier({
+				apiKey: options.apiKey,
+				tier: "PIPELINE_ANALYSIS",
+				temperature: 0,
+				maxTokens: TRIAGE_MAX_TOKENS,
+			});
+		this.adjudicationProvider =
+			options.adjudicationProvider ??
+			createProviderForTier({
+				apiKey: options.apiKey,
+				tier: "PIPELINE_STRUCTURED",
+				temperature: 0.1,
+				maxTokens: ADJUDICATION_MAX_TOKENS,
+			});
+	}
+
+	/**
+	 * Cheap shortlist. A failed batch is dropped rather than passed through:
+	 * an unreviewed candidate reaching the GM is the failure mode this whole
+	 * feature is designed to avoid.
+	 */
+	async triage(
+		candidates: ContinuityCandidate[]
+	): Promise<ContinuityCandidate[]> {
+		if (candidates.length === 0) return [];
+
+		const kept: ContinuityCandidate[] = [];
+		for (const batch of chunk(candidates, TRIAGE_BATCH_SIZE)) {
+			try {
+				const result = await this.triageProvider.generateStructuredOutput<{
+					verdicts?: TriageVerdict[];
+				}>(formatContinuityTriagePrompt(batch), {
+					temperature: 0,
+					maxTokens: TRIAGE_MAX_TOKENS,
+					schema: CONTINUITY_TRIAGE_SCHEMA,
+				});
+
+				for (const verdict of result.verdicts ?? []) {
+					const candidate = batch[verdict.index ?? -1];
+					if (candidate && verdict.worthKeeping === true) {
+						kept.push(candidate);
+					}
+				}
+			} catch (_error) {
+				// Drop the batch. Silence beats an unvetted finding.
+			}
+		}
+		return kept;
+	}
+
+	/**
+	 * Quality pass. Returns only candidates the model calls a real
+	 * contradiction, with the confidence and GM-facing phrasing it chose.
+	 */
+	async adjudicate(
+		candidates: ContinuityCandidate[]
+	): Promise<AdjudicatedCandidate[]> {
+		if (candidates.length === 0) return [];
+
+		const adjudicated: AdjudicatedCandidate[] = [];
+		for (const batch of chunk(candidates, ADJUDICATION_BATCH_SIZE)) {
+			try {
+				const result =
+					await this.adjudicationProvider.generateStructuredOutput<{
+						verdicts?: AdjudicationVerdict[];
+					}>(formatContinuityAdjudicationPrompt(batch), {
+						temperature: 0.1,
+						maxTokens: ADJUDICATION_MAX_TOKENS,
+						schema: CONTINUITY_ADJUDICATION_SCHEMA,
+					});
+
+				for (const verdict of result.verdicts ?? []) {
+					const candidate = batch[verdict.index ?? -1];
+					if (!candidate || verdict.isContradiction !== true) continue;
+
+					adjudicated.push({
+						candidate,
+						confidence: normalizeConfidence(verdict.confidence),
+						question: verdict.question?.trim() || candidate.question,
+						detail: verdict.detail?.trim() || null,
+					});
+				}
+			} catch (_error) {
+				// Same policy as triage: a batch we could not adjudicate is dropped.
+			}
+		}
+		return adjudicated;
+	}
+}

--- a/src/services/continuity/continuity-checker-service.ts
+++ b/src/services/continuity/continuity-checker-service.ts
@@ -1,0 +1,374 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { generateId } from "ai";
+import { getDAOFactory } from "@/dao/dao-factory";
+import { RulesContextService } from "@/services/campaign/rules-context-service";
+import { WorldStateChangelogService } from "@/services/graph/world-state-changelog-service";
+import { getDefaultProviderApiKey } from "@/services/llm/llm-provider-utils";
+import {
+	CONTINUITY_FINDING_TYPES,
+	type ContinuityCandidate,
+	type ContinuityFinding,
+	type ContinuityFindingType,
+	type ContinuityResolutionAction,
+	type ContinuityScanMode,
+	type ContinuityScanOptions,
+	type ContinuityScanResult,
+	meetsConfidence,
+} from "@/types/continuity";
+import type { WorldStateChangelogPayload } from "@/types/world-state";
+import {
+	type AdjudicatedCandidate,
+	ContinuityAdjudicationService,
+} from "./continuity-adjudication-service";
+import {
+	type ContinuityCorpus,
+	loadContinuityCorpus,
+} from "./continuity-corpus";
+import { detectDanglingThreads } from "./detect-dangling-threads";
+import { detectRelationshipContradictions } from "./detect-relationship-contradictions";
+import { detectRulesContradictions } from "./detect-rules-contradictions";
+import { detectStateContradictions } from "./detect-state-contradictions";
+import { detectTimelineContradictions } from "./detect-timeline-contradictions";
+
+/** Default ceiling on candidates sent to the model tiers in one scan. */
+const DEFAULT_MAX_CANDIDATES = 60;
+
+/**
+ * Order used when the candidate cap bites. State contradictions are the
+ * findings GMs act on most, dangling threads the most tolerant of waiting.
+ */
+const TYPE_PRIORITY: Record<ContinuityFindingType, number> = {
+	state_contradiction: 0,
+	relationship_contradiction: 1,
+	timeline_contradiction: 2,
+	rules_contradiction: 3,
+	dangling_thread: 4,
+};
+
+/**
+ * Dangling threads are not contradictions, so they skip the quality tier —
+ * triage alone is enough for a planning prompt, and this keeps the expensive
+ * model reserved for actual conflicts.
+ */
+const TRIAGE_ONLY_TYPES = new Set<ContinuityFindingType>(["dangling_thread"]);
+
+export interface ContinuityCheckerServiceOptions {
+	db: D1Database;
+	env?: Record<string, unknown>;
+	/** Injected in tests. Production resolves the provider API key from env. */
+	adjudicationService?: ContinuityAdjudicationService;
+}
+
+export interface ResolveFindingInput {
+	action: ContinuityResolutionAction;
+	note?: string | null;
+	resolvedBy?: string | null;
+	/** Required for "correct": the world state value to write back. */
+	correction?: {
+		entityId?: string | null;
+		status?: string | null;
+		campaignSessionId?: number | null;
+	};
+}
+
+export interface ResolveFindingResult {
+	finding: ContinuityFinding;
+	/** Set when a correction wrote a world state changelog entry. */
+	changelogEntryId: string | null;
+}
+
+function sortCandidates(
+	candidates: ContinuityCandidate[]
+): ContinuityCandidate[] {
+	return [...candidates].sort((left, right) => {
+		const byType = TYPE_PRIORITY[left.type] - TYPE_PRIORITY[right.type];
+		if (byType !== 0) return byType;
+		return (right.laterSession ?? -1) - (left.laterSession ?? -1);
+	});
+}
+
+export class ContinuityCheckerService {
+	private readonly db: D1Database;
+	private readonly env: Record<string, unknown>;
+	private readonly injectedAdjudicationService?: ContinuityAdjudicationService;
+
+	constructor(options: ContinuityCheckerServiceOptions) {
+		this.db = options.db;
+		this.env = options.env ?? {};
+		this.injectedAdjudicationService = options.adjudicationService;
+	}
+
+	/**
+	 * Scan a campaign for continuity findings.
+	 *
+	 * Incremental scans (the default) only consider sessions newer than the
+	 * last watermark as the *later* side of a contradiction, so routine checks
+	 * cost O(new sessions) rather than O(campaign history).
+	 */
+	async scan(
+		campaignId: string,
+		options: ContinuityScanOptions = {}
+	): Promise<ContinuityScanResult> {
+		const scanId = generateId();
+		const mode: ContinuityScanMode = options.mode ?? "incremental";
+		const maxCandidates = options.maxCandidates ?? DEFAULT_MAX_CANDIDATES;
+		const warnings: string[] = [];
+
+		const dao = getDAOFactory({ DB: this.db }).continuityFindingDAO;
+		const scanState = await dao.getScanState(campaignId);
+		const fromSession =
+			mode === "full" || scanState?.lastScannedSession == null
+				? null
+				: scanState.lastScannedSession + 1;
+
+		const corpus = await loadContinuityCorpus(this.db, campaignId);
+		const generated = await this.generateCandidates(
+			corpus,
+			campaignId,
+			options.types,
+			fromSession
+		);
+
+		const known = await dao.getKnownFingerprints(campaignId);
+		const unseen = sortCandidates(
+			generated.filter((candidate) => !known.has(candidate.fingerprint))
+		);
+		const truncated = unseen.length > maxCandidates;
+		const selected = unseen.slice(0, maxCandidates);
+
+		const adjudicated = await this.review(selected, warnings);
+		const minConfidence = options.minConfidence ?? "low";
+		const persistable = adjudicated.filter((item) =>
+			meetsConfidence(item.confidence, minConfidence)
+		);
+
+		const findings = await this.persist(campaignId, scanId, persistable);
+
+		await dao.recordScan({
+			campaignId,
+			scanId,
+			mode,
+			lastScannedSession: corpus.maxSessionNumber,
+		});
+
+		if (truncated) {
+			warnings.push(
+				`Candidate cap of ${maxCandidates} reached; ${unseen.length - maxCandidates} candidate(s) were not reviewed this run.`
+			);
+		}
+
+		return {
+			scanId,
+			campaignId,
+			mode,
+			scannedFromSession: fromSession,
+			scannedToSession: corpus.maxSessionNumber,
+			candidatesGenerated: generated.length,
+			candidatesAlreadyKnown: generated.length - unseen.length,
+			candidatesTriaged: selected.length,
+			candidatesAdjudicated: adjudicated.length,
+			findingsCreated: findings.length,
+			findings,
+			truncated,
+			warnings,
+		};
+	}
+
+	/** Run the deterministic detectors for the requested finding types. */
+	private async generateCandidates(
+		corpus: ContinuityCorpus,
+		campaignId: string,
+		types: ContinuityFindingType[] | undefined,
+		fromSession: number | null
+	): Promise<ContinuityCandidate[]> {
+		const requested = new Set(types?.length ? types : CONTINUITY_FINDING_TYPES);
+		const detectorOptions = { fromSession };
+		const candidates: ContinuityCandidate[] = [];
+
+		if (requested.has("state_contradiction")) {
+			candidates.push(...detectStateContradictions(corpus, detectorOptions));
+		}
+		if (requested.has("relationship_contradiction")) {
+			candidates.push(
+				...detectRelationshipContradictions(corpus, detectorOptions)
+			);
+		}
+		if (requested.has("timeline_contradiction")) {
+			candidates.push(...detectTimelineContradictions(corpus, detectorOptions));
+		}
+		if (requested.has("dangling_thread")) {
+			candidates.push(...detectDanglingThreads(corpus, detectorOptions));
+		}
+		if (requested.has("rules_contradiction")) {
+			const rules = await RulesContextService.getActiveRulesForCampaign(
+				{ DB: this.db, ...this.env },
+				campaignId
+			);
+			candidates.push(
+				...detectRulesContradictions(corpus, rules, detectorOptions)
+			);
+		}
+
+		return candidates;
+	}
+
+	/** Triage everything, then adjudicate only the types that warrant it. */
+	private async review(
+		candidates: ContinuityCandidate[],
+		warnings: string[]
+	): Promise<AdjudicatedCandidate[]> {
+		if (candidates.length === 0) return [];
+
+		const service = await this.getAdjudicationService();
+		if (!service) {
+			warnings.push(
+				"No LLM provider API key configured; continuity scan produced no findings."
+			);
+			return [];
+		}
+
+		const survivors = await service.triage(candidates);
+		const triageOnly = survivors.filter((candidate) =>
+			TRIAGE_ONLY_TYPES.has(candidate.type)
+		);
+		const forAdjudication = survivors.filter(
+			(candidate) => !TRIAGE_ONLY_TYPES.has(candidate.type)
+		);
+
+		const adjudicated = await service.adjudicate(forAdjudication);
+		return [
+			...adjudicated,
+			...triageOnly.map((candidate) => ({
+				candidate,
+				confidence: "medium" as const,
+				question: candidate.question,
+				detail: candidate.rationale,
+			})),
+		];
+	}
+
+	private async getAdjudicationService(): Promise<ContinuityAdjudicationService | null> {
+		if (this.injectedAdjudicationService) {
+			return this.injectedAdjudicationService;
+		}
+		try {
+			const apiKey = await getDefaultProviderApiKey(this.env);
+			if (!apiKey) return null;
+			return new ContinuityAdjudicationService({ apiKey });
+		} catch (_error) {
+			return null;
+		}
+	}
+
+	/** Write surviving findings, skipping fingerprints already on record. */
+	private async persist(
+		campaignId: string,
+		scanId: string,
+		items: AdjudicatedCandidate[]
+	): Promise<ContinuityFinding[]> {
+		const dao = getDAOFactory({ DB: this.db }).continuityFindingDAO;
+		const created: ContinuityFinding[] = [];
+
+		for (const item of items) {
+			const id = generateId();
+			const inserted = await dao.createFinding({
+				id,
+				campaignId,
+				fingerprint: item.candidate.fingerprint,
+				findingType: item.candidate.type,
+				confidence: item.confidence,
+				question: item.question,
+				detail: item.detail,
+				evidence: item.candidate.evidence,
+				subjectEntityId: item.candidate.subjectEntityId,
+				subjectName: item.candidate.subjectName,
+				scanId,
+			});
+			if (!inserted) continue;
+
+			const finding = await dao.getFindingById(id);
+			if (finding) created.push(finding);
+		}
+
+		return created;
+	}
+
+	/**
+	 * Record the GM's adjudication. `correct` additionally writes the corrected
+	 * value back to world state as a changelog entry, so the fix flows into the
+	 * graph on the next rebuild rather than living only in the report.
+	 */
+	async resolveFinding(
+		campaignId: string,
+		findingId: string,
+		input: ResolveFindingInput
+	): Promise<ResolveFindingResult> {
+		const dao = getDAOFactory({ DB: this.db }).continuityFindingDAO;
+		const existing = await dao.getFindingById(findingId);
+		if (!existing || existing.campaignId !== campaignId) {
+			throw new Error("Continuity finding not found");
+		}
+
+		let changelogEntryId: string | null = null;
+		if (input.action === "correct") {
+			changelogEntryId = await this.writeCorrection(
+				campaignId,
+				existing,
+				input
+			);
+		}
+
+		const status =
+			input.action === "confirm"
+				? "confirmed"
+				: input.action === "dismiss"
+					? "dismissed"
+					: "corrected";
+
+		await dao.updateFindingStatus(findingId, status, {
+			resolutionNote: input.note ?? null,
+			resolvedBy: input.resolvedBy ?? null,
+		});
+
+		const finding = await dao.getFindingById(findingId);
+		if (!finding) {
+			throw new Error("Continuity finding not found after update");
+		}
+		return { finding, changelogEntryId };
+	}
+
+	private async writeCorrection(
+		campaignId: string,
+		finding: ContinuityFinding,
+		input: ResolveFindingInput
+	): Promise<string> {
+		const entityId = input.correction?.entityId ?? finding.subjectEntityId;
+		const status = input.correction?.status?.trim();
+		if (!entityId || !status) {
+			throw new Error(
+				"A correction requires an entity id and a corrected status"
+			);
+		}
+
+		const payload: WorldStateChangelogPayload = {
+			campaign_session_id: input.correction?.campaignSessionId ?? null,
+			timestamp: new Date().toISOString(),
+			entity_updates: [
+				{
+					entity_id: entityId,
+					status,
+					source: "continuity_correction",
+					continuity_finding_id: finding.id,
+					note: input.note ?? null,
+				},
+			],
+			relationship_updates: [],
+			new_entities: [],
+		};
+
+		const entry = await new WorldStateChangelogService({
+			db: this.db,
+		}).recordChangelog(campaignId, payload);
+		return entry.id;
+	}
+}

--- a/src/services/continuity/continuity-corpus.ts
+++ b/src/services/continuity/continuity-corpus.ts
@@ -1,0 +1,226 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { getDAOFactory } from "@/dao/dao-factory";
+import { WorldStateChangelogDAO } from "@/dao/world-state-changelog-dao";
+import type { SessionDigestData } from "@/types/session-digest";
+import type { WorldStateChangelogPayload } from "@/types/world-state";
+import { isMatchableName } from "./continuity-text-utils";
+
+/** Max entities loaded for name matching. Long campaigns stay bounded. */
+const MAX_ENTITIES = 2000;
+
+/** A named slice of digest prose, so evidence can say *where* the match was. */
+export interface DigestTextBlock {
+	field: string;
+	text: string;
+}
+
+export interface CorpusDigest {
+	id: string;
+	sessionNumber: number;
+	sessionDate: string | null;
+	createdAt: string;
+	data: SessionDigestData;
+	/** Every searchable string in the digest, tagged by originating field. */
+	blocks: DigestTextBlock[];
+}
+
+export interface CorpusChangelogEntry {
+	id: string;
+	sessionNumber: number | null;
+	timestamp: string;
+	payload: WorldStateChangelogPayload;
+}
+
+/**
+ * Everything the detectors need, loaded once per scan.
+ *
+ * Holding this in memory is what keeps detection out of the combinatorial
+ * regime the issue warns about: each detector walks the corpus linearly rather
+ * than issuing a query per entity/digest pair.
+ */
+export interface ContinuityCorpus {
+	campaignId: string;
+	/** Ascending by session number. */
+	digests: CorpusDigest[];
+	/** Ascending by timestamp. */
+	changelog: CorpusChangelogEntry[];
+	/** Entity id → display name, including ids only seen in the changelog. */
+	entityNames: Map<string, string>;
+	/** Adjacency from the entity graph, used to narrow candidate pairs. */
+	neighbors: Map<string, Set<string>>;
+	maxSessionNumber: number | null;
+}
+
+/** Pull every searchable string out of a digest, tagged with its field name. */
+export function digestTextBlocks(data: SessionDigestData): DigestTextBlock[] {
+	const recap = data.last_session_recap;
+	const plan = data.next_session_plan;
+	const groups: Array<[string, string[]]> = [
+		["key_events", recap.key_events],
+		["open_threads", recap.open_threads],
+		["state_changes.npcs", recap.state_changes.npcs],
+		["state_changes.factions", recap.state_changes.factions],
+		["state_changes.locations", recap.state_changes.locations],
+		["next_session_plan.beats", plan.beats],
+		["next_session_plan.objectives_dm", plan.objectives_dm],
+		["next_session_plan.probable_player_goals", plan.probable_player_goals],
+		["next_session_plan.if_then_branches", plan.if_then_branches],
+		["npcs_to_run", data.npcs_to_run],
+		["locations_in_focus", data.locations_in_focus],
+		["encounter_seeds", data.encounter_seeds],
+		["clues_and_revelations", data.clues_and_revelations],
+		["treasure_and_rewards", data.treasure_and_rewards],
+	];
+
+	const blocks: DigestTextBlock[] = [];
+	for (const [field, values] of groups) {
+		for (const value of values ?? []) {
+			const text = typeof value === "string" ? value.trim() : "";
+			if (text) blocks.push({ field, text });
+		}
+	}
+	return blocks;
+}
+
+/**
+ * Recover a display name from a campaign-scoped entity id.
+ *
+ * Changelog payloads normalize ids to `<campaignId>_<entityName>` (see
+ * WorldStateChangelogService), so entities the graph has not yet materialized
+ * are still nameable — and therefore still checkable.
+ */
+export function nameFromEntityId(
+	campaignId: string,
+	entityId: string
+): string | null {
+	if (!entityId) return null;
+	const bare = entityId.startsWith(`${campaignId}_`)
+		? entityId.slice(campaignId.length + 1)
+		: entityId;
+	const name = bare.replace(/[_-]+/g, " ").trim();
+	return name.length > 0 ? name : null;
+}
+
+function registerName(
+	names: Map<string, string>,
+	entityId: string | undefined,
+	name: string | null | undefined
+): void {
+	if (!entityId || !name) return;
+	if (names.has(entityId)) return;
+	if (!isMatchableName(name)) return;
+	names.set(entityId, name.trim());
+}
+
+async function loadEntityNames(
+	db: D1Database,
+	campaignId: string,
+	changelog: CorpusChangelogEntry[]
+): Promise<Map<string, string>> {
+	const names = new Map<string, string>();
+
+	const entities = await getDAOFactory({
+		DB: db,
+	}).entityDAO.listEntitiesGraphProjectionByCampaign(campaignId, {
+		limit: MAX_ENTITIES,
+	});
+	for (const entity of entities) {
+		registerName(names, entity.id, entity.name);
+	}
+
+	// Changelog-only ids: the graph may lag behind world state updates, and a
+	// contradiction about an un-materialized entity is still a contradiction.
+	for (const entry of changelog) {
+		for (const created of entry.payload.new_entities ?? []) {
+			registerName(
+				names,
+				created.entity_id,
+				created.name ?? nameFromEntityId(campaignId, created.entity_id)
+			);
+		}
+		for (const update of entry.payload.entity_updates ?? []) {
+			registerName(
+				names,
+				update.entity_id,
+				nameFromEntityId(campaignId, update.entity_id)
+			);
+		}
+	}
+
+	return names;
+}
+
+async function loadNeighbors(
+	db: D1Database,
+	campaignId: string
+): Promise<Map<string, Set<string>>> {
+	const neighbors = new Map<string, Set<string>>();
+	const edges = await getDAOFactory({
+		DB: db,
+	}).entityDAO.getGraphRelationshipEdgesForCampaign(campaignId);
+
+	const link = (from: string, to: string) => {
+		const existing = neighbors.get(from);
+		if (existing) {
+			existing.add(to);
+			return;
+		}
+		neighbors.set(from, new Set([to]));
+	};
+
+	for (const edge of edges) {
+		link(edge.fromEntityId, edge.toEntityId);
+		link(edge.toEntityId, edge.fromEntityId);
+	}
+	return neighbors;
+}
+
+/** Load the digests, changelog and graph a scan needs, in three queries. */
+export async function loadContinuityCorpus(
+	db: D1Database,
+	campaignId: string
+): Promise<ContinuityCorpus> {
+	const daoFactory = getDAOFactory({ DB: db });
+	const [digestRows, changelogRows] = await Promise.all([
+		daoFactory.sessionDigestDAO.getSessionDigestsByCampaign(campaignId),
+		new WorldStateChangelogDAO(db).listEntriesForCampaign(campaignId),
+	]);
+
+	const digests: CorpusDigest[] = digestRows
+		.map((digest) => ({
+			id: digest.id,
+			sessionNumber: digest.sessionNumber,
+			sessionDate: digest.sessionDate,
+			createdAt: digest.createdAt,
+			data: digest.digestData,
+			blocks: digestTextBlocks(digest.digestData),
+		}))
+		.sort((left, right) => left.sessionNumber - right.sessionNumber);
+
+	const changelog: CorpusChangelogEntry[] = changelogRows
+		.map((entry) => ({
+			id: entry.id,
+			sessionNumber: entry.campaignSessionId,
+			timestamp: entry.timestamp,
+			payload: entry.payload,
+		}))
+		.sort((left, right) => left.timestamp.localeCompare(right.timestamp));
+
+	const [entityNames, neighbors] = await Promise.all([
+		loadEntityNames(db, campaignId, changelog),
+		loadNeighbors(db, campaignId),
+	]);
+
+	const maxSessionNumber = digests.length
+		? digests[digests.length - 1].sessionNumber
+		: null;
+
+	return {
+		campaignId,
+		digests,
+		changelog,
+		entityNames,
+		neighbors,
+		maxSessionNumber,
+	};
+}

--- a/src/services/continuity/continuity-text-utils.ts
+++ b/src/services/continuity/continuity-text-utils.ts
@@ -1,0 +1,220 @@
+/**
+ * Pure text helpers shared by the continuity detectors.
+ *
+ * Everything here is deterministic and cheap on purpose: the detectors run over
+ * the whole corpus before a single model token is spent, so any work done here
+ * is work the LLM tiers never have to pay for.
+ */
+
+/** Words that are too generic to treat as an entity mention on their own. */
+const AMBIGUOUS_SINGLE_WORD_NAMES = new Set([
+	"the",
+	"party",
+	"group",
+	"town",
+	"city",
+	"village",
+	"king",
+	"queen",
+	"guard",
+	"guards",
+	"inn",
+	"tavern",
+	"temple",
+	"keep",
+	"castle",
+	"forest",
+	"north",
+	"south",
+	"east",
+	"west",
+	"council",
+	"order",
+	"guild",
+	"church",
+	"crown",
+	"empire",
+	"kingdom",
+]);
+
+/** Single-word names shorter than this are ignored — too collision-prone. */
+const MIN_SINGLE_WORD_NAME_LENGTH = 4;
+
+const STOP_WORDS = new Set([
+	"a",
+	"about",
+	"after",
+	"all",
+	"an",
+	"and",
+	"are",
+	"as",
+	"at",
+	"be",
+	"been",
+	"before",
+	"but",
+	"by",
+	"can",
+	"did",
+	"do",
+	"for",
+	"from",
+	"had",
+	"has",
+	"have",
+	"he",
+	"her",
+	"him",
+	"his",
+	"how",
+	"i",
+	"if",
+	"in",
+	"into",
+	"is",
+	"it",
+	"its",
+	"of",
+	"on",
+	"or",
+	"our",
+	"out",
+	"over",
+	"she",
+	"so",
+	"some",
+	"that",
+	"the",
+	"their",
+	"them",
+	"then",
+	"there",
+	"these",
+	"they",
+	"this",
+	"to",
+	"up",
+	"was",
+	"we",
+	"were",
+	"what",
+	"when",
+	"where",
+	"which",
+	"who",
+	"will",
+	"with",
+	"you",
+	"your",
+]);
+
+/** Escape a literal string for safe inclusion in a RegExp. */
+export function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Names we are willing to search for in free text. Rejecting weak names up
+ * front is the cheapest false-positive control the checker has.
+ */
+export function isMatchableName(name: string): boolean {
+	const trimmed = name.trim();
+	if (trimmed.length === 0) return false;
+
+	const words = trimmed.split(/\s+/);
+	if (words.length > 1) return true;
+
+	if (trimmed.length < MIN_SINGLE_WORD_NAME_LENGTH) return false;
+	return !AMBIGUOUS_SINGLE_WORD_NAMES.has(trimmed.toLowerCase());
+}
+
+/**
+ * Whole-word, case-insensitive containment check.
+ *
+ * Uses lookaround rather than `\b` so names ending in punctuation (e.g.
+ * "Vane's") and names containing apostrophes still match correctly.
+ */
+export function mentionsName(text: string, name: string): boolean {
+	if (!text || !isMatchableName(name)) return false;
+	const pattern = new RegExp(
+		`(?<![\\p{L}\\p{N}])${escapeRegExp(name.trim())}(?![\\p{L}\\p{N}])`,
+		"iu"
+	);
+	return pattern.test(text);
+}
+
+/** First text in `texts` that mentions `name`, or null. */
+export function findMention(texts: string[], name: string): string | null {
+	for (const text of texts) {
+		if (mentionsName(text, name)) return text;
+	}
+	return null;
+}
+
+/** Lowercased content words, used for cheap overlap scoring. */
+export function contentTokens(text: string): Set<string> {
+	const tokens = text
+		.toLowerCase()
+		.replace(/[^\p{L}\p{N}\s]/gu, " ")
+		.split(/\s+/)
+		.filter((token) => token.length > 2 && !STOP_WORDS.has(token));
+	return new Set(tokens);
+}
+
+/**
+ * Jaccard-style overlap between two texts, in [0, 1].
+ * Used to decide whether a later digest plausibly resolves an open thread.
+ */
+export function tokenOverlap(left: string, right: string): number {
+	const leftTokens = contentTokens(left);
+	const rightTokens = contentTokens(right);
+	if (leftTokens.size === 0 || rightTokens.size === 0) return 0;
+
+	let shared = 0;
+	for (const token of leftTokens) {
+		if (rightTokens.has(token)) shared += 1;
+	}
+	return shared / Math.min(leftTokens.size, rightTokens.size);
+}
+
+/** Trim an excerpt to a bounded length without cutting mid-word. */
+export function toExcerpt(text: string, maxLength = 240): string {
+	const normalized = text.replace(/\s+/g, " ").trim();
+	if (normalized.length <= maxLength) return normalized;
+	const truncated = normalized.slice(0, maxLength);
+	const lastSpace = truncated.lastIndexOf(" ");
+	return `${lastSpace > maxLength / 2 ? truncated.slice(0, lastSpace) : truncated}…`;
+}
+
+/**
+ * Stable 32-bit FNV-1a hash rendered as hex. Deterministic across runs and
+ * platforms, which is what makes fingerprints — and therefore dismissals —
+ * survive redeploys.
+ */
+export function stableHash(value: string): string {
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < value.length; i++) {
+		hash ^= value.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193) >>> 0;
+	}
+	return hash.toString(16).padStart(8, "0");
+}
+
+/**
+ * Build the fingerprint that dedupes a finding across scans.
+ *
+ * Parts are normalized so cosmetic changes (casing, whitespace) do not create a
+ * "new" finding the GM has already dismissed.
+ */
+export function buildFingerprint(type: string, parts: unknown[]): string {
+	const canonical = [type, ...parts]
+		.map((part) =>
+			String(part ?? "")
+				.toLowerCase()
+				.replace(/\s+/g, " ")
+				.trim()
+		)
+		.join("|");
+	return `${type}:${stableHash(canonical)}`;
+}

--- a/src/services/continuity/continuity-vocabulary.ts
+++ b/src/services/continuity/continuity-vocabulary.ts
@@ -1,0 +1,154 @@
+/**
+ * Status vocabularies used to read free-text world state into coarse buckets.
+ *
+ * World state statuses are written by the extraction pipeline, not by a fixed
+ * enum, so the detectors match on keywords. Buckets are deliberately coarse:
+ * their job is to *narrow candidates*, and the model tiers decide what is
+ * actually a contradiction.
+ */
+
+/** Statuses meaning the subject is permanently removed from play. */
+const REMOVED_KEYWORDS = [
+	"dead",
+	"deceased",
+	"died",
+	"dies",
+	"killed",
+	"slain",
+	"murdered",
+	"executed",
+	"destroyed",
+	"razed",
+	"demolished",
+	"annihilated",
+	"disbanded",
+	"dissolved",
+	"obliterated",
+];
+
+/** Statuses meaning the subject is absent but could plausibly return. */
+const ABSENT_KEYWORDS = [
+	"departed",
+	"left",
+	"gone",
+	"missing",
+	"vanished",
+	"disappeared",
+	"exiled",
+	"banished",
+	"imprisoned",
+	"captured",
+	"abducted",
+	"fled",
+	"petrified",
+	"comatose",
+	"unconscious",
+];
+
+/** Statuses that explicitly undo a removal or absence. */
+const RESTORED_KEYWORDS = [
+	"alive",
+	"revived",
+	"resurrected",
+	"reborn",
+	"returned",
+	"rebuilt",
+	"restored",
+	"escaped",
+	"freed",
+	"released",
+	"rescued",
+	"reformed",
+	"recovered",
+];
+
+const ALLIED_KEYWORDS = [
+	"ally",
+	"allied",
+	"alliance",
+	"friendly",
+	"friend",
+	"peace",
+	"peaceful",
+	"truce",
+	"cooperative",
+	"trusted",
+	"supportive",
+	"pact",
+];
+
+const HOSTILE_KEYWORDS = [
+	"hostile",
+	"enemy",
+	"enemies",
+	"war",
+	"at war",
+	"rival",
+	"feud",
+	"betrayed",
+	"betrayal",
+	"opposed",
+	"antagonistic",
+	"vendetta",
+	"hunted",
+];
+
+export type EntityStatusBucket = "removed" | "absent" | "restored" | "other";
+export type RelationshipPolarity = "allied" | "hostile" | "neutral";
+
+function matchesAny(value: string, keywords: string[]): boolean {
+	const normalized = value.toLowerCase();
+	return keywords.some((keyword) =>
+		new RegExp(`(?<![\\p{L}])${keyword}(?![\\p{L}])`, "u").test(normalized)
+	);
+}
+
+/**
+ * Bucket a free-text entity status.
+ *
+ * `restored` is checked first: "resurrected but still legally dead" should read
+ * as restored, and a status mentioning both is far more likely to be a return
+ * than a fresh death.
+ */
+export function classifyEntityStatus(
+	status: string | undefined | null
+): EntityStatusBucket {
+	if (!status) return "other";
+	if (matchesAny(status, RESTORED_KEYWORDS)) return "restored";
+	if (matchesAny(status, REMOVED_KEYWORDS)) return "removed";
+	if (matchesAny(status, ABSENT_KEYWORDS)) return "absent";
+	return "other";
+}
+
+export function classifyRelationshipStatus(
+	status: string | undefined | null
+): RelationshipPolarity {
+	if (!status) return "neutral";
+	if (matchesAny(status, HOSTILE_KEYWORDS)) return "hostile";
+	if (matchesAny(status, ALLIED_KEYWORDS)) return "allied";
+	return "neutral";
+}
+
+/** Phrases that mark a sentence as a table ruling rather than narration. */
+const RULING_MARKERS = [
+	"house rule",
+	"houserule",
+	"we ruled",
+	"i ruled",
+	"ruled that",
+	"we decided",
+	"table rule",
+	"from now on",
+	"going forward",
+	"rule change",
+	"we agreed",
+	"errata",
+	"we're using",
+	"we are using",
+];
+
+/** True when a digest line reads like a ruling the table made. */
+export function looksLikeRuling(text: string): boolean {
+	const normalized = text.toLowerCase();
+	return RULING_MARKERS.some((marker) => normalized.includes(marker));
+}

--- a/src/services/continuity/detect-dangling-threads.ts
+++ b/src/services/continuity/detect-dangling-threads.ts
@@ -1,0 +1,121 @@
+import type { ContinuityCandidate } from "@/types/continuity";
+import type { ContinuityCorpus, CorpusDigest } from "./continuity-corpus";
+import {
+	buildFingerprint,
+	toExcerpt,
+	tokenOverlap,
+} from "./continuity-text-utils";
+
+/**
+ * Overlap above which a later digest line is taken to be the same thread.
+ * Tuned to be forgiving: wrongly treating a thread as resolved is a silent
+ * miss, which is far cheaper than nagging a GM about a thread they closed.
+ */
+const RESOLUTION_OVERLAP_THRESHOLD = 0.5;
+
+/**
+ * Sessions a thread must survive before it is worth mentioning. A hook left
+ * open for one session is just next week's plot.
+ */
+const MIN_SESSIONS_DANGLING = 2;
+
+/** Threads shorter than this are labels, not hooks, and score badly on overlap. */
+const MIN_THREAD_LENGTH = 12;
+
+function laterDigests(
+	corpus: ContinuityCorpus,
+	afterSession: number
+): CorpusDigest[] {
+	return corpus.digests.filter((digest) => digest.sessionNumber > afterSession);
+}
+
+/** True when some later digest line plainly covers the same ground. */
+function looksResolved(
+	corpus: ContinuityCorpus,
+	thread: string,
+	sessionNumber: number
+): boolean {
+	for (const digest of laterDigests(corpus, sessionNumber)) {
+		for (const block of digest.blocks) {
+			if (tokenOverlap(thread, block.text) >= RESOLUTION_OVERLAP_THRESHOLD) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+/**
+ * Hooks introduced and never picked up again.
+ *
+ * Not an error — the issue calls this "the report a GM most wants before
+ * planning the next session" — so the phrasing stays neutral and these are the
+ * one finding type that never claims something is wrong.
+ */
+export function detectDanglingThreads(
+	corpus: ContinuityCorpus,
+	options: { fromSession: number | null } = { fromSession: null }
+): ContinuityCandidate[] {
+	const maxSession = corpus.maxSessionNumber;
+	if (maxSession === null) return [];
+
+	const candidates: ContinuityCandidate[] = [];
+	const seenThreads = new Set<string>();
+
+	for (const digest of corpus.digests) {
+		const sessionsSince = maxSession - digest.sessionNumber;
+		if (sessionsSince < MIN_SESSIONS_DANGLING) continue;
+
+		for (const thread of digest.data.last_session_recap.open_threads ?? []) {
+			const text = typeof thread === "string" ? thread.trim() : "";
+			if (text.length < MIN_THREAD_LENGTH) continue;
+
+			const normalized = text.toLowerCase();
+			if (seenThreads.has(normalized)) continue;
+			seenThreads.add(normalized);
+
+			if (looksResolved(corpus, text, digest.sessionNumber)) continue;
+
+			candidates.push({
+				fingerprint: buildFingerprint("dangling_thread", [
+					digest.id,
+					normalized,
+				]),
+				type: "dangling_thread",
+				subjectEntityId: null,
+				subjectName: null,
+				question: `Session ${digest.sessionNumber} left this thread open and nothing since has picked it up: "${toExcerpt(text, 160)}". Still live?`,
+				rationale: `Open thread recorded in session ${digest.sessionNumber} with no substantially overlapping content in the ${sessionsSince} session(s) since.`,
+				evidence: [
+					{
+						source: "session_digest",
+						label: `Session ${digest.sessionNumber} digest (open_threads)`,
+						referenceId: digest.id,
+						sessionNumber: digest.sessionNumber,
+						excerpt: toExcerpt(text),
+					},
+					{
+						source: "session_digest",
+						label: `Sessions ${digest.sessionNumber + 1}–${maxSession}`,
+						referenceId: null,
+						sessionNumber: maxSession,
+						excerpt: "No later digest revisits this thread.",
+					},
+				],
+				earlierSession: digest.sessionNumber,
+				laterSession: maxSession,
+			});
+		}
+	}
+
+	// Incremental scans still walk the whole history — a thread only becomes
+	// dangling by the *absence* of later content — but callers asking for a
+	// window get the threads that newly qualified within it.
+	const fromSession = options.fromSession;
+	if (fromSession === null) return candidates;
+	return candidates.filter(
+		(candidate) =>
+			candidate.earlierSession !== null &&
+			candidate.earlierSession + MIN_SESSIONS_DANGLING >= fromSession
+	);
+}

--- a/src/services/continuity/detect-relationship-contradictions.ts
+++ b/src/services/continuity/detect-relationship-contradictions.ts
@@ -1,0 +1,195 @@
+import type {
+	ContinuityCandidate,
+	ContinuityEvidence,
+} from "@/types/continuity";
+import type { ContinuityCorpus } from "./continuity-corpus";
+import {
+	buildFingerprint,
+	mentionsName,
+	toExcerpt,
+} from "./continuity-text-utils";
+import {
+	classifyRelationshipStatus,
+	type RelationshipPolarity,
+} from "./continuity-vocabulary";
+
+interface PolarityMark {
+	polarity: RelationshipPolarity;
+	status: string;
+	sessionNumber: number | null;
+	timestamp: string;
+	entryId: string;
+}
+
+interface PolarityFlip {
+	fromEntityId: string;
+	toEntityId: string;
+	fromName: string;
+	toName: string;
+	before: PolarityMark;
+	after: PolarityMark;
+}
+
+function pairKey(from: string, to: string): string {
+	return from < to ? `${from}::${to}` : `${to}::${from}`;
+}
+
+function newStatusOf(update: { new_status?: string }): string {
+	return typeof update.new_status === "string" ? update.new_status : "";
+}
+
+/**
+ * Detect allied↔hostile reversals in the relationship changelog.
+ *
+ * Only polarity *reversals* count. A drift through neutral, or a restatement of
+ * the same polarity, is normal campaign bookkeeping and is skipped.
+ */
+export function collectPolarityFlips(corpus: ContinuityCorpus): PolarityFlip[] {
+	const latest = new Map<string, PolarityMark>();
+	const flips: PolarityFlip[] = [];
+
+	for (const entry of corpus.changelog) {
+		for (const update of entry.payload.relationship_updates ?? []) {
+			const { from, to } = update;
+			if (!from || !to) continue;
+
+			const fromName = corpus.entityNames.get(from);
+			const toName = corpus.entityNames.get(to);
+			if (!fromName || !toName) continue;
+
+			const status = newStatusOf(update);
+			const polarity = classifyRelationshipStatus(status);
+			if (polarity === "neutral") continue;
+
+			const key = pairKey(from, to);
+			const previous = latest.get(key);
+			const current: PolarityMark = {
+				polarity,
+				status,
+				sessionNumber: entry.sessionNumber,
+				timestamp: entry.timestamp,
+				entryId: entry.id,
+			};
+			latest.set(key, current);
+
+			if (!previous || previous.polarity === polarity) continue;
+
+			flips.push({
+				fromEntityId: from,
+				toEntityId: to,
+				fromName,
+				toName,
+				before: previous,
+				after: current,
+			});
+		}
+	}
+
+	return flips;
+}
+
+/**
+ * Look for something between the two sessions that could explain the reversal.
+ *
+ * A digest line naming both parties in the intervening window is treated as the
+ * missing event: the GM recorded *why* the relationship changed, so there is
+ * nothing to ask about.
+ */
+function findInterveningEvent(
+	corpus: ContinuityCorpus,
+	flip: PolarityFlip
+): { digestId: string; sessionNumber: number; text: string } | null {
+	const start = flip.before.sessionNumber;
+	const end = flip.after.sessionNumber;
+	if (start === null || end === null) return null;
+
+	for (const digest of corpus.digests) {
+		if (digest.sessionNumber < start || digest.sessionNumber > end) continue;
+		for (const block of digest.blocks) {
+			if (
+				mentionsName(block.text, flip.fromName) &&
+				mentionsName(block.text, flip.toName)
+			) {
+				return {
+					digestId: digest.id,
+					sessionNumber: digest.sessionNumber,
+					text: block.text,
+				};
+			}
+		}
+	}
+	return null;
+}
+
+function relationshipEvidence(
+	mark: PolarityMark,
+	flip: PolarityFlip
+): ContinuityEvidence {
+	const label =
+		mark.sessionNumber === null
+			? "World state relationship change"
+			: `Session ${mark.sessionNumber} relationship change`;
+	return {
+		source: "entity_relationship",
+		label,
+		referenceId: mark.entryId,
+		sessionNumber: mark.sessionNumber,
+		excerpt: toExcerpt(
+			`${flip.fromName} → ${flip.toName} recorded as "${mark.status}" (${mark.polarity}).`
+		),
+	};
+}
+
+/**
+ * Report allied factions later described as hostile (or the reverse) with no
+ * intervening session that mentions both of them.
+ */
+export function detectRelationshipContradictions(
+	corpus: ContinuityCorpus,
+	options: { fromSession: number | null } = { fromSession: null }
+): ContinuityCandidate[] {
+	const candidates: ContinuityCandidate[] = [];
+
+	for (const flip of collectPolarityFlips(corpus)) {
+		const laterSession = flip.after.sessionNumber;
+		if (
+			options.fromSession !== null &&
+			laterSession !== null &&
+			laterSession < options.fromSession
+		) {
+			continue;
+		}
+
+		if (findInterveningEvent(corpus, flip)) continue;
+
+		const whenBefore =
+			flip.before.sessionNumber === null
+				? "earlier"
+				: `session ${flip.before.sessionNumber}`;
+		const whenAfter =
+			laterSession === null ? "later" : `session ${laterSession}`;
+
+		candidates.push({
+			fingerprint: buildFingerprint("relationship_contradiction", [
+				pairKey(flip.fromEntityId, flip.toEntityId),
+				flip.before.sessionNumber,
+				flip.after.sessionNumber,
+				flip.before.polarity,
+				flip.after.polarity,
+			]),
+			type: "relationship_contradiction",
+			subjectEntityId: flip.fromEntityId,
+			subjectName: `${flip.fromName} / ${flip.toName}`,
+			question: `${flip.fromName} and ${flip.toName} were ${flip.before.polarity} in ${whenBefore} and ${flip.after.polarity} by ${whenAfter}, with no session recording why. Is an event missing?`,
+			rationale: `Relationship polarity reversed from ${flip.before.polarity} ("${flip.before.status}") to ${flip.after.polarity} ("${flip.after.status}") and no digest between those sessions mentions both parties together.`,
+			evidence: [
+				relationshipEvidence(flip.before, flip),
+				relationshipEvidence(flip.after, flip),
+			],
+			earlierSession: flip.before.sessionNumber,
+			laterSession,
+		});
+	}
+
+	return candidates;
+}

--- a/src/services/continuity/detect-rules-contradictions.ts
+++ b/src/services/continuity/detect-rules-contradictions.ts
@@ -1,0 +1,120 @@
+import type { CampaignRule } from "@/services/campaign/rules-context-service";
+import type { ContinuityCandidate } from "@/types/continuity";
+import type { ContinuityCorpus } from "./continuity-corpus";
+import {
+	buildFingerprint,
+	toExcerpt,
+	tokenOverlap,
+} from "./continuity-text-utils";
+import { looksLikeRuling } from "./continuity-vocabulary";
+
+/**
+ * Minimum vocabulary overlap before a digest ruling and a house rule are
+ * considered to be about the same subject. Below this, pairing them wastes a
+ * model call on two unrelated statements.
+ */
+const SUBJECT_OVERLAP_THRESHOLD = 0.25;
+
+/** Cap pairings per ruling so one chatty digest cannot dominate a scan. */
+const MAX_RULES_PER_RULING = 3;
+
+interface DigestRuling {
+	digestId: string;
+	sessionNumber: number;
+	field: string;
+	text: string;
+}
+
+/**
+ * Pull ruling-shaped lines out of the digests.
+ *
+ * `checkHouseRuleConflictTool` already compares a candidate rule against the
+ * recorded rules pairwise. What it cannot see is a ruling the table made at
+ * the table and only ever wrote down in a session recap — which is exactly the
+ * gap the issue asks this detector to close.
+ */
+export function collectDigestRulings(
+	corpus: ContinuityCorpus,
+	fromSession: number | null
+): DigestRuling[] {
+	const rulings: DigestRuling[] = [];
+	for (const digest of corpus.digests) {
+		if (fromSession !== null && digest.sessionNumber < fromSession) continue;
+		for (const block of digest.blocks) {
+			if (!looksLikeRuling(block.text)) continue;
+			rulings.push({
+				digestId: digest.id,
+				sessionNumber: digest.sessionNumber,
+				field: block.field,
+				text: block.text,
+			});
+		}
+	}
+	return rulings;
+}
+
+function rankRulesBySubject(
+	ruling: DigestRuling,
+	rules: CampaignRule[]
+): CampaignRule[] {
+	return rules
+		.map((rule) => ({
+			rule,
+			score: tokenOverlap(ruling.text, `${rule.name} ${rule.text}`),
+		}))
+		.filter((scored) => scored.score >= SUBJECT_OVERLAP_THRESHOLD)
+		.sort((left, right) => right.score - left.score)
+		.slice(0, MAX_RULES_PER_RULING)
+		.map((scored) => scored.rule);
+}
+
+/**
+ * Pair rulings recorded in digests against the campaign's active rules when
+ * they talk about the same subject. Whether they actually conflict is a
+ * judgement call, so it is left to the adjudication tier.
+ */
+export function detectRulesContradictions(
+	corpus: ContinuityCorpus,
+	rules: CampaignRule[],
+	options: { fromSession: number | null } = { fromSession: null }
+): ContinuityCandidate[] {
+	if (rules.length === 0) return [];
+
+	const candidates: ContinuityCandidate[] = [];
+	for (const ruling of collectDigestRulings(corpus, options.fromSession)) {
+		for (const rule of rankRulesBySubject(ruling, rules)) {
+			candidates.push({
+				fingerprint: buildFingerprint("rules_contradiction", [
+					ruling.digestId,
+					ruling.text,
+					rule.id,
+				]),
+				type: "rules_contradiction",
+				subjectEntityId: rule.entityId ?? null,
+				subjectName: rule.name,
+				question: `Session ${ruling.sessionNumber} records a ruling that may not match the house rule "${rule.name}". Which one is current?`,
+				rationale: `A digest line reads like a table ruling and shares subject vocabulary with the active ${rule.category} rule "${rule.name}".`,
+				evidence: [
+					{
+						source: "house_rule",
+						label: `House rule: ${rule.name}`,
+						referenceId: rule.id,
+						sessionNumber: null,
+						excerpt: toExcerpt(rule.text),
+					},
+					{
+						source: "session_digest",
+						label: `Session ${ruling.sessionNumber} digest (${ruling.field})`,
+						referenceId: ruling.digestId,
+						sessionNumber: ruling.sessionNumber,
+						excerpt: toExcerpt(ruling.text),
+					},
+				],
+				earlierSession: null,
+				laterSession: ruling.sessionNumber,
+			});
+		}
+	}
+
+	return candidates;
+}

--- a/src/services/continuity/detect-state-contradictions.ts
+++ b/src/services/continuity/detect-state-contradictions.ts
@@ -1,0 +1,207 @@
+import type {
+	ContinuityCandidate,
+	ContinuityEvidence,
+} from "@/types/continuity";
+import type {
+	ContinuityCorpus,
+	CorpusChangelogEntry,
+	CorpusDigest,
+} from "./continuity-corpus";
+import {
+	buildFingerprint,
+	mentionsName,
+	toExcerpt,
+} from "./continuity-text-utils";
+import {
+	classifyEntityStatus,
+	type EntityStatusBucket,
+} from "./continuity-vocabulary";
+
+/** Digest fields that describe *upcoming* play, where a mention is strongest. */
+const FORWARD_LOOKING_FIELDS = new Set([
+	"npcs_to_run",
+	"locations_in_focus",
+	"next_session_plan.beats",
+	"next_session_plan.objectives_dm",
+	"encounter_seeds",
+]);
+
+/** The last recorded removal/absence for one entity. */
+interface StatusMark {
+	entityId: string;
+	name: string;
+	bucket: EntityStatusBucket;
+	status: string;
+	sessionNumber: number | null;
+	timestamp: string;
+	entryId: string;
+}
+
+function statusOf(update: { status?: string }): string {
+	return typeof update.status === "string" ? update.status : "";
+}
+
+/**
+ * Walk the changelog in order and keep, per entity, the most recent removal or
+ * absence that has *not* since been undone.
+ *
+ * Handling `restored` by clearing the mark is what stops the checker from
+ * flagging every resurrection in the campaign — the single most obvious false
+ * positive in fiction.
+ */
+export function collectOpenStatusMarks(
+	corpus: ContinuityCorpus
+): Map<string, StatusMark> {
+	const marks = new Map<string, StatusMark>();
+
+	for (const entry of corpus.changelog) {
+		for (const update of entry.payload.entity_updates ?? []) {
+			const entityId = update.entity_id;
+			if (!entityId) continue;
+
+			const name = corpus.entityNames.get(entityId);
+			if (!name) continue;
+
+			const status = statusOf(update);
+			const bucket = classifyEntityStatus(status);
+
+			if (bucket === "restored") {
+				marks.delete(entityId);
+				continue;
+			}
+			if (bucket !== "removed" && bucket !== "absent") continue;
+
+			marks.set(entityId, {
+				entityId,
+				name,
+				bucket,
+				status,
+				sessionNumber: entry.sessionNumber,
+				timestamp: entry.timestamp,
+				entryId: entry.id,
+			});
+		}
+	}
+
+	return marks;
+}
+
+function changelogEvidence(
+	mark: StatusMark,
+	entry: CorpusChangelogEntry | undefined
+): ContinuityEvidence {
+	const sessionLabel =
+		mark.sessionNumber === null
+			? "World state change"
+			: `Session ${mark.sessionNumber} world state`;
+	return {
+		source: "world_state_changelog",
+		label: sessionLabel,
+		referenceId: entry?.id ?? mark.entryId,
+		sessionNumber: mark.sessionNumber,
+		excerpt: toExcerpt(`${mark.name} recorded as "${mark.status}".`),
+	};
+}
+
+function digestEvidence(
+	digest: CorpusDigest,
+	field: string,
+	text: string
+): ContinuityEvidence {
+	return {
+		source: "session_digest",
+		label: `Session ${digest.sessionNumber} digest (${field})`,
+		referenceId: digest.id,
+		sessionNumber: digest.sessionNumber,
+		excerpt: toExcerpt(text),
+	};
+}
+
+function buildQuestion(mark: StatusMark, digest: CorpusDigest): string {
+	const when =
+		mark.sessionNumber === null
+			? "World state"
+			: `Session ${mark.sessionNumber}`;
+	return `${when} recorded ${mark.name} as "${mark.status}", but session ${digest.sessionNumber} references ${mark.name} as present. Intentional?`;
+}
+
+function buildRationale(
+	mark: StatusMark,
+	field: string,
+	forwardLooking: boolean
+): string {
+	const strength = mark.bucket === "removed" ? "removed from play" : "absent";
+	const context = forwardLooking
+		? `the later mention is in "${field}", which describes upcoming play`
+		: `the later mention is in "${field}"`;
+	return `${mark.name} was marked ${strength} ("${mark.status}") and no later world state entry restores them; ${context}.`;
+}
+
+/**
+ * Find entities recorded as dead/destroyed/departed that a later digest still
+ * treats as present.
+ *
+ * Candidate generation is bounded by the number of *marked* entities, not by
+ * the entity count: an entity nobody ever removed is never a candidate.
+ */
+export function detectStateContradictions(
+	corpus: ContinuityCorpus,
+	options: { fromSession: number | null } = { fromSession: null }
+): ContinuityCandidate[] {
+	const marks = collectOpenStatusMarks(corpus);
+	if (marks.size === 0) return [];
+
+	const changelogById = new Map(
+		corpus.changelog.map((entry) => [entry.id, entry])
+	);
+	const candidates: ContinuityCandidate[] = [];
+
+	for (const mark of marks.values()) {
+		// A removal with no session number cannot be ordered against digests.
+		if (mark.sessionNumber === null) continue;
+
+		for (const digest of corpus.digests) {
+			if (digest.sessionNumber <= mark.sessionNumber) continue;
+			if (
+				options.fromSession !== null &&
+				digest.sessionNumber < options.fromSession
+			) {
+				continue;
+			}
+
+			const hit = digest.blocks.find((block) =>
+				mentionsName(block.text, mark.name)
+			);
+			if (!hit) continue;
+
+			const forwardLooking = FORWARD_LOOKING_FIELDS.has(hit.field);
+			candidates.push({
+				fingerprint: buildFingerprint("state_contradiction", [
+					mark.entityId,
+					mark.sessionNumber,
+					digest.sessionNumber,
+					hit.field,
+					hit.text,
+				]),
+				type: "state_contradiction",
+				subjectEntityId: mark.entityId,
+				subjectName: mark.name,
+				question: buildQuestion(mark, digest),
+				rationale: buildRationale(mark, hit.field, forwardLooking),
+				evidence: [
+					changelogEvidence(mark, changelogById.get(mark.entryId)),
+					digestEvidence(digest, hit.field, hit.text),
+				],
+				earlierSession: mark.sessionNumber,
+				laterSession: digest.sessionNumber,
+			});
+
+			// One candidate per (entity, later session). Repeating the same
+			// question for every line in a digest is exactly the noise that
+			// gets a checker switched off.
+			break;
+		}
+	}
+
+	return candidates;
+}

--- a/src/services/continuity/detect-timeline-contradictions.ts
+++ b/src/services/continuity/detect-timeline-contradictions.ts
@@ -1,0 +1,170 @@
+import type {
+	ContinuityCandidate,
+	ContinuityEvidence,
+} from "@/types/continuity";
+import type { ContinuityCorpus, CorpusDigest } from "./continuity-corpus";
+import {
+	buildFingerprint,
+	mentionsName,
+	toExcerpt,
+} from "./continuity-text-utils";
+
+function digestEvidence(
+	digest: CorpusDigest,
+	excerpt: string
+): ContinuityEvidence {
+	return {
+		source: "session_digest",
+		label: `Session ${digest.sessionNumber} digest`,
+		referenceId: digest.id,
+		sessionNumber: digest.sessionNumber,
+		excerpt: toExcerpt(excerpt),
+	};
+}
+
+function parseDate(value: string | null): number | null {
+	if (!value) return null;
+	const parsed = Date.parse(value);
+	return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * Sessions whose recorded dates run backwards against their session numbers.
+ *
+ * This is fully deterministic — there is no interpretation involved — so it is
+ * the cheapest continuity signal in the system and the most reliable.
+ */
+function detectSessionDateInversions(
+	corpus: ContinuityCorpus,
+	fromSession: number | null
+): ContinuityCandidate[] {
+	const dated = corpus.digests
+		.map((digest) => ({ digest, date: parseDate(digest.sessionDate) }))
+		.filter(
+			(item): item is { digest: CorpusDigest; date: number } =>
+				item.date !== null
+		);
+
+	const candidates: ContinuityCandidate[] = [];
+	for (let i = 1; i < dated.length; i++) {
+		const previous = dated[i - 1];
+		const current = dated[i];
+		if (current.date >= previous.date) continue;
+		if (
+			fromSession !== null &&
+			current.digest.sessionNumber < fromSession &&
+			previous.digest.sessionNumber < fromSession
+		) {
+			continue;
+		}
+
+		candidates.push({
+			fingerprint: buildFingerprint("timeline_contradiction", [
+				"date_inversion",
+				previous.digest.id,
+				current.digest.id,
+			]),
+			type: "timeline_contradiction",
+			subjectEntityId: null,
+			subjectName: null,
+			question: `Session ${current.digest.sessionNumber} is dated ${current.digest.sessionDate}, before session ${previous.digest.sessionNumber} on ${previous.digest.sessionDate}. Is one of these dates wrong?`,
+			rationale:
+				"Session numbers and session dates disagree on ordering. Either a date was mistyped or the sessions were played out of order.",
+			evidence: [
+				digestEvidence(
+					previous.digest,
+					`Session ${previous.digest.sessionNumber} dated ${previous.digest.sessionDate}.`
+				),
+				digestEvidence(
+					current.digest,
+					`Session ${current.digest.sessionNumber} dated ${current.digest.sessionDate}.`
+				),
+			],
+			earlierSession: previous.digest.sessionNumber,
+			laterSession: current.digest.sessionNumber,
+		});
+	}
+
+	return candidates;
+}
+
+/**
+ * Entities referenced in a digest earlier than the session that introduces them.
+ *
+ * Often benign (extraction lag, a foreshadowed name) which is exactly why this
+ * goes through triage rather than straight to the GM.
+ */
+function detectPrematureReferences(
+	corpus: ContinuityCorpus,
+	fromSession: number | null
+): ContinuityCandidate[] {
+	const introducedAt = new Map<string, { session: number; entryId: string }>();
+
+	for (const entry of corpus.changelog) {
+		if (entry.sessionNumber === null) continue;
+		for (const created of entry.payload.new_entities ?? []) {
+			const entityId = created.entity_id;
+			if (!entityId || introducedAt.has(entityId)) continue;
+			introducedAt.set(entityId, {
+				session: entry.sessionNumber,
+				entryId: entry.id,
+			});
+		}
+	}
+
+	const candidates: ContinuityCandidate[] = [];
+	for (const [entityId, introduction] of introducedAt) {
+		const name = corpus.entityNames.get(entityId);
+		if (!name) continue;
+
+		for (const digest of corpus.digests) {
+			if (digest.sessionNumber >= introduction.session) continue;
+			if (fromSession !== null && introduction.session < fromSession) continue;
+
+			const hit = digest.blocks.find((block) => mentionsName(block.text, name));
+			if (!hit) continue;
+
+			candidates.push({
+				fingerprint: buildFingerprint("timeline_contradiction", [
+					"premature_reference",
+					entityId,
+					introduction.session,
+					digest.sessionNumber,
+				]),
+				type: "timeline_contradiction",
+				subjectEntityId: entityId,
+				subjectName: name,
+				question: `${name} is first introduced in session ${introduction.session} but appears in the session ${digest.sessionNumber} digest. Was ${name} introduced earlier than recorded?`,
+				rationale: `World state records ${name} as a new entity in session ${introduction.session}, yet an earlier digest already names them.`,
+				evidence: [
+					{
+						source: "world_state_changelog",
+						label: `Session ${introduction.session} world state`,
+						referenceId: introduction.entryId,
+						sessionNumber: introduction.session,
+						excerpt: toExcerpt(
+							`${name} recorded as a new entity in session ${introduction.session}.`
+						),
+					},
+					digestEvidence(digest, hit.text),
+				],
+				earlierSession: digest.sessionNumber,
+				laterSession: introduction.session,
+			});
+			break;
+		}
+	}
+
+	return candidates;
+}
+
+/** Both timeline detectors: date inversions and premature references. */
+export function detectTimelineContradictions(
+	corpus: ContinuityCorpus,
+	options: { fromSession: number | null } = { fromSession: null }
+): ContinuityCandidate[] {
+	return [
+		...detectSessionDateInversions(corpus, options.fromSession),
+		...detectPrematureReferences(corpus, options.fromSession),
+	];
+}

--- a/src/tools/campaign-context/context-tools-bundle.ts
+++ b/src/tools/campaign-context/context-tools-bundle.ts
@@ -6,6 +6,11 @@ import { getMessageHistory } from "@/tools/message-history-tools";
 import { getChecklistStatusTool } from "./checklist-tools";
 import { captureConversationalContext } from "./context-capture-tools";
 import {
+	checkCampaignContinuityTool,
+	listContinuityFindingsTool,
+	resolveContinuityFindingTool,
+} from "./continuity-tools";
+import {
 	checkHouseRuleConflictTool,
 	defineHouseRuleTool,
 	deleteEntityTool,
@@ -60,6 +65,9 @@ export const campaignContextToolsBundle = {
 	listHouseRulesTool,
 	updateHouseRuleTool,
 	checkHouseRuleConflictTool,
+	checkCampaignContinuityTool,
+	listContinuityFindingsTool,
+	resolveContinuityFindingTool,
 	getMessageHistory,
 	getChecklistStatusTool,
 	recordPlanningTasks,

--- a/src/tools/campaign-context/continuity-tools.ts
+++ b/src/tools/campaign-context/continuity-tools.ts
@@ -210,9 +210,12 @@ export const checkCampaignContinuityTool = tool({
 				env: env as Record<string, unknown>,
 			});
 			const result = await service.scan(input.campaignId, {
-				mode: input.mode,
+				mode: input.mode ?? "incremental",
 				types: input.types as never,
-				minConfidence: input.minConfidence,
+				// Schema defaults only apply when the AI SDK validates input, so
+				// restate them here; the service would otherwise fall back to
+				// persisting low-confidence findings.
+				minConfidence: input.minConfidence ?? "medium",
 				maxCandidates: input.maxCandidates,
 			});
 
@@ -269,25 +272,31 @@ export const listContinuityFindingsTool = tool({
 			);
 			if (access.error) return access.error;
 
+			const status = input.status ?? "open";
 			const findings = await getDAOFactory(
 				env
 			).continuityFindingDAO.listFindingsForCampaign(input.campaignId, {
-				status: input.status,
+				status,
 				types: input.types as never,
-				limit: input.limit,
+				limit: input.limit ?? 25,
 			});
-			const visible = input.highConfidenceOnly
+
+			// Default to the quiet behaviour on an omitted flag rather than
+			// relying on the schema default — a caller that invokes execute()
+			// directly must not accidentally get the noisy report.
+			const highConfidenceOnly = input.highConfidenceOnly !== false;
+			const visible = highConfidenceOnly
 				? findings.filter((finding) => finding.confidence === "high")
 				: findings;
 
 			return createToolSuccess(
 				visible.length === 0
-					? `No ${input.status} continuity findings for "${access.campaignName}".`
-					: `${visible.length} ${input.status} continuity finding(s) for "${access.campaignName}".`,
+					? `No ${status} continuity findings for "${access.campaignName}".`
+					: `${visible.length} ${status} continuity finding(s) for "${access.campaignName}".`,
 				{
 					total: findings.length,
 					shown: visible.length,
-					highConfidenceOnly: input.highConfidenceOnly,
+					highConfidenceOnly,
 					findings: visible.map(summarizeFinding),
 				},
 				toolCallId

--- a/src/tools/campaign-context/continuity-tools.ts
+++ b/src/tools/campaign-context/continuity-tools.ts
@@ -1,0 +1,379 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { tool } from "ai";
+import { z } from "zod";
+import type { ToolResult } from "@/app-constants";
+import { getDAOFactory } from "@/dao/dao-factory";
+import {
+	ContinuityCheckerService,
+	type ResolveFindingInput,
+} from "@/services/continuity/continuity-checker-service";
+import {
+	commonSchemas,
+	createToolError,
+	createToolSuccess,
+	getEnvFromContext,
+	requireCampaignAccessForTool,
+	requireGMRole,
+	type ToolEnv,
+	type ToolExecuteOptions,
+} from "@/tools/utils";
+import {
+	CONTINUITY_FINDING_TYPES,
+	type ContinuityFinding,
+} from "@/types/continuity";
+
+interface ContinuityToolEnv extends ToolEnv {
+	DB?: D1Database;
+}
+
+const findingTypeSchema = z.enum(
+	CONTINUITY_FINDING_TYPES as unknown as [string, ...string[]]
+);
+
+const checkContinuitySchema = z.object({
+	campaignId: commonSchemas.campaignId,
+	mode: z
+		.enum(["incremental", "full"])
+		.optional()
+		.default("incremental")
+		.describe(
+			"incremental checks only sessions newer than the last scan; full rescans the whole campaign and costs considerably more."
+		),
+	types: z
+		.array(findingTypeSchema)
+		.optional()
+		.describe("Restrict the scan to specific finding types."),
+	minConfidence: z
+		.enum(["high", "medium", "low"])
+		.optional()
+		.default("medium")
+		.describe("Lowest confidence to record. Defaults to medium and above."),
+	maxCandidates: z
+		.number()
+		.int()
+		.min(1)
+		.max(200)
+		.optional()
+		.describe("Cap on candidates reviewed by the model tiers this run."),
+	jwt: commonSchemas.jwt,
+});
+
+const listFindingsSchema = z.object({
+	campaignId: commonSchemas.campaignId,
+	status: z
+		.enum(["open", "confirmed", "dismissed", "corrected"])
+		.optional()
+		.default("open")
+		.describe("Filter by adjudication status."),
+	types: z
+		.array(findingTypeSchema)
+		.optional()
+		.describe("Restrict to specific finding types."),
+	highConfidenceOnly: z
+		.boolean()
+		.optional()
+		.default(true)
+		.describe(
+			"Show only high-confidence findings. Defaults to true so the report stays trustworthy."
+		),
+	limit: z.number().int().min(1).max(100).optional().default(25),
+	jwt: commonSchemas.jwt,
+});
+
+const resolveFindingSchema = z.object({
+	campaignId: commonSchemas.campaignId,
+	findingId: z.string().min(1).describe("The continuity finding to resolve."),
+	action: z
+		.enum(["confirm", "dismiss", "correct"])
+		.describe(
+			"confirm records it as a real problem; dismiss retires it permanently; correct also writes the fix back to world state."
+		),
+	note: z
+		.string()
+		.optional()
+		.describe("Optional GM note recorded with the resolution."),
+	correctedEntityId: z
+		.string()
+		.optional()
+		.describe(
+			"Entity to correct. Defaults to the finding's subject. Required for 'correct' when the finding has no subject."
+		),
+	correctedStatus: z
+		.string()
+		.optional()
+		.describe("The corrected world state status. Required for 'correct'."),
+	campaignSessionId: z
+		.number()
+		.int()
+		.nonnegative()
+		.optional()
+		.describe("Session the correction applies to, when known."),
+	jwt: commonSchemas.jwt,
+});
+
+/** Shape a finding for chat: the question plus both sides, nothing more. */
+function summarizeFinding(finding: ContinuityFinding) {
+	return {
+		id: finding.id,
+		type: finding.findingType,
+		confidence: finding.confidence,
+		question: finding.question,
+		detail: finding.detail,
+		subject: finding.subjectName,
+		status: finding.status,
+		evidence: finding.evidence.map((item) => ({
+			label: item.label,
+			sessionNumber: item.sessionNumber,
+			excerpt: item.excerpt,
+			referenceId: item.referenceId,
+		})),
+	};
+}
+
+async function requireGmCampaignAccess(
+	env: ContinuityToolEnv,
+	campaignId: string,
+	jwt: string | null | undefined,
+	toolCallId: string
+) {
+	const access = await requireCampaignAccessForTool({
+		env,
+		campaignId,
+		jwt,
+		toolCallId,
+	});
+	if ("toolCallId" in access) {
+		return { error: access, campaignName: null } as const;
+	}
+	const gmError = await requireGMRole(
+		env,
+		campaignId,
+		access.userId,
+		toolCallId
+	);
+	if (gmError) return { error: gmError, campaignName: null } as const;
+	return {
+		error: null,
+		campaignName: access.campaign.name,
+		userId: access.userId,
+	} as const;
+}
+
+/**
+ * ContinuityToolEnv carries an index signature, so an `in` check cannot
+ * discriminate it from a ToolResult. Return an explicit tagged result instead.
+ */
+function requireDb(
+	options: ToolExecuteOptions | undefined,
+	toolCallId: string
+):
+	| { env: ContinuityToolEnv & { DB: D1Database }; error: null }
+	| { env: null; error: ToolResult } {
+	const env = getEnvFromContext(options) as ContinuityToolEnv | null;
+	if (!env?.DB) {
+		return {
+			env: null,
+			error: createToolError(
+				"Environment not available",
+				"Direct database access is required for continuity checks.",
+				500,
+				toolCallId
+			),
+		};
+	}
+	return { env: env as ContinuityToolEnv & { DB: D1Database }, error: null };
+}
+
+export const checkCampaignContinuityTool = tool({
+	description:
+		"Scan a campaign for likely continuity problems — entities referenced after being recorded dead or destroyed, timeline conflicts, unexplained faction reversals, rulings that clash with house rules, and unresolved plot threads. Reports questions with citations, not errors.",
+	inputSchema: checkContinuitySchema,
+	execute: async (
+		input: z.infer<typeof checkContinuitySchema>,
+		options?: ToolExecuteOptions
+	): Promise<ToolResult> => {
+		const toolCallId = options?.toolCallId ?? crypto.randomUUID();
+		try {
+			const { env, error: envError } = requireDb(options, toolCallId);
+			if (envError) return envError;
+
+			const access = await requireGmCampaignAccess(
+				env,
+				input.campaignId,
+				input.jwt,
+				toolCallId
+			);
+			if (access.error) return access.error;
+
+			const service = new ContinuityCheckerService({
+				db: env.DB,
+				env: env as Record<string, unknown>,
+			});
+			const result = await service.scan(input.campaignId, {
+				mode: input.mode,
+				types: input.types as never,
+				minConfidence: input.minConfidence,
+				maxCandidates: input.maxCandidates,
+			});
+
+			const message =
+				result.findingsCreated === 0
+					? `No new continuity questions for "${access.campaignName}".`
+					: `Found ${result.findingsCreated} continuity question(s) for "${access.campaignName}".`;
+
+			return createToolSuccess(
+				message,
+				{
+					scanId: result.scanId,
+					mode: result.mode,
+					scannedFromSession: result.scannedFromSession,
+					scannedToSession: result.scannedToSession,
+					candidatesGenerated: result.candidatesGenerated,
+					candidatesAlreadyKnown: result.candidatesAlreadyKnown,
+					findingsCreated: result.findingsCreated,
+					truncated: result.truncated,
+					warnings: result.warnings,
+					findings: result.findings.map(summarizeFinding),
+				},
+				toolCallId
+			);
+		} catch (error) {
+			return createToolError(
+				"Failed to check campaign continuity",
+				error instanceof Error ? error.message : "Unknown error",
+				500,
+				toolCallId
+			);
+		}
+	},
+});
+
+export const listContinuityFindingsTool = tool({
+	description:
+		"List continuity findings previously detected for a campaign, newest and highest-confidence first.",
+	inputSchema: listFindingsSchema,
+	execute: async (
+		input: z.infer<typeof listFindingsSchema>,
+		options?: ToolExecuteOptions
+	): Promise<ToolResult> => {
+		const toolCallId = options?.toolCallId ?? crypto.randomUUID();
+		try {
+			const { env, error: envError } = requireDb(options, toolCallId);
+			if (envError) return envError;
+
+			const access = await requireGmCampaignAccess(
+				env,
+				input.campaignId,
+				input.jwt,
+				toolCallId
+			);
+			if (access.error) return access.error;
+
+			const findings = await getDAOFactory(
+				env
+			).continuityFindingDAO.listFindingsForCampaign(input.campaignId, {
+				status: input.status,
+				types: input.types as never,
+				limit: input.limit,
+			});
+			const visible = input.highConfidenceOnly
+				? findings.filter((finding) => finding.confidence === "high")
+				: findings;
+
+			return createToolSuccess(
+				visible.length === 0
+					? `No ${input.status} continuity findings for "${access.campaignName}".`
+					: `${visible.length} ${input.status} continuity finding(s) for "${access.campaignName}".`,
+				{
+					total: findings.length,
+					shown: visible.length,
+					highConfidenceOnly: input.highConfidenceOnly,
+					findings: visible.map(summarizeFinding),
+				},
+				toolCallId
+			);
+		} catch (error) {
+			return createToolError(
+				"Failed to list continuity findings",
+				error instanceof Error ? error.message : "Unknown error",
+				500,
+				toolCallId
+			);
+		}
+	},
+});
+
+const RESOLUTION_VERBS: Record<
+	z.infer<typeof resolveFindingSchema>["action"],
+	string
+> = {
+	confirm: "Confirmed",
+	dismiss: "Dismissed",
+	correct: "Corrected",
+};
+
+function toResolveInput(
+	input: z.infer<typeof resolveFindingSchema>,
+	resolvedBy: string | null
+): ResolveFindingInput {
+	return {
+		action: input.action,
+		note: input.note ?? null,
+		resolvedBy,
+		correction: {
+			entityId: input.correctedEntityId ?? null,
+			status: input.correctedStatus ?? null,
+			campaignSessionId: input.campaignSessionId ?? null,
+		},
+	};
+}
+
+export const resolveContinuityFindingTool = tool({
+	description:
+		"Confirm, dismiss, or correct a continuity finding. Dismissed findings never resurface; corrections are written back to campaign world state.",
+	inputSchema: resolveFindingSchema,
+	execute: async (
+		input: z.infer<typeof resolveFindingSchema>,
+		options?: ToolExecuteOptions
+	): Promise<ToolResult> => {
+		const toolCallId = options?.toolCallId ?? crypto.randomUUID();
+		try {
+			const { env, error: envError } = requireDb(options, toolCallId);
+			if (envError) return envError;
+
+			const access = await requireGmCampaignAccess(
+				env,
+				input.campaignId,
+				input.jwt,
+				toolCallId
+			);
+			if (access.error) return access.error;
+
+			const service = new ContinuityCheckerService({
+				db: env.DB,
+				env: env as Record<string, unknown>,
+			});
+			const result = await service.resolveFinding(
+				input.campaignId,
+				input.findingId,
+				toResolveInput(input, access.userId ?? null)
+			);
+
+			return createToolSuccess(
+				`${RESOLUTION_VERBS[input.action]} continuity finding for "${access.campaignName}".`,
+				{
+					finding: summarizeFinding(result.finding),
+					changelogEntryId: result.changelogEntryId,
+				},
+				toolCallId
+			);
+		} catch (error) {
+			return createToolError(
+				"Failed to resolve continuity finding",
+				error instanceof Error ? error.message : "Unknown error",
+				500,
+				toolCallId
+			);
+		}
+	},
+});

--- a/src/types/continuity.ts
+++ b/src/types/continuity.ts
@@ -1,0 +1,209 @@
+/**
+ * Campaign continuity checker types (issue #744).
+ *
+ * The checker looks for likely contradictions across session digests, the world
+ * state changelog and the entity graph, and reports them as *questions* a GM can
+ * adjudicate in seconds rather than as errors.
+ */
+
+/** Categories of continuity finding the checker can raise. */
+export type ContinuityFindingType =
+	/** Entity recorded dead/destroyed/departed, then referenced as present. */
+	| "state_contradiction"
+	/** Event ordering that conflicts across digests or against first appearance. */
+	| "timeline_contradiction"
+	/** Allies described as hostile (or vice versa) with no intervening event. */
+	| "relationship_contradiction"
+	/** A ruling implied by a digest that conflicts with a recorded house rule. */
+	| "rules_contradiction"
+	/** A hook introduced and never resolved. Not an error — a planning prompt. */
+	| "dangling_thread";
+
+export const CONTINUITY_FINDING_TYPES: readonly ContinuityFindingType[] = [
+	"state_contradiction",
+	"timeline_contradiction",
+	"relationship_contradiction",
+	"rules_contradiction",
+	"dangling_thread",
+] as const;
+
+/**
+ * Confidence in a finding. The UI defaults to `high` only — a checker that
+ * cries wolf gets switched off after one use.
+ */
+export type ContinuityConfidence = "high" | "medium" | "low";
+
+/** Lifecycle of a finding. `dismissed` findings never resurface. */
+export type ContinuityFindingStatus =
+	| "open"
+	| "confirmed"
+	| "dismissed"
+	| "corrected";
+
+/** Where a piece of evidence came from, so the GM can jump straight to it. */
+export type ContinuityEvidenceSource =
+	| "session_digest"
+	| "world_state_changelog"
+	| "entity"
+	| "entity_relationship"
+	| "house_rule";
+
+/**
+ * One side of a finding. Every finding cites at least two of these — the GM
+ * should never have to go investigate which sources disagree.
+ */
+export interface ContinuityEvidence {
+	source: ContinuityEvidenceSource;
+	/** Short human label, e.g. "Session 12 digest". */
+	label: string;
+	/** Row id of the digest / changelog entry / entity so the UI can deep-link. */
+	referenceId: string | null;
+	/** Campaign session number when known, for ordering the two sides. */
+	sessionNumber: number | null;
+	/** The exact text that triggered the finding. Kept short. */
+	excerpt: string;
+}
+
+/**
+ * A pre-LLM candidate produced by deterministic detectors. Cheap to generate;
+ * only survivors of triage reach the expensive adjudication tier.
+ */
+export interface ContinuityCandidate {
+	/** Stable across scans — the dedupe and dismissal-memory key. */
+	fingerprint: string;
+	type: ContinuityFindingType;
+	subjectEntityId: string | null;
+	subjectName: string | null;
+	/** Deterministic phrasing, refined by the adjudicator when it survives. */
+	question: string;
+	/** Why the detector flagged it, fed to the model as context. */
+	rationale: string;
+	evidence: ContinuityEvidence[];
+	/** Session the earlier side of the contradiction was recorded in. */
+	earlierSession: number | null;
+	/** Session the later, conflicting reference appears in. */
+	laterSession: number | null;
+}
+
+/** Normalized finding exposed to routes, tools and the UI. */
+export interface ContinuityFinding {
+	id: string;
+	campaignId: string;
+	fingerprint: string;
+	findingType: ContinuityFindingType;
+	confidence: ContinuityConfidence;
+	question: string;
+	detail: string | null;
+	evidence: ContinuityEvidence[];
+	subjectEntityId: string | null;
+	subjectName: string | null;
+	status: ContinuityFindingStatus;
+	resolutionNote: string | null;
+	resolvedBy: string | null;
+	resolvedAt: string | null;
+	scanId: string | null;
+	detectedAt: string;
+	updatedAt: string;
+}
+
+/** Raw row shape returned directly from D1. */
+export interface ContinuityFindingRecord {
+	id: string;
+	campaign_id: string;
+	fingerprint: string;
+	finding_type: string;
+	confidence: string;
+	question: string;
+	detail: string | null;
+	evidence: string;
+	subject_entity_id: string | null;
+	subject_name: string | null;
+	status: string;
+	resolution_note: string | null;
+	resolved_by: string | null;
+	resolved_at: string | null;
+	scan_id: string | null;
+	detected_at: string;
+	updated_at: string;
+}
+
+export interface CreateContinuityFindingInput {
+	id: string;
+	campaignId: string;
+	fingerprint: string;
+	findingType: ContinuityFindingType;
+	confidence: ContinuityConfidence;
+	question: string;
+	detail?: string | null;
+	evidence: ContinuityEvidence[];
+	subjectEntityId?: string | null;
+	subjectName?: string | null;
+	scanId?: string | null;
+}
+
+/** Incremental checks new sessions only; full rescans the whole campaign. */
+export type ContinuityScanMode = "incremental" | "full";
+
+export interface ContinuityScanOptions {
+	mode?: ContinuityScanMode;
+	/** Restrict detection to a subset of finding types. */
+	types?: ContinuityFindingType[];
+	/** Hard cap on candidates sent to the model. Protects long campaigns. */
+	maxCandidates?: number;
+	/** Lowest confidence to persist. Defaults to persisting all tiers. */
+	minConfidence?: ContinuityConfidence;
+}
+
+export interface ContinuityScanResult {
+	scanId: string;
+	campaignId: string;
+	mode: ContinuityScanMode;
+	/** Sessions considered as the "later reference" side of a contradiction. */
+	scannedFromSession: number | null;
+	scannedToSession: number | null;
+	candidatesGenerated: number;
+	/** Candidates dropped because an identical fingerprint already exists. */
+	candidatesAlreadyKnown: number;
+	candidatesTriaged: number;
+	candidatesAdjudicated: number;
+	findingsCreated: number;
+	findings: ContinuityFinding[];
+	/** Set when the candidate cap truncated detection, so callers can say so. */
+	truncated: boolean;
+	/** Populated when the LLM tiers were unavailable and detection ran raw. */
+	warnings: string[];
+}
+
+export interface ContinuityScanState {
+	campaignId: string;
+	lastScannedSession: number | null;
+	lastScanId: string | null;
+	lastScanMode: ContinuityScanMode | null;
+	lastScanAt: string | null;
+}
+
+/** GM adjudication of a finding. */
+export type ContinuityResolutionAction = "confirm" | "dismiss" | "correct";
+
+export function isContinuityFindingType(
+	value: unknown
+): value is ContinuityFindingType {
+	return (
+		typeof value === "string" &&
+		CONTINUITY_FINDING_TYPES.includes(value as ContinuityFindingType)
+	);
+}
+
+const CONFIDENCE_RANK: Record<ContinuityConfidence, number> = {
+	low: 0,
+	medium: 1,
+	high: 2,
+};
+
+/** True when `value` is at least as confident as `minimum`. */
+export function meetsConfidence(
+	value: ContinuityConfidence,
+	minimum: ContinuityConfidence
+): boolean {
+	return CONFIDENCE_RANK[value] >= CONFIDENCE_RANK[minimum];
+}

--- a/tests/dao/continuity-finding-dao.test.ts
+++ b/tests/dao/continuity-finding-dao.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { ContinuityFindingDAO } from "@/dao/continuity-finding-dao";
+import type { ContinuityFindingRecord } from "@/types/continuity";
+import { createMockD1, createMockStmt, type MockStmt } from "./helpers";
+
+function record(
+	overrides: Partial<ContinuityFindingRecord> = {}
+): ContinuityFindingRecord {
+	return {
+		id: "finding-1",
+		campaign_id: "camp-1",
+		fingerprint: "state_contradiction:abc123",
+		finding_type: "state_contradiction",
+		confidence: "high",
+		question:
+			"Session 12 recorded Vane's death; session 19 references him. Intentional?",
+		detail: "Check whether the death was faked.",
+		evidence: JSON.stringify([
+			{
+				source: "world_state_changelog",
+				label: "Session 12 world state",
+				referenceId: "cl-12",
+				sessionNumber: 12,
+				excerpt: 'Vane recorded as "dead".',
+			},
+		]),
+		subject_entity_id: "camp-1_vane",
+		subject_name: "Vane",
+		status: "open",
+		resolution_note: null,
+		resolved_by: null,
+		resolved_at: null,
+		scan_id: "scan-1",
+		detected_at: "2025-01-01T00:00:00Z",
+		updated_at: "2025-01-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+describe("ContinuityFindingDAO", () => {
+	let stmt: MockStmt;
+	let dao: ContinuityFindingDAO;
+
+	beforeEach(() => {
+		stmt = createMockStmt();
+		dao = new ContinuityFindingDAO(createMockD1(stmt));
+	});
+
+	it("reports true when a new finding is written", async () => {
+		stmt.run.mockResolvedValue({ meta: { changes: 1 } });
+
+		const created = await dao.createFinding({
+			id: "finding-1",
+			campaignId: "camp-1",
+			fingerprint: "state_contradiction:abc123",
+			findingType: "state_contradiction",
+			confidence: "high",
+			question: "Intentional?",
+			evidence: [],
+		});
+
+		expect(created).toBe(true);
+		expect(stmt.bind).toHaveBeenCalled();
+	});
+
+	it("reports false when the fingerprint already exists", async () => {
+		// INSERT OR IGNORE reports zero changes — this is how a dismissed
+		// finding is prevented from resurfacing on a later scan.
+		stmt.run.mockResolvedValue({ meta: { changes: 0 } });
+
+		const created = await dao.createFinding({
+			id: "finding-2",
+			campaignId: "camp-1",
+			fingerprint: "state_contradiction:abc123",
+			findingType: "state_contradiction",
+			confidence: "high",
+			question: "Intentional?",
+			evidence: [],
+		});
+
+		expect(created).toBe(false);
+	});
+
+	it("uses INSERT OR IGNORE so a duplicate never overwrites a resolution", async () => {
+		const db = createMockD1(stmt);
+		stmt.run.mockResolvedValue({ meta: { changes: 1 } });
+		await new ContinuityFindingDAO(db).createFinding({
+			id: "finding-1",
+			campaignId: "camp-1",
+			fingerprint: "fp",
+			findingType: "dangling_thread",
+			confidence: "medium",
+			question: "Still live?",
+			evidence: [],
+		});
+
+		const sql = (db.prepare as unknown as { mock: { calls: string[][] } }).mock
+			.calls[0][0];
+		expect(sql).toContain("INSERT OR IGNORE INTO continuity_findings");
+	});
+
+	it("parses evidence JSON when mapping a row", async () => {
+		stmt.first.mockResolvedValue(record());
+
+		const finding = await dao.getFindingById("finding-1");
+
+		expect(finding?.evidence).toHaveLength(1);
+		expect(finding?.evidence[0].label).toBe("Session 12 world state");
+		expect(finding?.subjectName).toBe("Vane");
+	});
+
+	it("survives malformed evidence JSON rather than throwing", async () => {
+		stmt.first.mockResolvedValue(record({ evidence: "not json" }));
+
+		const finding = await dao.getFindingById("finding-1");
+
+		expect(finding?.evidence).toEqual([]);
+	});
+
+	it("returns known fingerprints as a set for cheap scan-time filtering", async () => {
+		stmt.all.mockResolvedValue({
+			results: [{ fingerprint: "fp-1" }, { fingerprint: "fp-2" }],
+		});
+
+		const fingerprints = await dao.getKnownFingerprints("camp-1");
+
+		expect(fingerprints.has("fp-1")).toBe(true);
+		expect(fingerprints.size).toBe(2);
+	});
+
+	it("orders findings by confidence so high-confidence questions surface first", async () => {
+		const db = createMockD1(stmt);
+		stmt.all.mockResolvedValue({ results: [] });
+
+		await new ContinuityFindingDAO(db).listFindingsForCampaign("camp-1", {
+			status: "open",
+		});
+
+		const sql = (db.prepare as unknown as { mock: { calls: string[][] } }).mock
+			.calls[0][0];
+		expect(sql).toContain("CASE confidence WHEN 'high' THEN 0");
+	});
+
+	it("records the scan watermark without ever moving it backwards", async () => {
+		const db = createMockD1(stmt);
+
+		await new ContinuityFindingDAO(db).recordScan({
+			campaignId: "camp-1",
+			scanId: "scan-2",
+			mode: "incremental",
+			lastScannedSession: 14,
+		});
+
+		const sql = (db.prepare as unknown as { mock: { calls: string[][] } }).mock
+			.calls[0][0];
+		expect(sql).toContain("ON CONFLICT(campaign_id) DO UPDATE");
+		expect(sql).toContain("MAX(");
+	});
+});

--- a/tests/services/continuity-adjudication-service.test.ts
+++ b/tests/services/continuity-adjudication-service.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ContinuityAdjudicationService } from "@/services/continuity/continuity-adjudication-service";
+import type { LLMProvider } from "@/services/llm/llm-provider";
+import type { ContinuityCandidate } from "@/types/continuity";
+
+function candidate(index: number): ContinuityCandidate {
+	return {
+		fingerprint: `state_contradiction:${index}`,
+		type: "state_contradiction",
+		subjectEntityId: `camp-1_npc-${index}`,
+		subjectName: `NPC ${index}`,
+		question: `Deterministic question ${index}`,
+		rationale: `Rationale ${index}`,
+		evidence: [
+			{
+				source: "world_state_changelog",
+				label: "Session 12 world state",
+				referenceId: "cl-12",
+				sessionNumber: 12,
+				excerpt: "recorded as dead",
+			},
+			{
+				source: "session_digest",
+				label: "Session 19 digest",
+				referenceId: "digest-19",
+				sessionNumber: 19,
+				excerpt: "still scheming",
+			},
+		],
+		earlierSession: 12,
+		laterSession: 19,
+	};
+}
+
+function provider(
+	generateStructuredOutput: LLMProvider["generateStructuredOutput"]
+): LLMProvider {
+	return {
+		generateSummary: vi.fn(),
+		generateStructuredOutput,
+	} as unknown as LLMProvider;
+}
+
+describe("ContinuityAdjudicationService", () => {
+	let triageOutput: ReturnType<typeof vi.fn>;
+	let adjudicationOutput: ReturnType<typeof vi.fn>;
+
+	function buildService() {
+		return new ContinuityAdjudicationService({
+			apiKey: "test-key",
+			triageProvider: provider(triageOutput as never),
+			adjudicationProvider: provider(adjudicationOutput as never),
+		});
+	}
+
+	beforeEach(() => {
+		triageOutput = vi.fn();
+		adjudicationOutput = vi.fn();
+	});
+
+	it("keeps only the candidates triage marks worth keeping", async () => {
+		triageOutput.mockResolvedValue({
+			verdicts: [
+				{ index: 0, worthKeeping: true },
+				{ index: 1, worthKeeping: false },
+			],
+		});
+
+		const kept = await buildService().triage([candidate(0), candidate(1)]);
+
+		expect(kept).toHaveLength(1);
+		expect(kept[0].subjectName).toBe("NPC 0");
+	});
+
+	it("drops a triage batch that fails rather than letting it through unvetted", async () => {
+		triageOutput.mockRejectedValue(new Error("provider unavailable"));
+
+		const kept = await buildService().triage([candidate(0)]);
+
+		expect(kept).toEqual([]);
+	});
+
+	it("batches triage so a large candidate set is not one giant prompt", async () => {
+		triageOutput.mockResolvedValue({ verdicts: [] });
+		const candidates = Array.from({ length: 25 }, (_, i) => candidate(i));
+
+		await buildService().triage(candidates);
+
+		// 25 candidates at a batch size of 12 → 3 calls.
+		expect(triageOutput).toHaveBeenCalledTimes(3);
+	});
+
+	it("returns only candidates adjudged to be real contradictions", async () => {
+		adjudicationOutput.mockResolvedValue({
+			verdicts: [
+				{
+					index: 0,
+					isContradiction: true,
+					confidence: "high",
+					question:
+						"Session 12 recorded the death; session 19 references him. Intentional?",
+					detail: "Check whether the death was faked.",
+				},
+				{ index: 1, isContradiction: false, confidence: "low" },
+			],
+		});
+
+		const results = await buildService().adjudicate([
+			candidate(0),
+			candidate(1),
+		]);
+
+		expect(results).toHaveLength(1);
+		expect(results[0].confidence).toBe("high");
+		expect(results[0].question).toContain("Intentional?");
+		expect(results[0].detail).toBe("Check whether the death was faked.");
+	});
+
+	it("falls back to the detector's phrasing when the model returns none", async () => {
+		adjudicationOutput.mockResolvedValue({
+			verdicts: [{ index: 0, isContradiction: true, confidence: "medium" }],
+		});
+
+		const [result] = await buildService().adjudicate([candidate(0)]);
+
+		expect(result.question).toBe("Deterministic question 0");
+		expect(result.detail).toBeNull();
+	});
+
+	it("treats an unrecognised confidence value as low", async () => {
+		adjudicationOutput.mockResolvedValue({
+			verdicts: [{ index: 0, isContradiction: true, confidence: "very sure" }],
+		});
+
+		const [result] = await buildService().adjudicate([candidate(0)]);
+
+		expect(result.confidence).toBe("low");
+	});
+
+	it("ignores verdicts pointing at a candidate index that does not exist", async () => {
+		adjudicationOutput.mockResolvedValue({
+			verdicts: [{ index: 99, isContradiction: true, confidence: "high" }],
+		});
+
+		expect(await buildService().adjudicate([candidate(0)])).toEqual([]);
+	});
+
+	it("makes no provider calls for an empty candidate list", async () => {
+		const service = buildService();
+
+		expect(await service.triage([])).toEqual([]);
+		expect(await service.adjudicate([])).toEqual([]);
+		expect(triageOutput).not.toHaveBeenCalled();
+		expect(adjudicationOutput).not.toHaveBeenCalled();
+	});
+});

--- a/tests/services/continuity-checker-service.test.ts
+++ b/tests/services/continuity-checker-service.test.ts
@@ -1,0 +1,364 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getDAOFactory } from "@/dao/dao-factory";
+import type { ContinuityAdjudicationService } from "@/services/continuity/continuity-adjudication-service";
+import { ContinuityCheckerService } from "@/services/continuity/continuity-checker-service";
+import { loadContinuityCorpus } from "@/services/continuity/continuity-corpus";
+import type {
+	ContinuityCandidate,
+	ContinuityFinding,
+} from "@/types/continuity";
+
+vi.mock("@/dao/dao-factory", () => ({
+	getDAOFactory: vi.fn(),
+}));
+
+vi.mock("@/services/continuity/continuity-corpus", async (importOriginal) => {
+	const actual =
+		await importOriginal<
+			typeof import("@/services/continuity/continuity-corpus")
+		>();
+	return { ...actual, loadContinuityCorpus: vi.fn() };
+});
+
+vi.mock("@/services/graph/world-state-changelog-service", () => ({
+	WorldStateChangelogService: class {
+		async recordChangelog() {
+			return { id: "changelog-entry-1" };
+		}
+	},
+}));
+
+const CAMPAIGN_ID = "camp-1";
+const DB = {} as D1Database;
+
+function emptyCorpus(maxSessionNumber: number | null = 12) {
+	return {
+		campaignId: CAMPAIGN_ID,
+		digests: [],
+		changelog: [],
+		entityNames: new Map<string, string>(),
+		neighbors: new Map<string, Set<string>>(),
+		maxSessionNumber,
+	};
+}
+
+function candidate(
+	overrides: Partial<ContinuityCandidate> = {}
+): ContinuityCandidate {
+	return {
+		fingerprint: "state_contradiction:abc123",
+		type: "state_contradiction",
+		subjectEntityId: `${CAMPAIGN_ID}_vane`,
+		subjectName: "Vane",
+		question: "Session 12 recorded Vane's death; session 19 references him.",
+		rationale: "Vane was marked dead and never restored.",
+		evidence: [
+			{
+				source: "world_state_changelog",
+				label: "Session 12 world state",
+				referenceId: "cl-12",
+				sessionNumber: 12,
+				excerpt: 'Vane recorded as "dead".',
+			},
+			{
+				source: "session_digest",
+				label: "Session 19 digest",
+				referenceId: "digest-19",
+				sessionNumber: 19,
+				excerpt: "Vane, still scheming",
+			},
+		],
+		earlierSession: 12,
+		laterSession: 19,
+		...overrides,
+	};
+}
+
+function finding(
+	overrides: Partial<ContinuityFinding> = {}
+): ContinuityFinding {
+	return {
+		id: "finding-1",
+		campaignId: CAMPAIGN_ID,
+		fingerprint: "state_contradiction:abc123",
+		findingType: "state_contradiction",
+		confidence: "high",
+		question: "Intentional?",
+		detail: null,
+		evidence: [],
+		subjectEntityId: `${CAMPAIGN_ID}_vane`,
+		subjectName: "Vane",
+		status: "open",
+		resolutionNote: null,
+		resolvedBy: null,
+		resolvedAt: null,
+		scanId: "scan-1",
+		detectedAt: "2025-01-01T00:00:00Z",
+		updatedAt: "2025-01-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+describe("ContinuityCheckerService", () => {
+	let dao: {
+		getScanState: ReturnType<typeof vi.fn>;
+		getKnownFingerprints: ReturnType<typeof vi.fn>;
+		createFinding: ReturnType<typeof vi.fn>;
+		getFindingById: ReturnType<typeof vi.fn>;
+		updateFindingStatus: ReturnType<typeof vi.fn>;
+		recordScan: ReturnType<typeof vi.fn>;
+	};
+	let adjudication: {
+		triage: ReturnType<typeof vi.fn>;
+		adjudicate: ReturnType<typeof vi.fn>;
+	};
+
+	function buildService() {
+		return new ContinuityCheckerService({
+			db: DB,
+			env: {},
+			adjudicationService:
+				adjudication as unknown as ContinuityAdjudicationService,
+		});
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		dao = {
+			getScanState: vi.fn(async () => null),
+			getKnownFingerprints: vi.fn(async () => new Set<string>()),
+			createFinding: vi.fn(async () => true),
+			getFindingById: vi.fn(async () => finding()),
+			updateFindingStatus: vi.fn(async () => undefined),
+			recordScan: vi.fn(async () => undefined),
+		};
+		vi.mocked(getDAOFactory).mockReturnValue({
+			continuityFindingDAO: dao,
+			// The rules detector runs by default and reads rules through entityDAO.
+			entityDAO: { listEntitiesByCampaign: vi.fn(async () => []) },
+		} as never);
+		vi.mocked(loadContinuityCorpus).mockResolvedValue(emptyCorpus() as never);
+		adjudication = {
+			triage: vi.fn(async (items: ContinuityCandidate[]) => items),
+			adjudicate: vi.fn(async (items: ContinuityCandidate[]) =>
+				items.map((item) => ({
+					candidate: item,
+					confidence: "high" as const,
+					question: item.question,
+					detail: "Check the session 12 recap.",
+				}))
+			),
+		};
+	});
+
+	it("records the scan watermark so the next incremental run is bounded", async () => {
+		const result = await buildService().scan(CAMPAIGN_ID);
+
+		expect(result.mode).toBe("incremental");
+		expect(dao.recordScan).toHaveBeenCalledWith({
+			campaignId: CAMPAIGN_ID,
+			scanId: result.scanId,
+			mode: "incremental",
+			lastScannedSession: 12,
+		});
+	});
+
+	it("scans from the session after the watermark on an incremental run", async () => {
+		dao.getScanState.mockResolvedValue({
+			campaignId: CAMPAIGN_ID,
+			lastScannedSession: 8,
+			lastScanId: "scan-0",
+			lastScanMode: "incremental",
+			lastScanAt: "2025-01-01T00:00:00Z",
+		});
+
+		const result = await buildService().scan(CAMPAIGN_ID);
+
+		expect(result.scannedFromSession).toBe(9);
+	});
+
+	it("ignores the watermark on a full scan", async () => {
+		dao.getScanState.mockResolvedValue({
+			campaignId: CAMPAIGN_ID,
+			lastScannedSession: 8,
+			lastScanId: "scan-0",
+			lastScanMode: "incremental",
+			lastScanAt: "2025-01-01T00:00:00Z",
+		});
+
+		const result = await buildService().scan(CAMPAIGN_ID, { mode: "full" });
+
+		expect(result.scannedFromSession).toBeNull();
+	});
+
+	it("never re-reviews a fingerprint already on record", async () => {
+		vi.mocked(loadContinuityCorpus).mockResolvedValue({
+			...emptyCorpus(),
+			entityNames: new Map([[`${CAMPAIGN_ID}_vane`, "Vane"]]),
+			changelog: [
+				{
+					id: "cl-12",
+					sessionNumber: 12,
+					timestamp: "2025-01-12T00:00:00Z",
+					payload: {
+						campaign_session_id: 12,
+						timestamp: "2025-01-12T00:00:00Z",
+						entity_updates: [
+							{ entity_id: `${CAMPAIGN_ID}_vane`, status: "dead" },
+						],
+						relationship_updates: [],
+						new_entities: [],
+					},
+				},
+			],
+			digests: [
+				{
+					id: "digest-19",
+					sessionNumber: 19,
+					sessionDate: null,
+					createdAt: "2025-01-19T00:00:00Z",
+					data: {} as never,
+					blocks: [{ field: "npcs_to_run", text: "Vane, still scheming" }],
+				},
+			],
+		} as never);
+
+		const generated = await buildService().scan(CAMPAIGN_ID);
+		expect(generated.candidatesGenerated).toBe(1);
+
+		// Re-run with the fingerprint the first pass produced marked as known —
+		// this is the mechanism that keeps a dismissed finding dismissed.
+		const firstFingerprint =
+			adjudication.triage.mock.calls[0][0][0].fingerprint;
+		dao.getKnownFingerprints.mockResolvedValue(new Set([firstFingerprint]));
+		adjudication.triage.mockClear();
+
+		const rerun = await buildService().scan(CAMPAIGN_ID, { mode: "full" });
+
+		expect(rerun.candidatesAlreadyKnown).toBe(1);
+		expect(rerun.candidatesTriaged).toBe(0);
+		expect(adjudication.triage).not.toHaveBeenCalled();
+	});
+
+	it("drops findings below the requested confidence floor", async () => {
+		adjudication.adjudicate.mockResolvedValue([
+			{
+				candidate: candidate(),
+				confidence: "low",
+				question: "Maybe?",
+				detail: null,
+			},
+		]);
+		adjudication.triage.mockResolvedValue([candidate()]);
+
+		const result = await buildService().scan(CAMPAIGN_ID, {
+			minConfidence: "high",
+		});
+
+		expect(dao.createFinding).not.toHaveBeenCalled();
+		expect(result.findingsCreated).toBe(0);
+	});
+
+	it("warns and produces nothing when no provider key is configured", async () => {
+		const service = new ContinuityCheckerService({ db: DB, env: {} });
+		vi.mocked(loadContinuityCorpus).mockResolvedValue({
+			...emptyCorpus(),
+			entityNames: new Map([[`${CAMPAIGN_ID}_vane`, "Vane"]]),
+			changelog: [
+				{
+					id: "cl-12",
+					sessionNumber: 12,
+					timestamp: "2025-01-12T00:00:00Z",
+					payload: {
+						campaign_session_id: 12,
+						timestamp: "2025-01-12T00:00:00Z",
+						entity_updates: [
+							{ entity_id: `${CAMPAIGN_ID}_vane`, status: "dead" },
+						],
+						relationship_updates: [],
+						new_entities: [],
+					},
+				},
+			],
+			digests: [
+				{
+					id: "digest-19",
+					sessionNumber: 19,
+					sessionDate: null,
+					createdAt: "2025-01-19T00:00:00Z",
+					data: {} as never,
+					blocks: [{ field: "npcs_to_run", text: "Vane, still scheming" }],
+				},
+			],
+		} as never);
+
+		const result = await service.scan(CAMPAIGN_ID);
+
+		expect(result.findingsCreated).toBe(0);
+		expect(result.warnings.join(" ")).toContain("No LLM provider API key");
+	});
+
+	describe("resolveFinding", () => {
+		it("marks a dismissed finding so it can never resurface", async () => {
+			dao.getFindingById.mockResolvedValue(finding());
+
+			await buildService().resolveFinding(CAMPAIGN_ID, "finding-1", {
+				action: "dismiss",
+				note: "Vane faked his death on purpose.",
+				resolvedBy: "gm@example.com",
+			});
+
+			expect(dao.updateFindingStatus).toHaveBeenCalledWith(
+				"finding-1",
+				"dismissed",
+				{
+					resolutionNote: "Vane faked his death on purpose.",
+					resolvedBy: "gm@example.com",
+				}
+			);
+		});
+
+		it("writes a correction back to world state", async () => {
+			dao.getFindingById.mockResolvedValue(finding());
+
+			const result = await buildService().resolveFinding(
+				CAMPAIGN_ID,
+				"finding-1",
+				{
+					action: "correct",
+					correction: { status: "alive", campaignSessionId: 19 },
+				}
+			);
+
+			expect(result.changelogEntryId).toBe("changelog-entry-1");
+			expect(dao.updateFindingStatus).toHaveBeenCalledWith(
+				"finding-1",
+				"corrected",
+				expect.anything()
+			);
+		});
+
+		it("refuses a correction with no corrected status", async () => {
+			dao.getFindingById.mockResolvedValue(finding());
+
+			await expect(
+				buildService().resolveFinding(CAMPAIGN_ID, "finding-1", {
+					action: "correct",
+				})
+			).rejects.toThrow(/requires an entity id and a corrected status/);
+		});
+
+		it("rejects a finding belonging to another campaign", async () => {
+			dao.getFindingById.mockResolvedValue(
+				finding({ campaignId: "other-campaign" })
+			);
+
+			await expect(
+				buildService().resolveFinding(CAMPAIGN_ID, "finding-1", {
+					action: "confirm",
+				})
+			).rejects.toThrow(/not found/i);
+		});
+	});
+});

--- a/tests/services/continuity-detectors.test.ts
+++ b/tests/services/continuity-detectors.test.ts
@@ -1,0 +1,575 @@
+import { describe, expect, it } from "vitest";
+import type { CampaignRule } from "@/services/campaign/rules-context-service";
+import type {
+	ContinuityCorpus,
+	CorpusChangelogEntry,
+	CorpusDigest,
+} from "@/services/continuity/continuity-corpus";
+import { digestTextBlocks } from "@/services/continuity/continuity-corpus";
+import {
+	buildFingerprint,
+	isMatchableName,
+	mentionsName,
+	tokenOverlap,
+} from "@/services/continuity/continuity-text-utils";
+import {
+	classifyEntityStatus,
+	classifyRelationshipStatus,
+	looksLikeRuling,
+} from "@/services/continuity/continuity-vocabulary";
+import { detectDanglingThreads } from "@/services/continuity/detect-dangling-threads";
+import { detectRelationshipContradictions } from "@/services/continuity/detect-relationship-contradictions";
+import { detectRulesContradictions } from "@/services/continuity/detect-rules-contradictions";
+import { detectStateContradictions } from "@/services/continuity/detect-state-contradictions";
+import { detectTimelineContradictions } from "@/services/continuity/detect-timeline-contradictions";
+import type { SessionDigestData } from "@/types/session-digest";
+
+const CAMPAIGN_ID = "camp-1";
+
+function digestData(
+	overrides: Partial<{
+		keyEvents: string[];
+		openThreads: string[];
+		npcsToRun: string[];
+		beats: string[];
+	}> = {}
+): SessionDigestData {
+	return {
+		last_session_recap: {
+			key_events: overrides.keyEvents ?? [],
+			state_changes: { factions: [], locations: [], npcs: [] },
+			open_threads: overrides.openThreads ?? [],
+		},
+		next_session_plan: {
+			objectives_dm: [],
+			probable_player_goals: [],
+			beats: overrides.beats ?? [],
+			if_then_branches: [],
+		},
+		npcs_to_run: overrides.npcsToRun ?? [],
+		locations_in_focus: [],
+		encounter_seeds: [],
+		clues_and_revelations: [],
+		treasure_and_rewards: [],
+		todo_checklist: [],
+	};
+}
+
+function digest(
+	sessionNumber: number,
+	data: SessionDigestData,
+	sessionDate: string | null = null
+): CorpusDigest {
+	return {
+		id: `digest-${sessionNumber}`,
+		sessionNumber,
+		sessionDate,
+		createdAt: `2025-01-0${Math.min(sessionNumber, 9)}T00:00:00Z`,
+		data,
+		blocks: digestTextBlocks(data),
+	};
+}
+
+function changelog(
+	id: string,
+	sessionNumber: number | null,
+	payload: Partial<CorpusChangelogEntry["payload"]>
+): CorpusChangelogEntry {
+	return {
+		id,
+		sessionNumber,
+		timestamp: `2025-01-${String(sessionNumber ?? 1).padStart(2, "0")}T00:00:00Z`,
+		payload: {
+			campaign_session_id: sessionNumber,
+			timestamp: `2025-01-${String(sessionNumber ?? 1).padStart(2, "0")}T00:00:00Z`,
+			entity_updates: payload.entity_updates ?? [],
+			relationship_updates: payload.relationship_updates ?? [],
+			new_entities: payload.new_entities ?? [],
+		},
+	};
+}
+
+function corpus(overrides: Partial<ContinuityCorpus> = {}): ContinuityCorpus {
+	const digests = overrides.digests ?? [];
+	return {
+		campaignId: CAMPAIGN_ID,
+		digests,
+		changelog: overrides.changelog ?? [],
+		entityNames: overrides.entityNames ?? new Map(),
+		neighbors: overrides.neighbors ?? new Map(),
+		maxSessionNumber:
+			overrides.maxSessionNumber ??
+			(digests.length ? digests[digests.length - 1].sessionNumber : null),
+	};
+}
+
+describe("continuity text utils", () => {
+	it("matches names on whole-word boundaries only", () => {
+		expect(mentionsName("Lord Vane entered the hall", "Vane")).toBe(true);
+		expect(mentionsName("Vane's signet ring", "Vane")).toBe(true);
+		expect(mentionsName("The weathervane spun", "Vane")).toBe(false);
+	});
+
+	it("rejects short and generic single-word names", () => {
+		expect(isMatchableName("Vane")).toBe(true);
+		expect(isMatchableName("Bo")).toBe(false);
+		expect(isMatchableName("guards")).toBe(false);
+		expect(isMatchableName("The Council")).toBe(true);
+	});
+
+	it("produces stable fingerprints that ignore cosmetic differences", () => {
+		const left = buildFingerprint("state_contradiction", ["Vane", 12, 19]);
+		const right = buildFingerprint("state_contradiction", ["  vane ", 12, 19]);
+		expect(left).toBe(right);
+		expect(left).not.toBe(
+			buildFingerprint("state_contradiction", ["Vane", 12, 20])
+		);
+	});
+
+	it("scores token overlap between related and unrelated text", () => {
+		expect(
+			tokenOverlap(
+				"Find the missing courier from Blackreach",
+				"The missing courier from Blackreach was found dead"
+			)
+		).toBeGreaterThan(0.5);
+		expect(
+			tokenOverlap("Find the missing courier", "The tavern burned down")
+		).toBeLessThan(0.2);
+	});
+});
+
+describe("continuity vocabulary", () => {
+	it("buckets entity statuses", () => {
+		expect(classifyEntityStatus("dead")).toBe("removed");
+		expect(classifyEntityStatus("keep destroyed")).toBe("removed");
+		expect(classifyEntityStatus("imprisoned in Vaelport")).toBe("absent");
+		expect(classifyEntityStatus("wounded but stable")).toBe("other");
+	});
+
+	it("treats a restoration as restored even when it names the death", () => {
+		expect(classifyEntityStatus("resurrected after being killed")).toBe(
+			"restored"
+		);
+	});
+
+	it("classifies relationship polarity", () => {
+		expect(classifyRelationshipStatus("allied")).toBe("allied");
+		expect(classifyRelationshipStatus("openly hostile")).toBe("hostile");
+		expect(classifyRelationshipStatus("cordial")).toBe("neutral");
+	});
+
+	it("spots ruling-shaped digest lines", () => {
+		expect(looksLikeRuling("We ruled that flanking grants advantage")).toBe(
+			true
+		);
+		expect(looksLikeRuling("The party travelled north")).toBe(false);
+	});
+});
+
+describe("detectStateContradictions", () => {
+	const entityNames = new Map([[`${CAMPAIGN_ID}_vane`, "Vane"]]);
+
+	it("flags an entity referenced after being recorded dead", () => {
+		const candidates = detectStateContradictions(
+			corpus({
+				entityNames,
+				changelog: [
+					changelog("cl-12", 12, {
+						entity_updates: [
+							{ entity_id: `${CAMPAIGN_ID}_vane`, status: "dead" },
+						],
+					}),
+				],
+				digests: [
+					digest(12, digestData({ keyEvents: ["Vane fell to the assassin"] })),
+					digest(19, digestData({ npcsToRun: ["Vane, still scheming"] })),
+				],
+			})
+		);
+
+		expect(candidates).toHaveLength(1);
+		expect(candidates[0].type).toBe("state_contradiction");
+		expect(candidates[0].subjectName).toBe("Vane");
+		expect(candidates[0].earlierSession).toBe(12);
+		expect(candidates[0].laterSession).toBe(19);
+		expect(candidates[0].question).toContain("Intentional?");
+	});
+
+	it("always cites both sides of the contradiction", () => {
+		const [candidate] = detectStateContradictions(
+			corpus({
+				entityNames,
+				changelog: [
+					changelog("cl-12", 12, {
+						entity_updates: [
+							{ entity_id: `${CAMPAIGN_ID}_vane`, status: "dead" },
+						],
+					}),
+				],
+				digests: [digest(19, digestData({ npcsToRun: ["Vane"] }))],
+			})
+		);
+
+		expect(candidate.evidence).toHaveLength(2);
+		expect(candidate.evidence.map((item) => item.source)).toEqual([
+			"world_state_changelog",
+			"session_digest",
+		]);
+		expect(candidate.evidence[1].referenceId).toBe("digest-19");
+	});
+
+	it("does not flag a resurrection", () => {
+		const candidates = detectStateContradictions(
+			corpus({
+				entityNames,
+				changelog: [
+					changelog("cl-12", 12, {
+						entity_updates: [
+							{ entity_id: `${CAMPAIGN_ID}_vane`, status: "dead" },
+						],
+					}),
+					changelog("cl-15", 15, {
+						entity_updates: [
+							{ entity_id: `${CAMPAIGN_ID}_vane`, status: "resurrected" },
+						],
+					}),
+				],
+				digests: [digest(19, digestData({ npcsToRun: ["Vane"] }))],
+			})
+		);
+
+		expect(candidates).toEqual([]);
+	});
+
+	it("ignores mentions in the session that recorded the death", () => {
+		const candidates = detectStateContradictions(
+			corpus({
+				entityNames,
+				changelog: [
+					changelog("cl-12", 12, {
+						entity_updates: [
+							{ entity_id: `${CAMPAIGN_ID}_vane`, status: "dead" },
+						],
+					}),
+				],
+				digests: [digest(12, digestData({ keyEvents: ["Vane was killed"] }))],
+			})
+		);
+
+		expect(candidates).toEqual([]);
+	});
+
+	it("raises one question per later session, not one per matching line", () => {
+		const candidates = detectStateContradictions(
+			corpus({
+				entityNames,
+				changelog: [
+					changelog("cl-12", 12, {
+						entity_updates: [
+							{ entity_id: `${CAMPAIGN_ID}_vane`, status: "dead" },
+						],
+					}),
+				],
+				digests: [
+					digest(
+						19,
+						digestData({
+							keyEvents: ["Vane sent a courier", "Vane's seal was on it"],
+							npcsToRun: ["Vane"],
+						})
+					),
+				],
+			})
+		);
+
+		expect(candidates).toHaveLength(1);
+	});
+
+	it("respects the incremental fromSession window", () => {
+		const scanCorpus = corpus({
+			entityNames,
+			changelog: [
+				changelog("cl-12", 12, {
+					entity_updates: [
+						{ entity_id: `${CAMPAIGN_ID}_vane`, status: "dead" },
+					],
+				}),
+			],
+			digests: [digest(14, digestData({ npcsToRun: ["Vane"] }))],
+		});
+
+		expect(detectStateContradictions(scanCorpus, { fromSession: 20 })).toEqual(
+			[]
+		);
+		expect(
+			detectStateContradictions(scanCorpus, { fromSession: 13 })
+		).toHaveLength(1);
+	});
+});
+
+describe("detectRelationshipContradictions", () => {
+	const entityNames = new Map([
+		[`${CAMPAIGN_ID}_ironpact`, "Ironpact"],
+		[`${CAMPAIGN_ID}_silvercourt`, "Silvercourt"],
+	]);
+
+	const flipChangelog = [
+		changelog("cl-3", 3, {
+			relationship_updates: [
+				{
+					from: `${CAMPAIGN_ID}_ironpact`,
+					to: `${CAMPAIGN_ID}_silvercourt`,
+					new_status: "allied",
+				},
+			],
+		}),
+		changelog("cl-9", 9, {
+			relationship_updates: [
+				{
+					from: `${CAMPAIGN_ID}_ironpact`,
+					to: `${CAMPAIGN_ID}_silvercourt`,
+					new_status: "hostile",
+				},
+			],
+		}),
+	];
+
+	it("flags an unexplained allied-to-hostile reversal", () => {
+		const candidates = detectRelationshipContradictions(
+			corpus({
+				entityNames,
+				changelog: flipChangelog,
+				digests: [digest(6, digestData({ keyEvents: ["The party rested"] }))],
+			})
+		);
+
+		expect(candidates).toHaveLength(1);
+		expect(candidates[0].type).toBe("relationship_contradiction");
+		expect(candidates[0].evidence).toHaveLength(2);
+	});
+
+	it("stays quiet when an intervening session names both parties", () => {
+		const candidates = detectRelationshipContradictions(
+			corpus({
+				entityNames,
+				changelog: flipChangelog,
+				digests: [
+					digest(
+						6,
+						digestData({
+							keyEvents: ["Ironpact broke its pact with Silvercourt"],
+						})
+					),
+				],
+			})
+		);
+
+		expect(candidates).toEqual([]);
+	});
+
+	it("ignores restatements of the same polarity", () => {
+		const candidates = detectRelationshipContradictions(
+			corpus({
+				entityNames,
+				changelog: [
+					flipChangelog[0],
+					changelog("cl-5", 5, {
+						relationship_updates: [
+							{
+								from: `${CAMPAIGN_ID}_ironpact`,
+								to: `${CAMPAIGN_ID}_silvercourt`,
+								new_status: "friendly",
+							},
+						],
+					}),
+				],
+			})
+		);
+
+		expect(candidates).toEqual([]);
+	});
+});
+
+describe("detectTimelineContradictions", () => {
+	it("flags session dates that run backwards against session numbers", () => {
+		const candidates = detectTimelineContradictions(
+			corpus({
+				digests: [
+					digest(4, digestData(), "2025-03-01"),
+					digest(5, digestData(), "2025-02-01"),
+				],
+			})
+		);
+
+		expect(candidates).toHaveLength(1);
+		expect(candidates[0].type).toBe("timeline_contradiction");
+		expect(candidates[0].evidence).toHaveLength(2);
+	});
+
+	it("flags an entity named before the session that introduces it", () => {
+		const candidates = detectTimelineContradictions(
+			corpus({
+				entityNames: new Map([[`${CAMPAIGN_ID}_saltmere`, "Saltmere"]]),
+				changelog: [
+					changelog("cl-8", 8, {
+						new_entities: [
+							{ entity_id: `${CAMPAIGN_ID}_saltmere`, name: "Saltmere" },
+						],
+					}),
+				],
+				digests: [
+					digest(3, digestData({ keyEvents: ["Rumours of Saltmere"] })),
+				],
+			})
+		);
+
+		expect(candidates).toHaveLength(1);
+		expect(candidates[0].subjectName).toBe("Saltmere");
+	});
+
+	it("accepts consistent dates and orderings", () => {
+		const candidates = detectTimelineContradictions(
+			corpus({
+				digests: [
+					digest(4, digestData(), "2025-02-01"),
+					digest(5, digestData(), "2025-03-01"),
+				],
+			})
+		);
+
+		expect(candidates).toEqual([]);
+	});
+});
+
+describe("detectDanglingThreads", () => {
+	it("reports a thread nothing has picked up", () => {
+		const candidates = detectDanglingThreads(
+			corpus({
+				digests: [
+					digest(
+						1,
+						digestData({
+							openThreads: ["Who poisoned the Duke's wine at the gala?"],
+						})
+					),
+					digest(2, digestData({ keyEvents: ["The party sailed south"] })),
+					digest(3, digestData({ keyEvents: ["A storm wrecked the ship"] })),
+				],
+			})
+		);
+
+		expect(candidates).toHaveLength(1);
+		expect(candidates[0].type).toBe("dangling_thread");
+		expect(candidates[0].question).toContain("Still live?");
+	});
+
+	it("treats a thread as resolved when a later session covers it", () => {
+		const candidates = detectDanglingThreads(
+			corpus({
+				digests: [
+					digest(
+						1,
+						digestData({
+							openThreads: ["Who poisoned the Duke's wine at the gala?"],
+						})
+					),
+					digest(2, digestData()),
+					digest(
+						3,
+						digestData({
+							keyEvents: ["The steward confessed he poisoned the Duke's wine"],
+						})
+					),
+				],
+			})
+		);
+
+		expect(candidates).toEqual([]);
+	});
+
+	it("gives a recent thread time to breathe", () => {
+		const candidates = detectDanglingThreads(
+			corpus({
+				digests: [
+					digest(
+						1,
+						digestData({ openThreads: ["Who poisoned the Duke's wine?"] })
+					),
+					digest(2, digestData()),
+				],
+			})
+		);
+
+		expect(candidates).toEqual([]);
+	});
+});
+
+describe("detectRulesContradictions", () => {
+	const rules: CampaignRule[] = [
+		{
+			id: "rule-1",
+			entityId: "rule-1",
+			entityType: "house_rule",
+			name: "Flanking",
+			category: "combat",
+			text: "Flanking grants advantage on melee attack rolls.",
+			source: "house",
+			priority: 100,
+			active: true,
+			updatedAt: "2025-01-01T00:00:00Z",
+			metadata: {},
+		},
+	];
+
+	it("pairs a digest ruling with the house rule it may contradict", () => {
+		const candidates = detectRulesContradictions(
+			corpus({
+				digests: [
+					digest(
+						7,
+						digestData({
+							keyEvents: [
+								"We ruled that flanking grants no advantage on melee attack rolls this campaign.",
+							],
+						})
+					),
+				],
+			}),
+			rules
+		);
+
+		expect(candidates).toHaveLength(1);
+		expect(candidates[0].type).toBe("rules_contradiction");
+		expect(candidates[0].evidence.map((item) => item.source)).toEqual([
+			"house_rule",
+			"session_digest",
+		]);
+	});
+
+	it("ignores narration that merely shares a word with a rule", () => {
+		const candidates = detectRulesContradictions(
+			corpus({
+				digests: [
+					digest(7, digestData({ keyEvents: ["The party flanked the ogre."] })),
+				],
+			}),
+			rules
+		);
+
+		expect(candidates).toEqual([]);
+	});
+
+	it("returns nothing when the campaign has no rules", () => {
+		expect(
+			detectRulesContradictions(
+				corpus({
+					digests: [
+						digest(7, digestData({ keyEvents: ["We ruled that flanking..."] })),
+					],
+				}),
+				[]
+			)
+		).toEqual([]);
+	});
+});

--- a/tests/tools/continuity-tools.test.ts
+++ b/tests/tools/continuity-tools.test.ts
@@ -1,0 +1,457 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDaoFactory = {
+	campaignDAO: {
+		getCampaignByIdWithMapping: vi.fn(),
+		getCampaignRole: vi.fn(),
+	},
+	continuityFindingDAO: {
+		listFindingsForCampaign: vi.fn(),
+	},
+};
+
+const scanMock = vi.fn();
+const resolveFindingMock = vi.fn();
+
+vi.mock("@/dao/dao-factory", () => ({
+	getDAOFactory: vi.fn(() => mockDaoFactory),
+}));
+
+vi.mock("@/services/continuity/continuity-checker-service", () => ({
+	ContinuityCheckerService: class {
+		scan = scanMock;
+		resolveFinding = resolveFindingMock;
+	},
+}));
+
+import type { ToolResult } from "@/app-constants";
+import {
+	checkCampaignContinuityTool,
+	listContinuityFindingsTool,
+	resolveContinuityFindingTool,
+} from "@/tools/campaign-context/continuity-tools";
+import type { ToolExecuteOptions } from "@/tools/utils";
+import type { ContinuityFinding } from "@/types/continuity";
+
+const JWT = "x.eyJ1c2VybmFtZSI6Im9maXNrIn0=.y";
+
+function options(env: unknown = { DB: {} }): ToolExecuteOptions {
+	return {
+		toolCallId: "continuity-1",
+		messages: [],
+		env,
+	} as unknown as ToolExecuteOptions;
+}
+
+function finding(
+	overrides: Partial<ContinuityFinding> = {}
+): ContinuityFinding {
+	return {
+		id: "finding-1",
+		campaignId: "campaign-1",
+		fingerprint: "state_contradiction:abc123",
+		findingType: "state_contradiction",
+		confidence: "high",
+		question:
+			"Session 12 recorded Vane's death; session 19 references him. Intentional?",
+		detail: "Check whether the death was faked.",
+		evidence: [
+			{
+				source: "world_state_changelog",
+				label: "Session 12 world state",
+				referenceId: "cl-12",
+				sessionNumber: 12,
+				excerpt: 'Vane recorded as "dead".',
+			},
+			{
+				source: "session_digest",
+				label: "Session 19 digest",
+				referenceId: "digest-19",
+				sessionNumber: 19,
+				excerpt: "Vane, still scheming",
+			},
+		],
+		subjectEntityId: "campaign-1_vane",
+		subjectName: "Vane",
+		status: "open",
+		resolutionNote: null,
+		resolvedBy: null,
+		resolvedAt: null,
+		scanId: "scan-1",
+		detectedAt: "2026-01-01T00:00:00Z",
+		updatedAt: "2026-01-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+function emptyScan(overrides: Record<string, unknown> = {}) {
+	return {
+		scanId: "scan-1",
+		campaignId: "campaign-1",
+		mode: "incremental",
+		scannedFromSession: null,
+		scannedToSession: 19,
+		candidatesGenerated: 0,
+		candidatesAlreadyKnown: 0,
+		candidatesTriaged: 0,
+		candidatesAdjudicated: 0,
+		findingsCreated: 0,
+		findings: [],
+		truncated: false,
+		warnings: [],
+		...overrides,
+	};
+}
+
+describe("continuity tools", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockDaoFactory.campaignDAO.getCampaignByIdWithMapping.mockResolvedValue({
+			id: "campaign-1",
+			name: "Curse of Strahd",
+		});
+		mockDaoFactory.campaignDAO.getCampaignRole.mockResolvedValue("owner");
+		mockDaoFactory.continuityFindingDAO.listFindingsForCampaign.mockResolvedValue(
+			[]
+		);
+		scanMock.mockResolvedValue(emptyScan());
+		resolveFindingMock.mockResolvedValue({
+			finding: finding(),
+			changelogEntryId: null,
+		});
+	});
+
+	describe("checkCampaignContinuityTool", () => {
+		it("reports findings with both sides cited", async () => {
+			scanMock.mockResolvedValue(
+				emptyScan({
+					candidatesGenerated: 3,
+					candidatesAlreadyKnown: 2,
+					findingsCreated: 1,
+					findings: [finding()],
+				})
+			);
+
+			const result = (await checkCampaignContinuityTool.execute!(
+				{ campaignId: "campaign-1", jwt: JWT, mode: "incremental" },
+				options()
+			)) as ToolResult;
+
+			expect(result.result.success).toBe(true);
+			expect(result.result.message).toContain("1 continuity question(s)");
+			const data = result.result.data as {
+				findings: Array<{ evidence: unknown[]; question: string }>;
+				candidatesAlreadyKnown: number;
+			};
+			expect(data.candidatesAlreadyKnown).toBe(2);
+			expect(data.findings[0].evidence).toHaveLength(2);
+			expect(data.findings[0].question).toContain("Intentional?");
+		});
+
+		it("says so plainly when there is nothing new", async () => {
+			const result = (await checkCampaignContinuityTool.execute!(
+				{ campaignId: "campaign-1", jwt: JWT, mode: "incremental" },
+				options()
+			)) as ToolResult;
+
+			expect(result.result.success).toBe(true);
+			expect(result.result.message).toContain("No new continuity questions");
+		});
+
+		it("passes scan options through to the service", async () => {
+			await checkCampaignContinuityTool.execute!(
+				{
+					campaignId: "campaign-1",
+					jwt: JWT,
+					mode: "full",
+					types: ["state_contradiction"],
+					minConfidence: "high",
+					maxCandidates: 10,
+				},
+				options()
+			);
+
+			expect(scanMock).toHaveBeenCalledWith("campaign-1", {
+				mode: "full",
+				types: ["state_contradiction"],
+				minConfidence: "high",
+				maxCandidates: 10,
+			});
+		});
+
+		it("surfaces truncation warnings rather than implying full coverage", async () => {
+			scanMock.mockResolvedValue(
+				emptyScan({
+					truncated: true,
+					warnings: ["Candidate cap of 60 reached; 4 candidate(s) unreviewed."],
+				})
+			);
+
+			const result = (await checkCampaignContinuityTool.execute!(
+				{ campaignId: "campaign-1", jwt: JWT },
+				options()
+			)) as ToolResult;
+
+			const data = result.result.data as {
+				truncated: boolean;
+				warnings: string[];
+			};
+			expect(data.truncated).toBe(true);
+			expect(data.warnings[0]).toContain("unreviewed");
+		});
+
+		it("errors when no database binding is available", async () => {
+			const result = (await checkCampaignContinuityTool.execute!(
+				{ campaignId: "campaign-1", jwt: JWT },
+				options({})
+			)) as ToolResult;
+
+			expect(result.result.success).toBe(false);
+			expect(scanMock).not.toHaveBeenCalled();
+		});
+
+		it("refuses players — continuity is a GM tool", async () => {
+			mockDaoFactory.campaignDAO.getCampaignRole.mockResolvedValue(
+				"editor_player"
+			);
+
+			const result = (await checkCampaignContinuityTool.execute!(
+				{ campaignId: "campaign-1", jwt: JWT },
+				options()
+			)) as ToolResult;
+
+			expect(result.result.success).toBe(false);
+			expect(scanMock).not.toHaveBeenCalled();
+		});
+
+		it("reports a scan failure instead of throwing", async () => {
+			scanMock.mockRejectedValue(new Error("provider exploded"));
+
+			const result = (await checkCampaignContinuityTool.execute!(
+				{ campaignId: "campaign-1", jwt: JWT },
+				options()
+			)) as ToolResult;
+
+			expect(result.result.success).toBe(false);
+			expect(result.result.message).toContain("Failed to check");
+		});
+	});
+
+	describe("listContinuityFindingsTool", () => {
+		it("shows only high-confidence findings by default", async () => {
+			mockDaoFactory.continuityFindingDAO.listFindingsForCampaign.mockResolvedValue(
+				[
+					finding({ id: "high-1", confidence: "high" }),
+					finding({ id: "medium-1", confidence: "medium" }),
+					finding({ id: "low-1", confidence: "low" }),
+				]
+			);
+
+			const result = (await listContinuityFindingsTool.execute!(
+				{ campaignId: "campaign-1", jwt: JWT, status: "open", limit: 25 },
+				options()
+			)) as ToolResult;
+
+			const data = result.result.data as {
+				total: number;
+				shown: number;
+				findings: Array<{ id: string }>;
+			};
+			expect(data.total).toBe(3);
+			expect(data.shown).toBe(1);
+			expect(data.findings[0].id).toBe("high-1");
+		});
+
+		it("shows every confidence tier when asked", async () => {
+			mockDaoFactory.continuityFindingDAO.listFindingsForCampaign.mockResolvedValue(
+				[
+					finding({ id: "high-1", confidence: "high" }),
+					finding({ id: "low-1", confidence: "low" }),
+				]
+			);
+
+			const result = (await listContinuityFindingsTool.execute!(
+				{
+					campaignId: "campaign-1",
+					jwt: JWT,
+					status: "open",
+					highConfidenceOnly: false,
+					limit: 25,
+				},
+				options()
+			)) as ToolResult;
+
+			expect((result.result.data as { shown: number }).shown).toBe(2);
+		});
+
+		it("reports an empty result without inventing findings", async () => {
+			const result = (await listContinuityFindingsTool.execute!(
+				{ campaignId: "campaign-1", jwt: JWT, status: "open", limit: 25 },
+				options()
+			)) as ToolResult;
+
+			expect(result.result.success).toBe(true);
+			expect(result.result.message).toContain("No open continuity findings");
+		});
+
+		it("forwards status and type filters to the DAO", async () => {
+			await listContinuityFindingsTool.execute!(
+				{
+					campaignId: "campaign-1",
+					jwt: JWT,
+					status: "dismissed",
+					types: ["dangling_thread"],
+					limit: 5,
+				},
+				options()
+			);
+
+			expect(
+				mockDaoFactory.continuityFindingDAO.listFindingsForCampaign
+			).toHaveBeenCalledWith("campaign-1", {
+				status: "dismissed",
+				types: ["dangling_thread"],
+				limit: 5,
+			});
+		});
+
+		it("reports a listing failure instead of throwing", async () => {
+			mockDaoFactory.continuityFindingDAO.listFindingsForCampaign.mockRejectedValue(
+				new Error("d1 unavailable")
+			);
+
+			const result = (await listContinuityFindingsTool.execute!(
+				{ campaignId: "campaign-1", jwt: JWT, status: "open", limit: 25 },
+				options()
+			)) as ToolResult;
+
+			expect(result.result.success).toBe(false);
+			expect(result.result.message).toContain("Failed to list");
+		});
+	});
+
+	describe("resolveContinuityFindingTool", () => {
+		it("dismisses a finding and attributes it to the caller", async () => {
+			resolveFindingMock.mockResolvedValue({
+				finding: finding({ status: "dismissed" }),
+				changelogEntryId: null,
+			});
+
+			const result = (await resolveContinuityFindingTool.execute!(
+				{
+					campaignId: "campaign-1",
+					jwt: JWT,
+					findingId: "finding-1",
+					action: "dismiss",
+					note: "Vane faked his death on purpose.",
+				},
+				options()
+			)) as ToolResult;
+
+			expect(result.result.success).toBe(true);
+			expect(result.result.message).toContain("Dismissed");
+			expect(resolveFindingMock).toHaveBeenCalledWith(
+				"campaign-1",
+				"finding-1",
+				{
+					action: "dismiss",
+					note: "Vane faked his death on purpose.",
+					resolvedBy: "ofisk",
+					correction: {
+						entityId: null,
+						status: null,
+						campaignSessionId: null,
+					},
+				}
+			);
+		});
+
+		it("confirms a finding", async () => {
+			const result = (await resolveContinuityFindingTool.execute!(
+				{
+					campaignId: "campaign-1",
+					jwt: JWT,
+					findingId: "finding-1",
+					action: "confirm",
+				},
+				options()
+			)) as ToolResult;
+
+			expect(result.result.message).toContain("Confirmed");
+		});
+
+		it("returns the changelog entry a correction wrote back", async () => {
+			resolveFindingMock.mockResolvedValue({
+				finding: finding({ status: "corrected" }),
+				changelogEntryId: "changelog-1",
+			});
+
+			const result = (await resolveContinuityFindingTool.execute!(
+				{
+					campaignId: "campaign-1",
+					jwt: JWT,
+					findingId: "finding-1",
+					action: "correct",
+					correctedEntityId: "campaign-1_vane",
+					correctedStatus: "alive",
+					campaignSessionId: 19,
+				},
+				options()
+			)) as ToolResult;
+
+			expect(result.result.message).toContain("Corrected");
+			expect(
+				(result.result.data as { changelogEntryId: string }).changelogEntryId
+			).toBe("changelog-1");
+			expect(resolveFindingMock).toHaveBeenCalledWith(
+				"campaign-1",
+				"finding-1",
+				expect.objectContaining({
+					correction: {
+						entityId: "campaign-1_vane",
+						status: "alive",
+						campaignSessionId: 19,
+					},
+				})
+			);
+		});
+
+		it("reports a resolution failure instead of throwing", async () => {
+			resolveFindingMock.mockRejectedValue(
+				new Error("Continuity finding not found")
+			);
+
+			const result = (await resolveContinuityFindingTool.execute!(
+				{
+					campaignId: "campaign-1",
+					jwt: JWT,
+					findingId: "missing",
+					action: "confirm",
+				},
+				options()
+			)) as ToolResult;
+
+			expect(result.result.success).toBe(false);
+			expect(result.result.message).toContain("Failed to resolve");
+		});
+
+		it("refuses players", async () => {
+			mockDaoFactory.campaignDAO.getCampaignRole.mockResolvedValue(
+				"readonly_player"
+			);
+
+			const result = (await resolveContinuityFindingTool.execute!(
+				{
+					campaignId: "campaign-1",
+					jwt: JWT,
+					findingId: "finding-1",
+					action: "dismiss",
+				},
+				options()
+			)) as ToolResult;
+
+			expect(result.result.success).toBe(false);
+			expect(resolveFindingMock).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
Closes #744.

Finds likely contradictions across session digests, world state changes and the entity graph, and reports them as **questions a GM can adjudicate in seconds** — not as errors.

## What it detects

| Type | Signal |
| --- | --- |
| `state_contradiction` | Entity recorded dead/destroyed/departed, then referenced as present |
| `timeline_contradiction` | Session dates running backwards against session numbers; an entity named before the session that introduces it |
| `relationship_contradiction` | Allied factions later described as hostile (or the reverse) with no intervening session recording why |
| `rules_contradiction` | A ruling recorded in a digest that clashes with an active house rule — extends `checkHouseRuleConflictTool` beyond pairwise rule checks |
| `dangling_thread` | A hook introduced and never picked up again. Not an error — the planning prompt a GM most wants |

## False positives were the design problem, not the plumbing

A checker that cries wolf gets switched off after one use. Five mechanisms:

1. **Restoration clears the mark.** The changelog walk *deletes* an entity's death mark on a later "resurrected"/"returned"/"rebuilt" status. Resurrections never reach a model.
2. **Both prompt tiers are biased toward silence** — they share an explicit list of innocent explanations (disguise, faked death, unreliable narrator, flashback, shared names, memorials) and are told a miss is cheaper than a false alarm.
3. **Every finding cites both sides.** `evidence` is `NOT NULL`; every candidate carries ≥2 entries with deep-linkable reference ids.
4. **Findings are questions.** *"Session 12 recorded Vane's death; session 19 references him. Intentional?"*
5. **Dismissals are permanent** — see below.

### Dismissals never resurface

Each candidate carries a stable FNV-1a `fingerprint` over its normalized facts. `continuity_findings` has `UNIQUE(campaign_id, fingerprint)` and inserts use `INSERT OR IGNORE`, so re-detection is a no-op whatever the existing row's status. No separate dismissal list to keep in sync — and scans subtract known fingerprints *before* spending a token, so dismissed findings cost nothing on later runs.

## Cost

Follows the issue's guidance exactly:

- **Incremental by default.** `continuity_scan_state` holds a per-campaign watermark; incremental scans only treat sessions newer than it as the later side of a contradiction. Full scans are explicit.
- **Narrow deterministically first.** Five pure detectors run over a corpus loaded in three queries. Candidate volume scales with *recorded state changes*, not entity count — an entity nobody killed is never a candidate.
- **Cheap tier triages, quality tier adjudicates.** Triage on `PIPELINE_ANALYSIS` (Haiku), survivors only to `PIPELINE_STRUCTURED` (Sonnet). Dangling threads skip adjudication entirely.
- **Batched and capped.** 12 per triage call, 5 per adjudication call, 60 candidates per scan by default. When the cap bites the scan reports `truncated: true` and how many went unreviewed, rather than implying full coverage.

## Surface

GM-only throughout (`requireCanEdit` on routes, `requireGMRole` in tools; not in the player tool bundle).

- `POST /campaigns/:id/continuity/scan`
- `GET /campaigns/:id/continuity/findings` — **defaults to high-confidence only**
- `POST /campaigns/:id/continuity/findings/:findingId/resolve` — confirm / dismiss / correct

`correct` writes a `world_state_changelog` entry tagged `source: "continuity_correction"` with the finding id, so the fix flows into the graph on the next rebuild rather than living only in the report.

Agent tools: `checkCampaignContinuityTool`, `listContinuityFindingsTool`, `resolveContinuityFindingTool`.

## Verification

- `npm run check` — clean (the 7 remaining `tsc` errors pre-exist on `main`: stale `worker-configuration.d.ts` around `Queue<T>` and `ToolExecutionOptions`; confirmed by stashing)
- `npm run complexity` — passes
- `npx vitest run` — **163 files, 1437 tests, all passing**; 52 new tests across detectors, orchestration, the model tiers and the DAO
- `npm run build` + bundle size — within budget (+0.1 kB; server-side only)
- Migration applied against SQLite directly: duplicate fingerprint inserts collapse to one row, the watermark never moves backwards, `CHECK` constraints enforced

Docs: `docs/CONTINUITY_CHECKER.md`, indexed in `docs/README.md`, including the tuning constants and the rule that when tuning you should always prefer the direction producing *fewer* findings.

Migration renumbered to `0029` after rebasing past the runsheet feature's `0028`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
