### PR TITLE
feat(chat): make agent turns interruptible (#277)

### DIFF
--- a/complexity-baseline.json
+++ b/complexity-baseline.json
@@ -17,10 +17,6 @@
 			"ccn": 19,
 			"count": 1
 		},
-		"src/agents/base-agent.ts::onFinish": {
-			"ccn": 41,
-			"count": 1
-		},
 		"src/components/BlockingAuthenticationModal.tsx::handleGoogleCompleteSignup": {
 			"ccn": 17,
 			"count": 1

--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -644,7 +644,10 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 	 * - Streaming response generation
 	 *
 	 * @param onFinish - Callback function called when the response is complete
-	 * @param _options - Optional configuration including abort signal
+	 * @param options - Optional configuration including an abort signal. When the
+	 *   signal fires (user pressed Stop, or a newer turn superseded this one) the
+	 *   in-flight LLM call and tool loop are cancelled and whatever text was
+	 *   generated so far is persisted as an interrupted assistant message.
 	 *
 	 * @returns Promise that resolves when the response is complete
 	 *
@@ -657,8 +660,9 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 	 */
 	async onChatMessage(
 		onFinish: (message: any) => void | Promise<void>,
-		_options?: { abortSignal?: AbortSignal }
+		options?: { abortSignal?: AbortSignal }
 	): Promise<Response> {
+		const abortSignal = options?.abortSignal;
 		const log = createLogger(
 			this.env as Record<string, unknown>,
 			`[${this.constructor.name}]`
@@ -1079,6 +1083,131 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 
 		const MESSAGE_COMPRESSION_THRESHOLD = 30;
 
+		type TurnUsage = {
+			totalTokens?: number;
+			promptTokens?: number;
+			completionTokens?: number;
+		};
+
+		const totalTokensOf = (usage: TurnUsage | undefined): number => {
+			if (!usage) return 0;
+			return (
+				usage.totalTokens ??
+				(usage.promptTokens ?? 0) + (usage.completionTokens ?? 0)
+			);
+		};
+
+		/** Diagnostic payload for spends that were not written to D1. */
+		const buildVerboseUsageExtras = (
+			usage: TurnUsage | undefined,
+			finishReason: string | null,
+			tokens: number
+		): Record<string, unknown> => {
+			const extras: Record<string, unknown> = {
+				finishReason: finishReason ?? null,
+				agent: this.constructor.name,
+			};
+			if (usage) {
+				extras.promptTokens = usage.promptTokens;
+				extras.completionTokens = usage.completionTokens;
+				extras.totalTokens = usage.totalTokens;
+			} else {
+				extras.usageUnavailable = true;
+			}
+			if (tokens > 0 && !this.env?.DB) extras.d1Unavailable = true;
+			if (tokens === 0) extras.zeroTokenFinish = true;
+			return extras;
+		};
+
+		/**
+		 * Record token spend for this turn. Called from both the normal finish
+		 * path and the abort path — an interrupted turn still burned the tokens
+		 * it produced before the user stopped it, so it still counts against quota.
+		 */
+		const recordTurnUsage = async (
+			usage: TurnUsage | undefined,
+			finishReason: string | null,
+			source: string
+		) => {
+			if (!clientJwt || isHelpRequestForUsage) return;
+			try {
+				const username = parseUsernameFromClientJwt(clientJwt);
+				const tokens = totalTokensOf(usage);
+				const envRecord = this.env as Record<string, unknown> | undefined;
+
+				if (username && tokens > 0 && this.env?.DB) {
+					const rateLimitService = getLLMRateLimitService(
+						this.env as Parameters<typeof getLLMRateLimitService>[0]
+					);
+					await rateLimitService.recordUsage(username, tokens, 1, undefined, {
+						intent: LLM_SPEND_INTENT.user_prompt,
+						source,
+						agent: this.constructor.name,
+						promptTokens: usage?.promptTokens,
+						completionTokens: usage?.completionTokens,
+						totalTokens: usage?.totalTokens,
+					});
+					return;
+				}
+
+				if (!username || !isVerboseLlmSpendEnabled(envRecord)) return;
+				logVerboseLlmSpend(envRecord, {
+					intent: LLM_SPEND_INTENT.user_prompt,
+					source,
+					username,
+					tokens,
+					queryCount: 1,
+					extras: buildVerboseUsageExtras(usage, finishReason, tokens),
+				});
+			} catch (err) {
+				log.warn("Failed to record LLM usage", err);
+			}
+		};
+
+		/**
+		 * Persist an assistant turn to D1. Shared by the finish and abort paths so
+		 * a stopped turn keeps the text it already streamed to the user instead of
+		 * disappearing on the next history load.
+		 */
+		const persistAssistantTurn = async (
+			text: string,
+			extra?: {
+				explainability?: Explainability | null;
+				interrupted?: boolean;
+			}
+		) => {
+			const content = sanitizeGeneratedAssistantText(text);
+			if (!content.trim()) return;
+			if (!(this.env && "DB" in this.env && this.env.DB)) return;
+
+			const assistantData: {
+				jwt?: string | null;
+				campaignId?: string | null;
+				sessionId?: string;
+				explainability?: Explainability | null;
+				interrupted?: boolean;
+			} = {};
+			if (clientJwt) assistantData.jwt = clientJwt;
+			if (selectedCampaignId) assistantData.campaignId = selectedCampaignId;
+			const sessionIdFromUser = (lastUserMessage as any)?.data?.sessionId;
+			assistantData.sessionId =
+				(typeof sessionIdFromUser === "string" &&
+					sessionIdFromUser.length > 0 &&
+					sessionIdFromUser) ||
+				this.ctx?.id?.toString() ||
+				`session-${Date.now()}`;
+			if (extra?.explainability)
+				assistantData.explainability = extra.explainability;
+			if (extra?.interrupted) assistantData.interrupted = true;
+
+			const assistantMessage: ChatMessage = {
+				role: "assistant",
+				content,
+				data: assistantData,
+			};
+			await this.storeMessageToDatabase(assistantMessage);
+		};
+
 		const sampling =
 			MODEL_CONFIG.PROVIDER.DEFAULT === "anthropic"
 				? anthropicSamplingParams(
@@ -1095,6 +1224,10 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 			tools: enhancedTools,
 			...sampling,
 			maxOutputTokens: MODEL_CONFIG.PARAMETERS.MAX_TOKENS,
+			// Cancels the provider call and the multi-step tool loop when the user
+			// stops the turn. Without this a "stopped" turn keeps generating (and
+			// keeps billing) server-side long after the client stopped listening.
+			...(abortSignal ? { abortSignal } : {}),
 			stopWhen: stepCountIs(MAX_AGENT_STEPS),
 			prepareStep: async ({ messages }) => {
 				if (messages.length > MESSAGE_COMPRESSION_THRESHOLD) {
@@ -1127,72 +1260,11 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 					durationMs: Date.now() - turnStartedAt,
 				});
 				// Record LLM usage for rate limiting (chat consumes quota)
-				if (clientJwt && !isHelpRequestForUsage) {
-					try {
-						const username = parseUsernameFromClientJwt(clientJwt);
-						const usage = (args?.totalUsage ?? args?.usage) as
-							| {
-									totalTokens?: number;
-									promptTokens?: number;
-									completionTokens?: number;
-							  }
-							| undefined;
-						const tokens = usage
-							? (usage.totalTokens ??
-								(usage.promptTokens ?? 0) + (usage.completionTokens ?? 0))
-							: 0;
-						const envRecord = this.env as Record<string, unknown> | undefined;
-						const verbose = isVerboseLlmSpendEnabled(envRecord);
-
-						if (username && tokens > 0 && this.env?.DB) {
-							const rateLimitService = getLLMRateLimitService(
-								this.env as Parameters<typeof getLLMRateLimitService>[0]
-							);
-							await rateLimitService.recordUsage(
-								username,
-								tokens,
-								1,
-								undefined,
-								{
-									intent: LLM_SPEND_INTENT.user_prompt,
-									source: "base_agent:onChatMessage",
-									agent: this.constructor.name,
-									promptTokens: usage?.promptTokens,
-									completionTokens: usage?.completionTokens,
-									totalTokens: usage?.totalTokens,
-								}
-							);
-						} else if (verbose && username) {
-							const extras: Record<string, unknown> = {
-								finishReason: args?.finishReason ?? null,
-								agent: this.constructor.name,
-							};
-							if (usage) {
-								extras.promptTokens = usage.promptTokens;
-								extras.completionTokens = usage.completionTokens;
-								extras.totalTokens = usage.totalTokens;
-							} else {
-								extras.usageUnavailable = true;
-							}
-							if (tokens > 0 && !this.env?.DB) {
-								extras.d1Unavailable = true;
-							}
-							if (tokens === 0) {
-								extras.zeroTokenFinish = true;
-							}
-							logVerboseLlmSpend(envRecord, {
-								intent: LLM_SPEND_INTENT.user_prompt,
-								source: "base_agent:onChatMessage",
-								username,
-								tokens,
-								queryCount: 1,
-								extras,
-							});
-						}
-					} catch (err) {
-						log.warn("Failed to record LLM usage", err);
-					}
-				}
+				await recordTurnUsage(
+					(args?.totalUsage ?? args?.usage) as TurnUsage | undefined,
+					args?.finishReason ?? null,
+					"base_agent:onChatMessage"
+				);
 				// Persist assistant message with explainability
 				try {
 					const fullText = await result.text;
@@ -1202,39 +1274,60 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 					} catch (e) {
 						log.warn("Failed to build explainability", e);
 					}
-					const assistantData: {
-						jwt?: string | null;
-						campaignId?: string | null;
-						sessionId?: string;
-						explainability?: Explainability | null;
-					} = {};
-					if (clientJwt) assistantData.jwt = clientJwt;
-					if (selectedCampaignId) assistantData.campaignId = selectedCampaignId;
-					const sessionIdFromUser = (lastUserMessage as any)?.data?.sessionId;
-					assistantData.sessionId =
-						(typeof sessionIdFromUser === "string" &&
-							sessionIdFromUser.length > 0 &&
-							sessionIdFromUser) ||
-						this.ctx?.id?.toString() ||
-						`session-${Date.now()}`;
-					if (explainability) assistantData.explainability = explainability;
-					const assistantMessage: ChatMessage = {
-						role: "assistant",
-						content: sanitizeGeneratedAssistantText(fullText),
-						data: assistantData,
-					};
-					if (this.env && "DB" in this.env && this.env.DB) {
-						this.storeMessageToDatabase(assistantMessage).catch((error) => {
+					void persistAssistantTurn(fullText, { explainability }).catch(
+						(error) => {
 							log.error(
 								"Failed to store assistant message to database:",
 								error
 							);
-						});
-					}
+						}
+					);
 				} catch (persistError) {
 					log.error("Error while persisting assistant message:", persistError);
 				}
 				await (onFinish ?? (() => {}))(args);
+			},
+			onAbort: async ({ steps }) => {
+				// The user pressed Stop, or a newer message superseded this turn.
+				// Keep whatever was already generated so the conversation reflects
+				// reality instead of silently dropping a half-finished answer.
+				const partialText = steps
+					.map((step: any) => step?.text ?? "")
+					.join("")
+					.trim();
+				log.info("LLM turn aborted", {
+					stepCount: steps.length,
+					partialTextLength: partialText.length,
+					durationMs: Date.now() - turnStartedAt,
+				});
+
+				const abortedUsage = steps.reduce<TurnUsage>(
+					(acc, step: any) => {
+						const usage = step?.usage as TurnUsage | undefined;
+						return {
+							promptTokens:
+								(acc.promptTokens ?? 0) + (usage?.promptTokens ?? 0),
+							completionTokens:
+								(acc.completionTokens ?? 0) + (usage?.completionTokens ?? 0),
+							totalTokens: (acc.totalTokens ?? 0) + (usage?.totalTokens ?? 0),
+						};
+					},
+					{ promptTokens: 0, completionTokens: 0, totalTokens: 0 }
+				);
+				await recordTurnUsage(
+					abortedUsage,
+					"abort",
+					"base_agent:onChatMessage_aborted"
+				);
+
+				try {
+					await persistAssistantTurn(partialText, { interrupted: true });
+				} catch (persistError) {
+					log.error(
+						"Error while persisting interrupted assistant message:",
+						persistError
+					);
+				}
 			},
 			onError: (errorObj) => {
 				const error = errorObj.error as Error & Record<string, any>;

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -132,6 +132,7 @@ export function AppShell() {
 								onKeyDown={ctx.onKeyDown}
 								isLoading={ctx.isLoading}
 								onStop={ctx.onStop}
+								onContinueGeneration={ctx.onContinueGeneration}
 								formatTime={ctx.formatTime}
 								onSuggestionSubmit={ctx.onSuggestionSubmit}
 								onWorkOnNextStep={ctx.onWorkOnNextStep}

--- a/src/components/app/ChatArea.tsx
+++ b/src/components/app/ChatArea.tsx
@@ -60,6 +60,8 @@ interface ChatAreaProps {
 	onWorkOnNextStep?: (stepLabel: string) => void;
 	/** When provided, used as step labels for "Work on this" buttons (e.g. from planning-tasks API). */
 	openPlanningTaskTitles?: string[];
+	/** Resumes the newest reply that was stopped before it finished. */
+	onContinueGeneration?: () => void;
 }
 
 /**
@@ -90,6 +92,7 @@ export function ChatArea({
 	onRegenerate,
 	onWorkOnNextStep,
 	openPlanningTaskTitles,
+	onContinueGeneration,
 }: ChatAreaProps) {
 	const [placeholder] = useState(() => getRandomPrompt());
 	const [claimOptions, setClaimOptions] = useState<PlayerCharacterOption[]>([]);
@@ -378,6 +381,8 @@ export function ChatArea({
 					invisibleUserContents={invisibleUserContents}
 					onWorkOnNextStep={onWorkOnNextStep}
 					openPlanningTaskTitles={openPlanningTaskTitles}
+					onContinueGeneration={onContinueGeneration}
+					isStreaming={isLoading}
 				/>
 
 				{/* Thinking Spinner - shown when agent is processing */}
@@ -418,12 +423,16 @@ export function ChatArea({
 							style={{ height: textareaHeight }}
 						/>
 						<div className="absolute bottom-1 right-1 p-1.5 w-fit flex flex-row justify-end">
-							{isLoading ? (
+							{/* While streaming, an empty box offers Stop. Once the user types,
+							    it turns back into Send — which interrupts the current reply
+							    before sending, matching what Enter does. */}
+							{isLoading && !(input ?? "").trim() ? (
 								<button
 									type="button"
 									onClick={onStop}
 									className="inline-flex items-center cursor-pointer justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 rounded-full p-2 h-fit border border-primary/35 dark:border-primary/40 shadow-sm backdrop-blur-sm"
 									aria-label="Stop generation"
+									title="Stop generating"
 								>
 									<Stop size={16} />
 								</button>
@@ -435,6 +444,11 @@ export function ChatArea({
 										pendingToolCallConfirmation || !(input ?? "").trim()
 									}
 									aria-label="Send message"
+									title={
+										isLoading
+											? "Send — this stops the current reply"
+											: undefined
+									}
 								>
 									<PaperPlaneRight size={16} />
 								</button>

--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -2,6 +2,7 @@ import { CaretRight } from "@phosphor-icons/react";
 import { Card } from "@/components/card/Card";
 import { CopyAsMarkdownButton } from "@/components/chat/CopyAsMarkdownButton";
 import { ExplainabilitySection } from "@/components/chat/ExplainabilitySection";
+import { InterruptedNotice } from "@/components/chat/InterruptedNotice";
 import { MemoizedMarkdown } from "@/components/MemoizedMarkdown";
 import type { Message } from "@/types/ai-message";
 
@@ -14,6 +15,10 @@ interface ChatMessageListProps {
 	onWorkOnNextStep?: (stepLabel: string) => void;
 	/** When provided, used as the list of step labels for buttons (from planning-tasks API). Message text is still used as a hint for whether to show buttons. */
 	openPlanningTaskTitles?: string[];
+	/** When provided, the newest stopped reply offers a Continue button. */
+	onContinueGeneration?: () => void;
+	/** Suppresses the Continue button while a turn is already in flight. */
+	isStreaming?: boolean;
 }
 
 /**
@@ -169,293 +174,305 @@ export function ChatMessageList({
 	invisibleUserContents,
 	onWorkOnNextStep,
 	openPlanningTaskTitles,
+	onContinueGeneration,
+	isStreaming,
 }: ChatMessageListProps) {
+	const visibleMessages = messages.filter((m: Message) => {
+		if (m.role === "system") return false;
+		if (m.role === "user" && m.content === "Get started") return false;
+		if (m.role === "user" && invisibleUserContents?.has(getMessageText(m)))
+			return false;
+		if (!hasVisibleContent(m)) return false;
+		return true;
+	});
+
 	return (
 		<>
-			{messages
-				.filter((m: Message) => {
-					if (m.role === "system") return false;
-					if (m.role === "user" && m.content === "Get started") return false;
-					if (
-						m.role === "user" &&
-						invisibleUserContents?.has(getMessageText(m))
-					)
-						return false;
-					if (!hasVisibleContent(m)) return false;
-					return true;
-				})
-				.map((m: Message, _index) => {
-					const isUser = m.role === "user";
+			{visibleMessages.map((m: Message, index) => {
+				const isUser = m.role === "user";
+				const isInterrupted =
+					!isUser &&
+					(m.data as { interrupted?: boolean } | undefined)?.interrupted ===
+						true;
+				// Only the newest reply can be resumed — continuing something further
+				// back in the transcript would append to the wrong place.
+				const canContinue =
+					isInterrupted &&
+					index === visibleMessages.length - 1 &&
+					!isStreaming &&
+					onContinueGeneration != null;
+				const continueHandler = canContinue ? onContinueGeneration : undefined;
 
-					return (
-						<div key={m.id}>
+				return (
+					<div key={m.id}>
+						<div
+							className={`flex min-w-0 ${isUser ? "justify-end" : "justify-start"}`}
+						>
 							<div
-								className={`flex min-w-0 ${isUser ? "justify-end" : "justify-start"}`}
+								className={`min-w-0 ${isUser ? "flex flex-row-reverse gap-2 max-w-[85%]" : "w-full"}`}
 							>
-								<div
-									className={`min-w-0 ${isUser ? "flex flex-row-reverse gap-2 max-w-[85%]" : "w-full"}`}
-								>
-									<div className={`min-w-0 ${isUser ? "flex-1" : "w-full"}`}>
-										<div>
-											{(() => {
-												// Find the index of the last text part in the original parts array
-												const parts = m.parts || [];
-												let lastTextPartIndex = -1;
-												for (let j = parts.length - 1; j >= 0; j--) {
-													if (parts[j]?.type === "text") {
-														lastTextPartIndex = j;
-														break;
-													}
+								<div className={`min-w-0 ${isUser ? "flex-1" : "w-full"}`}>
+									<div>
+										{(() => {
+											// Find the index of the last text part in the original parts array
+											const parts = m.parts || [];
+											let lastTextPartIndex = -1;
+											for (let j = parts.length - 1; j >= 0; j--) {
+												if (parts[j]?.type === "text") {
+													lastTextPartIndex = j;
+													break;
 												}
+											}
 
-												return parts.map((part, i) => {
-													const hasTopLevelRender = false;
-													if (part.type === "text" && hasTopLevelRender) {
-														return null;
-													}
-													if (
-														part.type === "text" &&
-														typeof part.text === "string" &&
-														part.text.trim() !== ""
-													) {
-														const isLastTextPart = i === lastTextPartIndex;
-														const occurrenceIndex = parts
-															.slice(0, i + 1)
-															.filter(
-																(p) =>
-																	p.type === "text" &&
-																	typeof p.text === "string" &&
-																	p.text === part.text
-															).length;
-														const partKey = `${m.id}-text-${part.text}-n${occurrenceIndex}`;
+											return parts.map((part, i) => {
+												const hasTopLevelRender = false;
+												if (part.type === "text" && hasTopLevelRender) {
+													return null;
+												}
+												if (
+													part.type === "text" &&
+													typeof part.text === "string" &&
+													part.text.trim() !== ""
+												) {
+													const isLastTextPart = i === lastTextPartIndex;
+													const occurrenceIndex = parts
+														.slice(0, i + 1)
+														.filter(
+															(p) =>
+																p.type === "text" &&
+																typeof p.text === "string" &&
+																p.text === part.text
+														).length;
+													const partKey = `${m.id}-text-${part.text}-n${occurrenceIndex}`;
 
-														return (
-															<div key={partKey} className="min-w-0">
-																<Card
-																	className={`p-4 rounded-xl bg-neutral-100/80 dark:bg-neutral-900/80 backdrop-blur-sm min-w-0 ${
-																		isUser
-																			? "rounded-br-none"
-																			: "rounded-bl-none border-assistant-border"
-																	} ${
-																		part.text.startsWith("scheduled message")
-																			? "border-accent/50"
-																			: ""
-																	} relative shadow-sm border border-neutral-200/50 dark:border-neutral-700/50`}
-																>
-																	{part.text.startsWith(
-																		"scheduled message"
-																	) && (
-																		<span
-																			className="absolute -top-3 -left-2 text-base"
-																			aria-hidden="true"
-																		>
-																			🕒
-																		</span>
-																	)}
-																	{!isUser && (
-																		<CopyAsMarkdownButton
-																			markdown={part.text.replace(
-																				/^scheduled message: /,
-																				""
-																			)}
-																		/>
-																	)}
-																	{!isUser &&
-																		onWorkOnNextStep &&
-																		messageSuggestsNextSteps(part.text) &&
-																		(() => {
-																			const stepLabels =
-																				openPlanningTaskTitles &&
-																				openPlanningTaskTitles.length > 0
-																					? openPlanningTaskTitles
-																					: parseNextStepLabels(part.text);
-																			const segments =
-																				parseNextStepsSegments(part.text) ??
-																				(stepLabels.length > 0
-																					? segmentsFromLabelSearch(
-																							part.text,
-																							stepLabels
-																						)
-																					: null);
-																			if (
-																				stepLabels.length === 0 &&
-																				(!segments ||
-																					segments.listItemLines.length === 0)
-																			)
-																				return (
-																					<MemoizedMarkdown
-																						content={part.text.replace(
-																							/^scheduled message: /,
-																							""
-																						)}
-																					/>
-																				);
-																			// Render with "Work on this" next to each list item
-																			if (
-																				segments &&
-																				segments.listItemLines.length > 0
-																			) {
-																				const labels =
-																					stepLabels.length >=
-																					segments.listItemLines.length
-																						? stepLabels
-																						: [
-																								...stepLabels,
-																								...parseNextStepLabels(
-																									part.text
-																								).slice(stepLabels.length),
-																							];
-																				return (
-																					<>
-																						{segments.beforeList && (
-																							<MemoizedMarkdown
-																								content={segments.beforeList}
-																							/>
-																						)}
-																						<ul className="list-disc pl-5 my-2 space-y-1.5">
-																							{segments.listItemLines.map(
-																								(line, i) => {
-																									const label =
-																										labels[i] ??
-																										line
-																											.replace(
-																												LIST_ITEM_START,
-																												""
-																											)
-																											.replace(/\*\*/g, "")
-																											.trim()
-																											.split(" - ")[0]
-																											?.trim() ??
-																										line;
-																									return (
-																										<li
-																											key={`${label}::${line}`}
-																											className="flex items-center gap-2 [&>span]:min-w-0 [&>span]:flex-1"
-																										>
-																											<button
-																												type="button"
-																												onClick={() =>
-																													onWorkOnNextStep(
-																														label
-																													)
-																												}
-																												className="shrink-0 inline-flex items-center justify-center rounded border border-neutral-300 dark:border-neutral-600 bg-neutral-100 dark:bg-neutral-800 p-1.5 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-700 hover:text-neutral-800 dark:hover:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-500 focus:ring-offset-2 focus:ring-offset-neutral-100 dark:focus:ring-offset-neutral-900 transition-colors"
-																												aria-label={`Work on this step: ${label}`}
-																												title="Work on this"
-																											>
-																												<CaretRight
-																													size={16}
-																													weight="bold"
-																													aria-hidden
-																												/>
-																											</button>
-																											<span>
-																												<MemoizedMarkdown
-																													content={line}
-																												/>
-																											</span>
-																										</li>
-																									);
-																								}
-																							)}
-																						</ul>
-																						{segments.afterList && (
-																							<MemoizedMarkdown
-																								content={segments.afterList}
-																							/>
-																						)}
-																					</>
-																				);
-																			}
-																			// Fallback: single block + buttons below
+													return (
+														<div key={partKey} className="min-w-0">
+															<Card
+																className={`p-4 rounded-xl bg-neutral-100/80 dark:bg-neutral-900/80 backdrop-blur-sm min-w-0 ${
+																	isUser
+																		? "rounded-br-none"
+																		: "rounded-bl-none border-assistant-border"
+																} ${
+																	part.text.startsWith("scheduled message")
+																		? "border-accent/50"
+																		: ""
+																} relative shadow-sm border border-neutral-200/50 dark:border-neutral-700/50`}
+															>
+																{part.text.startsWith("scheduled message") && (
+																	<span
+																		className="absolute -top-3 -left-2 text-base"
+																		aria-hidden="true"
+																	>
+																		🕒
+																	</span>
+																)}
+																{!isUser && (
+																	<CopyAsMarkdownButton
+																		markdown={part.text.replace(
+																			/^scheduled message: /,
+																			""
+																		)}
+																	/>
+																)}
+																{!isUser &&
+																	onWorkOnNextStep &&
+																	messageSuggestsNextSteps(part.text) &&
+																	(() => {
+																		const stepLabels =
+																			openPlanningTaskTitles &&
+																			openPlanningTaskTitles.length > 0
+																				? openPlanningTaskTitles
+																				: parseNextStepLabels(part.text);
+																		const segments =
+																			parseNextStepsSegments(part.text) ??
+																			(stepLabels.length > 0
+																				? segmentsFromLabelSearch(
+																						part.text,
+																						stepLabels
+																					)
+																				: null);
+																		if (
+																			stepLabels.length === 0 &&
+																			(!segments ||
+																				segments.listItemLines.length === 0)
+																		)
+																			return (
+																				<MemoizedMarkdown
+																					content={part.text.replace(
+																						/^scheduled message: /,
+																						""
+																					)}
+																				/>
+																			);
+																		// Render with "Work on this" next to each list item
+																		if (
+																			segments &&
+																			segments.listItemLines.length > 0
+																		) {
+																			const labels =
+																				stepLabels.length >=
+																				segments.listItemLines.length
+																					? stepLabels
+																					: [
+																							...stepLabels,
+																							...parseNextStepLabels(
+																								part.text
+																							).slice(stepLabels.length),
+																						];
 																			return (
 																				<>
-																					<MemoizedMarkdown
-																						content={part.text.replace(
-																							/^scheduled message: /,
-																							""
+																					{segments.beforeList && (
+																						<MemoizedMarkdown
+																							content={segments.beforeList}
+																						/>
+																					)}
+																					<ul className="list-disc pl-5 my-2 space-y-1.5">
+																						{segments.listItemLines.map(
+																							(line, i) => {
+																								const label =
+																									labels[i] ??
+																									line
+																										.replace(
+																											LIST_ITEM_START,
+																											""
+																										)
+																										.replace(/\*\*/g, "")
+																										.trim()
+																										.split(" - ")[0]
+																										?.trim() ??
+																									line;
+																								return (
+																									<li
+																										key={`${label}::${line}`}
+																										className="flex items-center gap-2 [&>span]:min-w-0 [&>span]:flex-1"
+																									>
+																										<button
+																											type="button"
+																											onClick={() =>
+																												onWorkOnNextStep(label)
+																											}
+																											className="shrink-0 inline-flex items-center justify-center rounded border border-neutral-300 dark:border-neutral-600 bg-neutral-100 dark:bg-neutral-800 p-1.5 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-700 hover:text-neutral-800 dark:hover:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-500 focus:ring-offset-2 focus:ring-offset-neutral-100 dark:focus:ring-offset-neutral-900 transition-colors"
+																											aria-label={`Work on this step: ${label}`}
+																											title="Work on this"
+																										>
+																											<CaretRight
+																												size={16}
+																												weight="bold"
+																												aria-hidden
+																											/>
+																										</button>
+																										<span>
+																											<MemoizedMarkdown
+																												content={line}
+																											/>
+																										</span>
+																									</li>
+																								);
+																							}
 																						)}
-																					/>
-																					<div className="mt-2 flex flex-wrap gap-1.5">
-																						{stepLabels.map((label) => (
-																							<button
-																								key={label}
-																								type="button"
-																								onClick={() =>
-																									onWorkOnNextStep(label)
-																								}
-																								className="shrink-0 inline-flex items-center justify-center rounded border border-neutral-300 dark:border-neutral-600 bg-neutral-100 dark:bg-neutral-800 p-1.5 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-700 hover:text-neutral-800 dark:hover:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-500 focus:ring-offset-2 focus:ring-offset-neutral-100 dark:focus:ring-offset-neutral-900 transition-colors"
-																								aria-label={`Work on this step: ${label}`}
-																								title="Work on this"
-																							>
-																								<CaretRight
-																									size={16}
-																									weight="bold"
-																									aria-hidden
-																								/>
-																							</button>
-																						))}
-																					</div>
+																					</ul>
+																					{segments.afterList && (
+																						<MemoizedMarkdown
+																							content={segments.afterList}
+																						/>
+																					)}
 																				</>
 																			);
-																		})()}
-																	{(!onWorkOnNextStep ||
-																		!messageSuggestsNextSteps(part.text)) && (
-																		<MemoizedMarkdown
-																			content={part.text.replace(
-																				/^scheduled message: /,
-																				""
-																			)}
-																		/>
-																	)}
-																</Card>
-																{isLastTextPart &&
-																	!isUser &&
-																	m.data?.explainability &&
-																	m.data.explainability.contextSources?.length >
-																		0 && (
-																		<ExplainabilitySection
-																			explainability={m.data.explainability}
-																			collapsedByDefault
-																		/>
-																	)}
-																{isLastTextPart &&
-																	(() => {
-																		const createdAt = m.createdAt as
-																			| string
-																			| Date
-																			| undefined;
-																		const date =
-																			createdAt != null
-																				? new Date(createdAt)
-																				: null;
-																		const isValid =
-																			date != null &&
-																			!Number.isNaN(date.getTime());
-																		return isValid ? (
-																			<p
-																				className={`text-xs text-muted-foreground mt-2 px-1 ${
-																					isUser ? "text-right" : "text-left"
-																				}`}
-																			>
-																				{formatTime(date)}
-																			</p>
-																		) : null;
+																		}
+																		// Fallback: single block + buttons below
+																		return (
+																			<>
+																				<MemoizedMarkdown
+																					content={part.text.replace(
+																						/^scheduled message: /,
+																						""
+																					)}
+																				/>
+																				<div className="mt-2 flex flex-wrap gap-1.5">
+																					{stepLabels.map((label) => (
+																						<button
+																							key={label}
+																							type="button"
+																							onClick={() =>
+																								onWorkOnNextStep(label)
+																							}
+																							className="shrink-0 inline-flex items-center justify-center rounded border border-neutral-300 dark:border-neutral-600 bg-neutral-100 dark:bg-neutral-800 p-1.5 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-700 hover:text-neutral-800 dark:hover:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-500 focus:ring-offset-2 focus:ring-offset-neutral-100 dark:focus:ring-offset-neutral-900 transition-colors"
+																							aria-label={`Work on this step: ${label}`}
+																							title="Work on this"
+																						>
+																							<CaretRight
+																								size={16}
+																								weight="bold"
+																								aria-hidden
+																							/>
+																						</button>
+																					))}
+																				</div>
+																			</>
+																		);
 																	})()}
-															</div>
-														);
-													}
+																{(!onWorkOnNextStep ||
+																	!messageSuggestsNextSteps(part.text)) && (
+																	<MemoizedMarkdown
+																		content={part.text.replace(
+																			/^scheduled message: /,
+																			""
+																		)}
+																	/>
+																)}
+															</Card>
+															{isLastTextPart &&
+																!isUser &&
+																m.data?.explainability &&
+																m.data.explainability.contextSources?.length >
+																	0 && (
+																	<ExplainabilitySection
+																		explainability={m.data.explainability}
+																		collapsedByDefault
+																	/>
+																)}
+															<InterruptedNotice
+																interrupted={isInterrupted}
+																isLastTextPart={isLastTextPart}
+																onContinue={continueHandler}
+															/>
+															{isLastTextPart &&
+																(() => {
+																	const createdAt = m.createdAt as
+																		| string
+																		| Date
+																		| undefined;
+																	const date =
+																		createdAt != null
+																			? new Date(createdAt)
+																			: null;
+																	const isValid =
+																		date != null &&
+																		!Number.isNaN(date.getTime());
+																	return isValid ? (
+																		<p
+																			className={`text-xs text-muted-foreground mt-2 px-1 ${
+																				isUser ? "text-right" : "text-left"
+																			}`}
+																		>
+																			{formatTime(date)}
+																		</p>
+																	) : null;
+																})()}
+														</div>
+													);
+												}
 
-													return null;
-												});
-											})()}
-										</div>
+												return null;
+											});
+										})()}
 									</div>
 								</div>
 							</div>
 						</div>
-					);
-				})}
+					</div>
+				);
+			})}
 		</>
 	);
 }

--- a/src/components/chat/InterruptedNotice.tsx
+++ b/src/components/chat/InterruptedNotice.tsx
@@ -1,0 +1,47 @@
+import { ArrowClockwise, StopCircle } from "@phosphor-icons/react";
+
+interface InterruptedNoticeProps {
+	/** Whether the reply was stopped before it finished. */
+	interrupted: boolean;
+	/** The notice belongs after the final text part of a reply, not each one. */
+	isLastTextPart: boolean;
+	/** When provided, a Continue button is shown that resumes the reply. */
+	onContinue?: () => void;
+}
+
+/**
+ * Shown under an assistant reply that was stopped before it finished, so a
+ * partial answer is never mistaken for a complete one.
+ *
+ * The flag is set both locally (the moment Stop is pressed) and server-side on
+ * the persisted message, so the notice survives a reload.
+ *
+ * Deciding whether to render happens here rather than at the call site: the
+ * message-parts loop it sits in is already at the repo's complexity ceiling.
+ */
+export function InterruptedNotice({
+	interrupted,
+	isLastTextPart,
+	onContinue,
+}: InterruptedNoticeProps) {
+	if (!interrupted || !isLastTextPart) return null;
+
+	return (
+		<div className="mt-2 px-1 flex items-center gap-2 flex-wrap">
+			<span className="inline-flex items-center gap-1.5 text-xs text-neutral-500 dark:text-neutral-400">
+				<StopCircle size={14} weight="fill" aria-hidden />
+				Stopped — this reply is incomplete.
+			</span>
+			{onContinue && (
+				<button
+					type="button"
+					onClick={onContinue}
+					className="inline-flex items-center gap-1 text-xs font-medium text-neutral-700 dark:text-neutral-300 underline underline-offset-2 hover:text-neutral-900 dark:hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 rounded-sm cursor-pointer"
+				>
+					<ArrowClockwise size={12} aria-hidden />
+					Continue
+				</button>
+			)}
+		</div>
+	);
+}

--- a/src/contexts/AppShellContext.tsx
+++ b/src/contexts/AppShellContext.tsx
@@ -91,6 +91,8 @@ export interface AppShellContextValue {
 	onKeyDown: (e: React.KeyboardEvent) => void;
 	isLoading: boolean;
 	onStop: () => void;
+	/** Resume the newest reply that was stopped before it finished. */
+	onContinueGeneration: () => void;
 	formatTime: (date: Date) => string;
 	agentStatus: string | null;
 	onSuggestionSubmit: (suggestion: string) => void;
@@ -237,6 +239,7 @@ export function AppShellProvider({ children }: AppShellProviderProps) {
 		handleSessionRecapRequest,
 		handleNextStepsRequest,
 		stop,
+		handleContinueGeneration,
 		pendingToolCallConfirmation,
 		formatTime,
 		chatHistoryLoaded,
@@ -385,6 +388,7 @@ export function AppShellProvider({ children }: AppShellProviderProps) {
 			onKeyDown: handleKeyDown,
 			isLoading,
 			onStop: stop,
+			onContinueGeneration: handleContinueGeneration,
 			formatTime,
 			agentStatus,
 			onSuggestionSubmit: handleSuggestionSubmit,
@@ -460,6 +464,7 @@ export function AppShellProvider({ children }: AppShellProviderProps) {
 			handleKeyDown,
 			isLoading,
 			stop,
+			handleContinueGeneration,
 			formatTime,
 			agentStatus,
 			handleSuggestionSubmit,

--- a/src/durable-objects/chat.ts
+++ b/src/durable-objects/chat.ts
@@ -52,6 +52,17 @@ interface Env extends AuthEnv {
 export class Chat extends SimpleChatAgent<Env> {
 	private agents: Map<string, any> = new Map();
 
+	/**
+	 * Abort controller for the turn currently in flight, if any.
+	 *
+	 * A conversation maps to exactly one durable object instance, and every turn
+	 * mutates the shared `this.messages` array plus the cached agent instance's
+	 * messages. Two overlapping turns therefore clobber each other's context and
+	 * interleave their output into the same chat pane. Turns are single-flight:
+	 * a newer message always supersedes an older in-flight one.
+	 */
+	private activeTurn: AbortController | null = null;
+
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
 
@@ -160,6 +171,43 @@ export class Chat extends SimpleChatAgent<Env> {
 	}
 
 	/**
+	 * Begin a new turn, superseding any turn still in flight for this
+	 * conversation, and return the signal that scopes the new turn.
+	 *
+	 * Aborting an already-finished controller is a no-op, so completed turns need
+	 * no bookkeeping here.
+	 */
+	private beginTurn(request: Request): AbortSignal {
+		this.activeTurn?.abort(
+			new DOMException(
+				"Superseded by a newer message in this conversation",
+				"AbortError"
+			)
+		);
+
+		const controller = new AbortController();
+		this.activeTurn = controller;
+
+		// Best-effort: bridge a client disconnect (the Stop button aborting the
+		// fetch) into the turn. Not every runtime surfaces this reliably, which is
+		// why the supersede path above is the primary guarantee.
+		const clientSignal = request.signal;
+		if (clientSignal) {
+			if (clientSignal.aborted) {
+				controller.abort(clientSignal.reason);
+			} else {
+				clientSignal.addEventListener(
+					"abort",
+					() => controller.abort(clientSignal.reason),
+					{ once: true }
+				);
+			}
+		}
+
+		return controller.signal;
+	}
+
+	/**
 	 * Handle HTTP requests to the Chat durable object (PartyServer onRequest hook).
 	 */
 	async onRequest(request: Request): Promise<Response> {
@@ -171,6 +219,9 @@ export class Chat extends SimpleChatAgent<Env> {
 
 		// Handle POST chat message (e.g. from AI SDK useChat)
 		if (request.method === "POST") {
+			// Supersede any in-flight turn *before* touching `this.messages` below,
+			// so the older turn stops reading state the new one is about to rewrite.
+			const turnSignal = this.beginTurn(request);
 			try {
 				const body = (await request.json()) as {
 					messages?: Array<{
@@ -254,7 +305,9 @@ export class Chat extends SimpleChatAgent<Env> {
 						};
 					}
 				}
-				const response = await this.onChatMessage(() => {});
+				const response = await this.onChatMessage(() => {}, {
+					abortSignal: turnSignal,
+				});
 				return response;
 			} catch (err) {
 				createLogger(this.env as Record<string, unknown>, "[ChatDO]").error(
@@ -349,10 +402,11 @@ export class Chat extends SimpleChatAgent<Env> {
 	/**
 	 * Handles incoming chat messages and routes to appropriate specialized agent
 	 * @param onFinish - Callback function executed when streaming completes
+	 * @param options - Optional configuration including the turn's abort signal
 	 */
 	async onChatMessage(
 		onFinish: (message: any) => void | Promise<void>,
-		_options?: { abortSignal?: AbortSignal }
+		options?: { abortSignal?: AbortSignal }
 	) {
 		try {
 			const messages = this.messages as Array<{
@@ -433,7 +487,7 @@ export class Chat extends SimpleChatAgent<Env> {
 				const targetAgentInstance = this.getAgentInstance(defaultAgent);
 				targetAgentInstance.messages = [...messages];
 				return targetAgentInstance.onChatMessage(onFinish, {
-					abortSignal: _options?.abortSignal,
+					abortSignal: options?.abortSignal,
 				});
 			}
 
@@ -472,7 +526,7 @@ export class Chat extends SimpleChatAgent<Env> {
 			targetAgentInstance.messages = [...messages];
 
 			return targetAgentInstance.onChatMessage(onFinish, {
-				abortSignal: _options?.abortSignal,
+				abortSignal: options?.abortSignal,
 			});
 		} catch (error) {
 			// AuthenticationRequiredError: user must sign in - send notification that triggers auth modal

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -32,6 +32,19 @@ const toolsRequiringConfirmation: (
 
 const CHAT_HISTORY_PAGE_SIZE = 50;
 
+/**
+ * How long to wait for an interrupted turn to unwind before sending the next
+ * one. `stop()` resolves as soon as it calls `abort()`, not when the stream has
+ * actually torn down, so we wait for the hook's own status to go idle. The
+ * server-side supersede guard covers us if this ever times out.
+ */
+const INTERRUPT_SETTLE_TIMEOUT_MS = 2000;
+const INTERRUPT_SETTLE_POLL_MS = 25;
+
+/** Hidden prompt used by "Continue" to resume an interrupted response. */
+const CONTINUE_GENERATION_PROMPT =
+	"Please continue your previous response from where it was interrupted. Do not repeat what you already said.";
+
 function extractMessageText(msg: Message): string {
 	if (typeof msg.content === "string" && msg.content.trim()) return msg.content;
 	if (msg.parts?.length) {
@@ -203,6 +216,59 @@ export function useChatSession(options: UseChatSessionOptions) {
 	const isLoading = chatStatus === "submitted" || chatStatus === "streaming";
 	const setShowAuthModal = modalState.setShowAuthModal;
 
+	// Read during callbacks that must not re-create themselves on every status
+	// change. Assigned in the render body so it tracks the committed status.
+	const isLoadingRef = useRef(isLoading);
+	isLoadingRef.current = isLoading;
+
+	/**
+	 * Tag the in-flight assistant message as interrupted so the pane can show a
+	 * "Stopped" badge and a Continue action. The server persists the same flag on
+	 * the partial message, so the state survives a reload.
+	 */
+	const markLastAssistantInterrupted = useCallback(() => {
+		setChatMessages((prev) => {
+			const list = prev as Message[];
+			const lastIndex = list.length - 1;
+			const last = list[lastIndex];
+			if (!last || last.role !== "assistant") return prev;
+			if ((last.data as { interrupted?: boolean } | undefined)?.interrupted)
+				return prev;
+			return [
+				...list.slice(0, lastIndex),
+				{ ...last, data: { ...last.data, interrupted: true } },
+			] as typeof prev;
+		});
+	}, [setChatMessages]);
+
+	/** Stop the current turn. Safe to call when nothing is streaming. */
+	const handleStop = useCallback(() => {
+		if (!isLoadingRef.current) return;
+		void stop();
+		markLastAssistantInterrupted();
+		setAgentStatus(null);
+	}, [stop, markLastAssistantInterrupted]);
+
+	/**
+	 * Interrupt the in-flight turn and wait for it to settle.
+	 *
+	 * Sending a second message while one is streaming used to start a concurrent
+	 * request: the AI SDK overwrites its `activeResponse`, so both streams write
+	 * into the same message list and the pane fills with interleaved output.
+	 * A new message now always supersedes the turn before it.
+	 */
+	const interruptActiveTurn = useCallback(async () => {
+		if (!isLoadingRef.current) return;
+		handleStop();
+
+		const deadline = Date.now() + INTERRUPT_SETTLE_TIMEOUT_MS;
+		while (isLoadingRef.current && Date.now() < deadline) {
+			await new Promise((resolve) =>
+				setTimeout(resolve, INTERRUPT_SETTLE_POLL_MS)
+			);
+		}
+	}, [handleStop]);
+
 	const invisibleUserContentsRef = useRef<Set<string>>(new Set());
 	const [invisibleUserContentsVersion, setInvisibleUserContentsVersion] =
 		useState(0);
@@ -242,7 +308,7 @@ export function useChatSession(options: UseChatSessionOptions) {
 	);
 
 	const append = useCallback(
-		(message: {
+		async (message: {
 			id?: string;
 			role: string;
 			content: string;
@@ -253,7 +319,11 @@ export function useChatSession(options: UseChatSessionOptions) {
 			const enrichedData = { ...baseData, sessionId: conversationId };
 
 			if (message.role === "user") {
-				void sendMessage({
+				// Every user-message path (typing, suggestions, help, recap, next
+				// steps, "Work on this") funnels through here, so this is the one
+				// place that has to guarantee a single in-flight turn.
+				await interruptActiveTurn();
+				await sendMessage({
 					text: text || " ",
 					metadata: enrichedData,
 				});
@@ -268,7 +338,7 @@ export function useChatSession(options: UseChatSessionOptions) {
 				setChatMessages((prev) => [...prev, newMsg] as typeof prev);
 			}
 		},
-		[sendMessage, setChatMessages, conversationId]
+		[sendMessage, setChatMessages, conversationId, interruptActiveTurn]
 	);
 
 	const dispatchedCreateCampaignIdsRef = useRef<Set<string>>(new Set());
@@ -534,7 +604,7 @@ export function useChatSession(options: UseChatSessionOptions) {
 			const jwt = authState.getStoredJwt();
 			addToInvisible(suggestion);
 
-			append({
+			void append({
 				role: "user",
 				content: suggestion,
 				data: jwt
@@ -558,7 +628,7 @@ export function useChatSession(options: UseChatSessionOptions) {
 			if (action === "open_help") {
 				const cached = getCachedHelp("open_help");
 				if (cached) {
-					append({
+					void append({
 						role: "assistant",
 						content: cached,
 						data: authState.getStoredJwt()
@@ -575,7 +645,7 @@ export function useChatSession(options: UseChatSessionOptions) {
 				const helpPrompt =
 					"I need help with LoreSmith. Please act as a help agent: explain what you can help me with, give example questions I can ask, and share guidance on app functionality and best practices. Base your response on the product documentation and how the app is designed to be used.";
 				addToInvisible(helpPrompt);
-				append({
+				void append({
 					role: "user",
 					content: helpPrompt,
 					data: jwt
@@ -598,7 +668,7 @@ export function useChatSession(options: UseChatSessionOptions) {
 			}
 			const jwt = authState.getStoredJwt();
 			const response = getHelpContent(action);
-			append({
+			void append({
 				role: "assistant",
 				content: response,
 				data: jwt
@@ -698,7 +768,9 @@ export function useChatSession(options: UseChatSessionOptions) {
 
 		const jwt = authState.getStoredJwt();
 
-		append({
+		// `append` interrupts any in-flight turn first, so the input can be cleared
+		// immediately — the message is already captured.
+		void append({
 			role: "user",
 			content: agentInput ?? "",
 			data: jwt
@@ -736,6 +808,31 @@ export function useChatSession(options: UseChatSessionOptions) {
 		[submitAgentMessage]
 	);
 
+	/**
+	 * Resume an interrupted response. The model still has its own partial text in
+	 * context, so it picks up where it stopped rather than starting over. The
+	 * prompt itself is hidden from the transcript.
+	 */
+	const handleContinueGeneration = useCallback(() => {
+		if (isLoadingRef.current) return;
+		const jwt = authState.getStoredJwt();
+		addToInvisible(CONTINUE_GENERATION_PROMPT);
+		void append({
+			role: "user",
+			content: CONTINUE_GENERATION_PROMPT,
+			data: jwt
+				? { jwt, campaignId: selectedCampaignId ?? null }
+				: { campaignId: selectedCampaignId ?? null },
+		});
+		scrollToBottom();
+	}, [
+		append,
+		authState.getStoredJwt,
+		selectedCampaignId,
+		addToInvisible,
+		scrollToBottom,
+	]);
+
 	return {
 		messages: agentMessages,
 		isLoading,
@@ -748,7 +845,8 @@ export function useChatSession(options: UseChatSessionOptions) {
 		handleHelpAction,
 		handleSessionRecapRequest,
 		handleNextStepsRequest,
-		stop,
+		stop: handleStop,
+		handleContinueGeneration,
 		pendingToolCallConfirmation,
 		formatTime,
 		chatHistoryLoaded,

--- a/tests/agents/base-agent-abort.test.ts
+++ b/tests/agents/base-agent-abort.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BaseAgent } from "../../src/agents/base-agent";
+
+vi.mock("@/lib/agent-role-utils", () => ({
+	resolveClaimedPlayerContext: vi.fn().mockResolvedValue(null),
+}));
+
+const streamTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("ai", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("ai")>();
+	return {
+		...actual,
+		streamText: streamTextMock,
+		stepCountIs: vi.fn(() => () => false),
+	};
+});
+
+// DB is truthy so the persistence path runs; the DAO call itself is spied on.
+const mockEnv = {
+	DB: {} as D1Database,
+	R2: {} as R2Bucket,
+	VECTORIZE: {} as any,
+	AI: {} as any,
+	JWT_SECRET: "test-jwt-secret",
+	Chat: {} as DurableObjectNamespace,
+	UserFileTracker: {} as DurableObjectNamespace,
+	UploadSession: {} as DurableObjectNamespace,
+	ASSETS: {} as any,
+	NOTIFICATIONS: {} as DurableObjectNamespace,
+	FILE_PROCESSING_QUEUE: {} as any,
+	FILE_PROCESSING_DLQ: {} as any,
+} as any;
+
+const mockCtx = {
+	env: mockEnv,
+	id: { toString: () => "session-under-test" },
+	state: { get: vi.fn(), put: vi.fn(), delete: vi.fn() },
+} as any;
+
+/** Uses BaseAgent's real onChatMessage rather than overriding it. */
+class RealBaseAgent extends BaseAgent {
+	constructor() {
+		super(mockCtx, mockEnv, { generateText: vi.fn() } as any, {});
+	}
+}
+
+function makeStreamTextResult() {
+	return {
+		text: Promise.resolve("full response"),
+		toUIMessageStreamResponse: vi.fn().mockReturnValue(
+			new Response(
+				new ReadableStream({
+					start(controller) {
+						controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+						controller.close();
+					},
+				}),
+				{ headers: { "Content-Type": "text/event-stream" } }
+			)
+		),
+	};
+}
+
+describe("BaseAgent interrupt handling", () => {
+	let agent: RealBaseAgent;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		streamTextMock.mockReturnValue(makeStreamTextResult());
+		agent = new RealBaseAgent();
+		agent.addMessage({ role: "user", content: "Tell me about the campaign" });
+	});
+
+	it("passes the turn's abort signal to the provider call", async () => {
+		const controller = new AbortController();
+
+		await agent.onChatMessage(() => {}, { abortSignal: controller.signal });
+
+		expect(streamTextMock).toHaveBeenCalledTimes(1);
+		// Previously the option was accepted and dropped, so a stopped turn kept
+		// generating (and billing) server-side.
+		expect(streamTextMock.mock.calls[0][0].abortSignal).toBe(controller.signal);
+	});
+
+	it("omits abortSignal entirely when no signal is supplied", async () => {
+		await agent.onChatMessage(() => {});
+
+		expect(streamTextMock.mock.calls[0][0]).not.toHaveProperty("abortSignal");
+	});
+
+	it("persists the partial reply when the turn is aborted", async () => {
+		const storeSpy = vi
+			.spyOn(agent as any, "storeMessageToDatabase")
+			.mockResolvedValue(undefined);
+
+		await agent.onChatMessage(() => {}, {
+			abortSignal: new AbortController().signal,
+		});
+
+		const { onAbort } = streamTextMock.mock.calls[0][0];
+		expect(onAbort).toBeTypeOf("function");
+
+		await onAbort({
+			steps: [
+				{ text: "The party ", usage: { totalTokens: 10 } },
+				{ text: "arrives at", usage: { totalTokens: 5 } },
+			],
+		});
+
+		expect(storeSpy).toHaveBeenCalledTimes(1);
+		const stored = storeSpy.mock.calls[0][0] as any;
+		expect(stored.role).toBe("assistant");
+		expect(stored.content).toContain("The party arrives at");
+		// Drives the "Stopped — this reply is incomplete" notice after a reload.
+		expect(stored.data.interrupted).toBe(true);
+	});
+
+	it("stores nothing when the turn is aborted before any text", async () => {
+		const storeSpy = vi
+			.spyOn(agent as any, "storeMessageToDatabase")
+			.mockResolvedValue(undefined);
+
+		await agent.onChatMessage(() => {}, {
+			abortSignal: new AbortController().signal,
+		});
+
+		const { onAbort } = streamTextMock.mock.calls[0][0];
+		await onAbort({ steps: [] });
+
+		expect(storeSpy).not.toHaveBeenCalled();
+	});
+});

--- a/tests/components/ChatMessageListInterrupted.test.tsx
+++ b/tests/components/ChatMessageListInterrupted.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ChatMessageList } from "@/components/chat/ChatMessageList";
+import type { Message } from "@/types/ai-message";
+
+// Markdown rendering is irrelevant here and pulls in a heavy parser.
+vi.mock("@/components/MemoizedMarkdown", () => ({
+	MemoizedMarkdown: ({ content }: { content: string }) => (
+		<span>{content}</span>
+	),
+}));
+
+const formatTime = (date: Date) => date.toISOString();
+
+function message(
+	id: string,
+	role: string,
+	text: string,
+	data?: Record<string, unknown>
+): Message {
+	return { id, role, content: text, parts: [{ type: "text", text }], data };
+}
+
+const STOPPED_TEXT = /Stopped — this reply is incomplete/;
+
+describe("ChatMessageList interrupted replies", () => {
+	it("shows no stopped notice for a completed reply", () => {
+		render(
+			<ChatMessageList
+				messages={[
+					message("u1", "user", "hi"),
+					message("a1", "assistant", "complete answer"),
+				]}
+				formatTime={formatTime}
+			/>
+		);
+
+		expect(screen.queryByText(STOPPED_TEXT)).toBeNull();
+	});
+
+	it("marks an interrupted reply as incomplete", () => {
+		render(
+			<ChatMessageList
+				messages={[
+					message("u1", "user", "hi"),
+					message("a1", "assistant", "partial", { interrupted: true }),
+				]}
+				formatTime={formatTime}
+			/>
+		);
+
+		expect(screen.getByText(STOPPED_TEXT)).toBeInTheDocument();
+		// Partial output is kept, not discarded.
+		expect(screen.getByText("partial")).toBeInTheDocument();
+	});
+
+	it("offers Continue on the newest interrupted reply", () => {
+		const onContinueGeneration = vi.fn();
+		render(
+			<ChatMessageList
+				messages={[
+					message("u1", "user", "hi"),
+					message("a1", "assistant", "partial", { interrupted: true }),
+				]}
+				formatTime={formatTime}
+				onContinueGeneration={onContinueGeneration}
+			/>
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(onContinueGeneration).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not offer Continue on an older interrupted reply", () => {
+		render(
+			<ChatMessageList
+				messages={[
+					message("a1", "assistant", "partial", { interrupted: true }),
+					message("u2", "user", "next question"),
+					message("a2", "assistant", "complete answer"),
+				]}
+				formatTime={formatTime}
+				onContinueGeneration={vi.fn()}
+			/>
+		);
+
+		// The notice still explains the old reply was cut short...
+		expect(screen.getByText(STOPPED_TEXT)).toBeInTheDocument();
+		// ...but resuming it would append in the wrong place.
+		expect(screen.queryByRole("button", { name: "Continue" })).toBeNull();
+	});
+
+	it("hides Continue while another turn is streaming", () => {
+		render(
+			<ChatMessageList
+				messages={[
+					message("u1", "user", "hi"),
+					message("a1", "assistant", "partial", { interrupted: true }),
+				]}
+				formatTime={formatTime}
+				onContinueGeneration={vi.fn()}
+				isStreaming
+			/>
+		);
+
+		expect(screen.queryByRole("button", { name: "Continue" })).toBeNull();
+	});
+});

--- a/tests/durable-objects/chat-turn-supersede.test.ts
+++ b/tests/durable-objects/chat-turn-supersede.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Chat } from "../../src/durable-objects/chat";
+
+vi.mock("@/lib/agent-role-utils", () => ({
+	resolveClaimedPlayerContext: vi.fn().mockResolvedValue(null),
+}));
+
+const mockEnv = {
+	DB: undefined as unknown as D1Database,
+	R2: {} as R2Bucket,
+	VECTORIZE: {} as any,
+	AI: {} as any,
+	JWT_SECRET: "test-jwt-secret",
+	CHAT: {} as DurableObjectNamespace,
+	UPLOAD_SESSION: {} as DurableObjectNamespace,
+	NOTIFICATIONS: {} as DurableObjectNamespace,
+	ASSETS: {} as any,
+	FILE_PROCESSING_QUEUE: {} as any,
+	FILE_PROCESSING_DLQ: {} as any,
+} as any;
+
+const mockCtx = {
+	env: mockEnv,
+	id: { toString: () => "user-campaign-1" },
+	storage: {
+		get: vi.fn().mockResolvedValue(undefined),
+		put: vi.fn().mockResolvedValue(undefined),
+		delete: vi.fn().mockResolvedValue(undefined),
+	},
+} as any;
+
+/**
+ * A conversation is one durable object instance, and every turn rewrites the
+ * shared message array. Overlapping turns therefore corrupt each other's
+ * context and interleave output, so turns must be single-flight.
+ */
+describe("Chat durable object turn supersede", () => {
+	let chat: Chat;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		chat = new Chat(mockCtx, mockEnv);
+	});
+
+	function beginTurn(request: Request): AbortSignal {
+		return (chat as any).beginTurn(request);
+	}
+
+	it("aborts the in-flight turn when a newer one starts", () => {
+		const first = beginTurn(
+			new Request("https://test/chat", { method: "POST" })
+		);
+		expect(first.aborted).toBe(false);
+
+		const second = beginTurn(
+			new Request("https://test/chat", { method: "POST" })
+		);
+
+		expect(first.aborted).toBe(true);
+		expect(second.aborted).toBe(false);
+	});
+
+	it("propagates a client disconnect into the turn", () => {
+		const controller = new AbortController();
+		const signal = beginTurn(
+			new Request("https://test/chat", {
+				method: "POST",
+				signal: controller.signal,
+			})
+		);
+
+		expect(signal.aborted).toBe(false);
+		controller.abort();
+		expect(signal.aborted).toBe(true);
+	});
+
+	it("starts already-aborted when the client gave up before dispatch", () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		const signal = beginTurn(
+			new Request("https://test/chat", {
+				method: "POST",
+				signal: controller.signal,
+			})
+		);
+
+		expect(signal.aborted).toBe(true);
+	});
+
+	it("leaves a fresh turn usable after the previous one completed", () => {
+		// Aborting an already-finished controller is a no-op, so completed turns
+		// need no bookkeeping.
+		beginTurn(new Request("https://test/chat", { method: "POST" }));
+		const next = beginTurn(
+			new Request("https://test/chat", { method: "POST" })
+		);
+
+		expect(next.aborted).toBe(false);
+	});
+});

--- a/tests/hooks/useChatSession.test.ts
+++ b/tests/hooks/useChatSession.test.ts
@@ -3,14 +3,20 @@ import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatSession } from "@/hooks/useChatSession";
 
+// Mutable stand-in for the AI SDK chat state so tests can drive `status`
+// between "streaming" and "ready" the way a real turn does.
+const chatMock = vi.hoisted(() => ({
+	messages: [] as any[],
+	status: "ready" as string,
+	sendMessage: vi.fn(),
+	setMessages: vi.fn(),
+	stop: vi.fn(),
+	regenerate: vi.fn(),
+	error: undefined as Error | undefined,
+}));
+
 vi.mock("@ai-sdk/react", () => ({
-	useChat: vi.fn(() => ({
-		messages: [],
-		sendMessage: vi.fn(),
-		setMessages: vi.fn(),
-		status: "ready",
-		stop: vi.fn(),
-	})),
+	useChat: vi.fn(() => chatMock),
 }));
 
 vi.mock("@/lib/stream-status-interceptor", () => ({
@@ -55,9 +61,22 @@ const defaultOptions = {
 	authReady: true,
 };
 
+/** Apply the last functional updater passed to setMessages. */
+function applyLastMessagesUpdate(current: any[]): any[] | null {
+	const call = chatMock.setMessages.mock.calls
+		.slice()
+		.reverse()
+		.find(([arg]) => typeof arg === "function");
+	if (!call) return null;
+	return (call[0] as (prev: any[]) => any[])(current);
+}
+
 describe("useChatSession", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		chatMock.messages = [];
+		chatMock.status = "ready";
+		chatMock.error = undefined;
 		document.body.innerHTML = '<div id="chat-container"></div>';
 	});
 
@@ -86,5 +105,101 @@ describe("useChatSession", () => {
 			} as any);
 		});
 		expect(result.current.input).toBe("hello");
+	});
+
+	describe("interrupt controls", () => {
+		it("sends immediately when nothing is in flight", async () => {
+			const { result } = renderHook(() => useChatSession(defaultOptions));
+
+			await act(async () => {
+				await result.current.append({ role: "user", content: "hello" });
+			});
+
+			expect(chatMock.stop).not.toHaveBeenCalled();
+			expect(chatMock.sendMessage).toHaveBeenCalledTimes(1);
+		});
+
+		it("interrupts the in-flight turn before sending a new message", async () => {
+			chatMock.status = "streaming";
+			const { result, rerender } = renderHook(() =>
+				useChatSession(defaultOptions)
+			);
+
+			let pending!: Promise<void>;
+			act(() => {
+				pending = result.current.append({ role: "user", content: "second" });
+			});
+
+			// The previous turn is stopped, and nothing is sent until it settles —
+			// this is what stops two streams writing into the same message list.
+			expect(chatMock.stop).toHaveBeenCalledTimes(1);
+			expect(chatMock.sendMessage).not.toHaveBeenCalled();
+
+			chatMock.status = "ready";
+			rerender();
+			await act(async () => {
+				await pending;
+			});
+
+			expect(chatMock.sendMessage).toHaveBeenCalledTimes(1);
+		});
+
+		it("tags the partial reply as interrupted when stopped", () => {
+			chatMock.status = "streaming";
+			chatMock.messages = [
+				{ id: "u1", role: "user", content: "hi" },
+				{ id: "a1", role: "assistant", content: "partial answer" },
+			];
+			const { result } = renderHook(() => useChatSession(defaultOptions));
+
+			chatMock.setMessages.mockClear();
+			act(() => {
+				result.current.stop();
+			});
+
+			expect(chatMock.stop).toHaveBeenCalledTimes(1);
+			const next = applyLastMessagesUpdate(chatMock.messages);
+			expect(next?.at(-1)?.data?.interrupted).toBe(true);
+		});
+
+		it("stop is a no-op when no turn is in flight", () => {
+			chatMock.status = "ready";
+			const { result } = renderHook(() => useChatSession(defaultOptions));
+
+			act(() => {
+				result.current.stop();
+			});
+
+			expect(chatMock.stop).not.toHaveBeenCalled();
+		});
+
+		it("handleContinueGeneration resumes with a hidden prompt", async () => {
+			const { result } = renderHook(() => useChatSession(defaultOptions));
+
+			await act(async () => {
+				result.current.handleContinueGeneration();
+			});
+
+			expect(chatMock.sendMessage).toHaveBeenCalledTimes(1);
+			const [{ text }] = chatMock.sendMessage.mock.calls[0] as [
+				{ text: string },
+			];
+			expect(text).toContain("continue your previous response");
+			// Hidden from the transcript so "Continue" doesn't look like the user typed it.
+			expect(result.current.invisibleUserContentsRef.current.has(text)).toBe(
+				true
+			);
+		});
+
+		it("handleContinueGeneration does nothing while a turn is streaming", () => {
+			chatMock.status = "streaming";
+			const { result } = renderHook(() => useChatSession(defaultOptions));
+
+			act(() => {
+				result.current.handleContinueGeneration();
+			});
+
+			expect(chatMock.sendMessage).not.toHaveBeenCalled();
+		});
 	});
 });


### PR DESCRIPTION
Closes #277.

## Problem

Sending a new prompt while a reply was still streaming produced two concurrent
turns whose output interleaved into the same message list — the conversation
pane filled with duplicated, spliced text. Stop existed but only aborted the
browser fetch.

Three independent layers were involved:

1. **Client** — `handleKeyDown` had no in-flight guard, so Enter mid-stream
   called `sendMessage` again. `ai@7`'s `makeRequest` overwrites its
   `activeResponse`, so the first stream's `AbortController` became unreachable
   and both streams wrote into the same state.
2. **Durable Object** — both POSTs hit the same DO instance, and `onRequest`
   replaced `this.messages` wholesale mid-turn, so the two turns clobbered each
   other's conversation context.
3. **Server** — `onChatMessage` accepted an `abortSignal` and never used it.
   Stop left the LLM call, the 20-step tool loop, D1 persistence and token
   billing all running to completion.

## Change

**Turns are single-flight.** Every user-message path (typing, suggestions, help,
recap, next steps, "Work on this") funnels through `append`, which now
interrupts the in-flight turn and waits for it to settle before sending. The DO
independently supersedes any turn still running when a new POST arrives, so the
guarantee holds even if the client abort doesn't propagate.

**Stop actually stops.** `abortSignal` is threaded from the request through the
DO to `streamText`, cancelling the provider call and the tool loop.

**Partial results are kept, not dropped.** A new `onAbort` handler persists
whatever text was generated, tagged `interrupted: true`, and records the tokens
that were genuinely spent. The reply renders under a "Stopped — this reply is
incomplete" notice with a **Continue** action that resumes from the partial
text. The flag is set locally on Stop and server-side on the persisted message,
so the state survives a reload.

**Consistent controls.** While streaming, an empty input shows Stop; once you
type, it returns to Send — which interrupts before sending, matching Enter.

On "pause": a true pause of an in-flight LLM stream isn't possible over HTTP.
Stop-with-Continue is the honest equivalent and covers the issue's resume goal.

## Notes for the reviewer

- `complexity-baseline.json` loses an entry: extracting the usage/persistence
  helpers dropped `base-agent.ts::onFinish` from CCN 41 to under the threshold.
- The large line count on `ChatMessageList.tsx` is re-indentation from hoisting
  the message filter out of the render chain; `git diff -w` shows +36/-16.
- Heads up: this repo's `node_modules` was stale (`ai@6.0.184` installed vs
  `7.0.34` in the lockfile), which made `npm run check` fail locally on
  unrelated files. `npm ci` fixes it — worth doing before reviewing.

## Verification

- `npx vitest run` — 1546 passed (172 files), including 22 new tests
- `npx tsc --noEmit` — clean
- `npx biome check .` — clean
- `npm run build` — succeeds
- `npm run test:coverage` — passes (branches 71.06% vs 70% threshold)
- Not run: Playwright e2e (`tests/e2e/chat.spec.ts`), and I did not exercise the
  flow against a live LLM — there is no API key in this environment. The
  interrupt behavior is covered by unit tests at all three layers instead.

New tests, one per layer:
- `tests/hooks/useChatSession.test.ts` — a mid-stream send stops the previous
  turn and holds the new one until it settles; Stop tags the partial reply;
  Continue sends a hidden resume prompt
- `tests/durable-objects/chat-turn-supersede.test.ts` — a newer turn aborts the
  in-flight one; client disconnect propagates
- `tests/agents/base-agent-abort.test.ts` — the signal reaches `streamText`;
  partial text persists with `interrupted: true`; empty aborts store nothing

## How to see this change

```bash
gh pr checkout 757
npm ci                 # required — see the stale-deps note above
```

The interrupt path needs a live model, so the fastest honest check is the tests:

```bash
npx vitest run tests/hooks/useChatSession.test.ts \
  tests/durable-objects/chat-turn-supersede.test.ts \
  tests/agents/base-agent-abort.test.ts \
  tests/components/ChatMessageListInterrupted.test.tsx
```

To see it in the UI, run the two-terminal setup from `docs/DEV_SETUP.md`
(`npm run dev:cloudflare`, then `npm run start`), open http://localhost:5173,
pick a campaign, and ask the agent something long ("summarise everything you
know about this campaign"). While it streams, either press the Stop button or
type a new question and hit Enter.

**What you should see:**
- *Before:* the second answer streams alongside the first, interleaving into one
  run-on block and stretching the pane; Stop blanks the spinner but the worker
  keeps generating and billing.
- *After:* exactly one reply streams at a time. The interrupted reply keeps the
  text it had produced and sits under "Stopped — this reply is incomplete" with
  a **Continue** link that picks up where it left off. Continue appears only on
  the newest stopped reply, and never while something is streaming.

I did not capture screenshots — the states need a live LLM streaming a long
reply, which I could not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
