### PR TITLE
perf(routing): deterministic fast path + cached prefix for AgentRouter.routeMessage (#736)

### DIFF
--- a/src/app-constants.ts
+++ b/src/app-constants.ts
@@ -93,6 +93,24 @@ export const UPLOAD_CONFIG = {
 // Context recap: user message content for automatic recap (hidden in UI; routing uses it to send to recap agent)
 export const CONTEXT_RECAP_PLACEHOLDER = "[Context recap requested]" as const;
 
+/**
+ * Prompt text for chat turns the UI initiates on the user's behalf.
+ *
+ * These live here (rather than inline in the hooks) so the deterministic
+ * pre-router in `agent-routing-fast-path.ts` can match them without a second
+ * copy of the string drifting out of sync. New UI-initiated turns should also
+ * pass an explicit `agentType` hint in message data — the phrase table is the
+ * fallback for chat history replays and clients that predate the hint.
+ */
+export const UI_INITIATED_PROMPTS = {
+	HELP: "I need help with LoreSmith. Please act as a help agent: explain what you can help me with, give example questions I can ask, and share guidance on app functionality and best practices. Base your response on the product documentation and how the app is designed to be used.",
+	SESSION_RECAP:
+		"I want to record a session recap. Can you guide me through creating a session digest?",
+	NEXT_STEPS_GM: "What should I do next for this campaign?",
+	NEXT_STEPS_PLAYER:
+		"What should I do next with my character and at the table?",
+} as const;
+
 // Library path constants - centralized for consistency across upload and search
 export const LIBRARY_CONFIG = {
 	// Always use "library" as the base path for file storage

--- a/src/durable-objects/chat.ts
+++ b/src/durable-objects/chat.ts
@@ -333,6 +333,13 @@ export class Chat extends SimpleChatAgent<Env> {
 			return "recap";
 		}
 
+		const messageData =
+			lastUserMessage &&
+			typeof lastUserMessage === "object" &&
+			"data" in lastUserMessage
+				? (lastUserMessage as { data?: unknown }).data
+				: undefined;
+
 		const intent = await AgentRouter.routeMessage(
 			userMessage,
 			this.messages
@@ -340,7 +347,8 @@ export class Chat extends SimpleChatAgent<Env> {
 				.map((msg) => (msg as { content?: string }).content ?? "")
 				.join(" "),
 			null,
-			model
+			model,
+			{ messageData, env: this.env as Record<string, unknown> }
 		);
 
 		return intent.agent;

--- a/src/hooks/useAppEventHandlers.ts
+++ b/src/hooks/useAppEventHandlers.ts
@@ -15,7 +15,13 @@ export interface UseAppEventHandlersArgs {
 	append: (message: {
 		role: "user";
 		content: string;
-		data: { type: string; campaignId: string | null; jwt: string | null };
+		data: {
+			type: string;
+			campaignId: string | null;
+			jwt: string | null;
+			/** Skips server-side routing classification when the intent is known. */
+			agentType?: string;
+		};
 	}) => void;
 	authState: { getStoredJwt: () => string | null };
 	/** Called before sending a context recap request so the app can hide the placeholder user message from the UI */
@@ -141,6 +147,8 @@ export function useAppEventHandlers({
 				content: CONTEXT_RECAP_PLACEHOLDER,
 				data: {
 					type: "context_recap_request",
+					// Intent is known here — skip the routing classifier server-side.
+					agentType: "recap",
 					campaignId: selectedCampaignId,
 					jwt: jwt || null,
 				},
@@ -181,6 +189,8 @@ export function useAppEventHandlers({
 				content: CONTEXT_RECAP_PLACEHOLDER,
 				data: {
 					type: "context_recap_request",
+					// Intent is known here — skip the routing classifier server-side.
+					agentType: "recap",
 					campaignId: selectedCampaignId,
 					jwt: jwt || null,
 				},

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -2,7 +2,10 @@ import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, generateId } from "ai";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CONTEXT_RECAP_PLACEHOLDER } from "@/app-constants";
+import {
+	CONTEXT_RECAP_PLACEHOLDER,
+	UI_INITIATED_PROMPTS,
+} from "@/app-constants";
 import { PLAYER_ROLES } from "@/constants/campaign-roles";
 import { NOTIFICATION_TYPES } from "@/constants/notification-types";
 import { APP_EVENT_TYPE } from "@/lib/app-events";
@@ -572,8 +575,7 @@ export function useChatSession(options: UseChatSessionOptions) {
 					return;
 				}
 				const jwt = authState.getStoredJwt();
-				const helpPrompt =
-					"I need help with LoreSmith. Please act as a help agent: explain what you can help me with, give example questions I can ask, and share guidance on app functionality and best practices. Base your response on the product documentation and how the app is designed to be used.";
+				const helpPrompt = UI_INITIATED_PROMPTS.HELP;
 				addToInvisible(helpPrompt);
 				append({
 					role: "user",
@@ -583,10 +585,12 @@ export function useChatSession(options: UseChatSessionOptions) {
 								jwt,
 								campaignId: selectedCampaignId ?? null,
 								isHelpRequest: true,
+								agentType: "onboarding",
 							}
 						: {
 								campaignId: selectedCampaignId ?? null,
 								isHelpRequest: true,
+								agentType: "onboarding",
 							},
 				});
 				setInput("");
@@ -622,8 +626,7 @@ export function useChatSession(options: UseChatSessionOptions) {
 			const jwt = authState.getStoredJwt();
 			if (!jwt) return;
 
-			const recapMessage =
-				"I want to record a session recap. Can you guide me through creating a session digest?";
+			const recapMessage = UI_INITIATED_PROMPTS.SESSION_RECAP;
 			addToInvisible(recapMessage);
 
 			await append({
@@ -633,6 +636,7 @@ export function useChatSession(options: UseChatSessionOptions) {
 				data: {
 					jwt: jwt,
 					campaignId: selectedCampaignId,
+					agentType: "session-digest",
 				},
 			});
 		} catch (_error) {}
@@ -648,8 +652,8 @@ export function useChatSession(options: UseChatSessionOptions) {
 			const isPlayerRole = role !== null && PLAYER_ROLES.has(role as never);
 
 			const nextStepsMessage = isPlayerRole
-				? "What should I do next with my character and at the table?"
-				: "What should I do next for this campaign?";
+				? UI_INITIATED_PROMPTS.NEXT_STEPS_PLAYER
+				: UI_INITIATED_PROMPTS.NEXT_STEPS_GM;
 			addToInvisible(nextStepsMessage);
 
 			await append({
@@ -659,6 +663,7 @@ export function useChatSession(options: UseChatSessionOptions) {
 				data: {
 					jwt: jwt,
 					campaignId: selectedCampaignId,
+					agentType: "recap",
 				},
 			});
 		} catch (_error) {}

--- a/src/lib/agent-router.ts
+++ b/src/lib/agent-router.ts
@@ -1,10 +1,23 @@
 import { generateText } from "ai";
 import { getGenerationModelForProvider, MODEL_CONFIG } from "@/app-constants";
+import {
+	matchAdvisoryRoute,
+	matchDecisiveRoute,
+	type RoutingDecisionSource,
+	resolveExplicitAgentHint,
+} from "@/lib/agent-routing-fast-path";
+import { logRoutingDecision } from "@/lib/agent-routing-telemetry";
 import { anthropicSamplingParams } from "@/lib/anthropic-model-options";
+import type { EnvWithSecrets } from "@/lib/env-utils";
 import { AgentNotRegisteredError } from "@/lib/errors";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
+import { logVerboseLlmSpend } from "@/lib/llm-usage-verbose-log";
 import { createModel } from "./model-config";
 import { ModelManager } from "./model-manager";
-import { AGENT_ROUTING_PROMPTS } from "./prompts/agent-routing-prompts";
+import {
+	AGENT_ROUTING_PROMPTS,
+	type AgentRoutingPromptParts,
+} from "./prompts/agent-routing-prompts";
 
 export type AgentType =
 	| "campaign"
@@ -26,6 +39,22 @@ export interface AgentIntent {
 	agent: AgentType;
 	confidence: number;
 	reason: string;
+	/**
+	 * Which layer produced this decision. Useful for callers that want to know
+	 * whether a model call happened; always logged regardless.
+	 */
+	source?: RoutingDecisionSource;
+}
+
+/** Optional inputs that let `routeMessage` skip the classifier or log better. */
+export interface RouteMessageOptions {
+	/**
+	 * The `data` blob from the last user message. Read for an `agentType` hint
+	 * when the client already knows which agent it wants.
+	 */
+	messageData?: unknown;
+	/** Worker env, used only for routing-decision logging. */
+	env?: EnvWithSecrets | Record<string, unknown>;
 }
 
 export interface AgentRegistry {
@@ -132,19 +161,72 @@ export class AgentRouter {
 	 *
 	 * And makes routing decisions based on these descriptions rather than hardcoded rules.
 	 *
+	 * Before reaching the classifier, two cheaper layers get a chance to answer:
+	 * an explicit `agentType` hint from the caller, then a deterministic rules
+	 * pass over phrases with exactly one sensible destination. Both are exact —
+	 * genuinely ambiguous messages still reach the model.
+	 *
 	 * @param userMessage - The user's message to route
 	 * @param recentContext - Optional recent context for routing decisions
 	 * @param ragService - Optional RAG service for enhanced routing
+	 * @param model - Optional model override
+	 * @param options - Caller-supplied intent hint and env for logging
 	 * @returns Promise<AgentIntent> - The routing decision with agent, confidence, and reason
 	 */
 	static async routeMessage(
 		userMessage: string,
 		recentContext?: string,
 		_ragService?: any,
-		model?: any
+		model?: any,
+		options?: RouteMessageOptions
 	): Promise<AgentIntent> {
-		// Build dynamic prompt based on registered agents
 		const registeredAgents = AgentRouter.getRegisteredAgentTypes();
+		const env = options?.env;
+		const startedAt = Date.now();
+
+		// Layer 1: the caller already knows the intent (UI-initiated actions).
+		const hintedAgent = resolveExplicitAgentHint(
+			options?.messageData,
+			registeredAgents
+		);
+		if (hintedAgent) {
+			const intent: AgentIntent = {
+				agent: hintedAgent as AgentType,
+				confidence: 100,
+				reason: "Explicit agent hint from client",
+				source: "explicit-hint",
+			};
+			logRoutingDecision(env, {
+				source: "explicit-hint",
+				agent: intent.agent,
+				confidence: intent.confidence,
+				reason: intent.reason,
+				latencyMs: Date.now() - startedAt,
+			});
+			return intent;
+		}
+
+		// Layer 2: deterministic rules for unambiguous phrasing.
+		const decisive = matchDecisiveRoute(userMessage);
+		if (decisive && registeredAgents.includes(decisive.agent)) {
+			const intent: AgentIntent = {
+				agent: decisive.agent as AgentType,
+				confidence: decisive.confidence,
+				reason: decisive.reason,
+				source: "deterministic",
+			};
+			logRoutingDecision(env, {
+				source: "deterministic",
+				agent: intent.agent,
+				confidence: intent.confidence,
+				reason: intent.reason,
+				rule: decisive.rule,
+				latencyMs: Date.now() - startedAt,
+			});
+			return intent;
+		}
+
+		// Layer 3: genuinely ambiguous — ask the classifier.
 		const agentDescriptions = registeredAgents
 			.map(
 				(agentType) =>
@@ -152,67 +234,115 @@ export class AgentRouter {
 			)
 			.join("\n");
 
-		const prompt = AGENT_ROUTING_PROMPTS.formatAgentRoutingPrompt(
+		const promptParts = AGENT_ROUTING_PROMPTS.formatAgentRoutingPromptParts(
 			agentDescriptions,
 			userMessage,
-			recentContext,
-			registeredAgents
+			recentContext
 		);
 
+		// Evaluated but never routed on — this is the disagreement signal that
+		// tells us which advisory rules are safe to promote to decisive.
+		const advisory = matchAdvisoryRoute(userMessage);
+
+		const finish = (
+			intent: AgentIntent,
+			routedModelId?: string,
+			tokens?: number
+		) => {
+			logRoutingDecision(env, {
+				source: intent.source ?? "llm",
+				agent: intent.agent,
+				confidence: intent.confidence,
+				reason: intent.reason,
+				advisoryAgent: advisory?.agent,
+				advisoryAgreed: advisory ? advisory.agent === intent.agent : undefined,
+				rule: advisory?.rule,
+				latencyMs: Date.now() - startedAt,
+				model: routedModelId,
+			});
+			if (tokens !== undefined && routedModelId) {
+				logVerboseLlmSpend(env, {
+					intent: LLM_SPEND_INTENT.agent_routing,
+					source: "AgentRouter.routeMessage",
+					tokens,
+					model: routedModelId,
+					extras: { agent: intent.agent, confidence: intent.confidence },
+				});
+			}
+			return intent;
+		};
+
 		try {
-			// Use a simple LLM call to determine intent
-			// This could be replaced with your actual LLM service
-			const response = await AgentRouter.callLLM(prompt, model);
-			const [agent, confidenceStr, reason] = response.split("|");
+			const { text, modelId, tokens } = await AgentRouter.callLLM(
+				promptParts,
+				model
+			);
+			const [agent, confidenceStr, reason] = text.split("|");
 
 			// Validate that the agent is registered
 			if (!registeredAgents.includes(agent)) {
-				return {
-					agent: "resources" as AgentType,
-					confidence: 30,
-					reason: "Invalid agent, defaulting to resources",
-				};
+				return finish(
+					{
+						agent: "resources" as AgentType,
+						confidence: 30,
+						reason: "Invalid agent, defaulting to resources",
+						source: "fallback",
+					},
+					modelId,
+					tokens
+				);
 			}
 
-			return {
-				agent: agent as AgentType,
-				confidence: parseInt(confidenceStr, 10) || 50,
-				reason: reason || "LLM-based routing",
-			};
+			return finish(
+				{
+					agent: agent as AgentType,
+					confidence: parseInt(confidenceStr, 10) || 50,
+					reason: reason || "LLM-based routing",
+					source: "llm",
+				},
+				modelId,
+				tokens
+			);
 		} catch (_error) {
 			// Default to resources for file-related operations
-			return {
+			return finish({
 				agent: "resources" as AgentType,
 				confidence: 30,
 				reason: "LLM routing failed, defaulting to resources",
-			};
+				source: "fallback",
+			});
 		}
 	}
 
+	/**
+	 * Run the routing classifier.
+	 *
+	 * The stable half of the prompt (agent descriptions, routing rules,
+	 * examples) is sent as a cache-marked text part so the provider can serve it
+	 * from its prompt cache; only the message and its recent context follow the
+	 * breakpoint.
+	 *
+	 * Caveat worth knowing before optimizing further: that prefix currently
+	 * measures ~1.9k tokens, and Anthropic's minimum cacheable prefix on
+	 * claude-haiku-4-5 (the PIPELINE_LIGHT tier this uses) is 4096 tokens. Below
+	 * the minimum the breakpoint is silently ignored — no error, no cost, and no
+	 * cache either. It is kept because it costs nothing and starts working the
+	 * moment the prefix crosses that threshold or the tier moves to a
+	 * Sonnet/Opus model (1024 / 512 minimum respectively). The saving that is
+	 * real today is the deduplication below.
+	 *
+	 * The system prompt is deliberately short and static — the agent
+	 * descriptions used to be duplicated here *and* in the user message, so
+	 * every routing call shipped the registry twice.
+	 */
 	private static async callLLM(
-		userMessage: string,
+		promptParts: AgentRoutingPromptParts,
 		model?: any
-	): Promise<string> {
-		// Get all registered agents and their descriptions
-		const registeredAgents = AgentRouter.getRegisteredAgentTypes();
-		const agentDescriptions = registeredAgents
-			.map((agentType) => {
-				const description = AgentRouter.getAgentDescription(agentType);
-				return `${agentType}: ${description}`;
-			})
-			.join("\n");
-
-		// Create a generic system prompt that only uses agent descriptions
-		const systemPrompt = `You are an intelligent router that determines which AI agent should handle a user's request.
-
-Available agents and their capabilities:
-${agentDescriptions}
-
-Analyze the user's message and determine which agent would best serve their request. Consider the agent descriptions and user intent.
-
-Respond with ONLY the agent type followed by a confidence score (0-100) and a brief reason, separated by pipes.
-
-Example format: "agent_type|confidence|reason"`;
+	): Promise<{ text: string; modelId?: string; tokens?: number }> {
+		const systemPrompt =
+			"You are an intelligent router that determines which AI agent should handle a user's request. " +
+			"Respond with ONLY the agent type followed by a confidence score (0-100) and a brief reason, separated by pipes. " +
+			'Example format: "agent_type|confidence|reason"';
 
 		// Prefer PIPELINE_LIGHT for routing (faster, lower cost) when API key is available
 		const modelManager = ModelManager.getInstance();
@@ -226,7 +356,9 @@ Example format: "agent_type|confidence|reason"`;
 
 		// If no model is available, we can't route the message
 		if (!modelToUse) {
-			return "campaign|50|No model available for routing, using default agent";
+			return {
+				text: "campaign|50|No model available for routing, using default agent",
+			};
 		}
 
 		// Use generateText for the routing decision (single turn, no tools)
@@ -242,12 +374,40 @@ Example format: "agent_type|confidence|reason"`;
 		const result = await generateText({
 			model: modelToUse,
 			system: systemPrompt,
-			messages: [{ role: "user", content: userMessage }],
+			messages: [
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: promptParts.cacheablePrefix,
+							providerOptions: {
+								anthropic: { cacheControl: { type: "ephemeral" } },
+							},
+						},
+						{ type: "text", text: promptParts.variableSuffix },
+					],
+				},
+			],
 			...sampling,
 		});
 
-		const trimmedResponse = (result.text ?? "").trim();
-		return trimmedResponse;
+		const usage = result.usage as
+			| {
+					totalTokens?: number;
+					promptTokens?: number;
+					completionTokens?: number;
+			  }
+			| undefined;
+		const tokens =
+			usage?.totalTokens ??
+			(usage?.promptTokens ?? 0) + (usage?.completionTokens ?? 0);
+
+		return {
+			text: (result.text ?? "").trim(),
+			modelId: routedModelId,
+			tokens,
+		};
 	}
 
 	static getAgentDescription(agentType: string): string {

--- a/src/lib/agent-routing-fast-path.ts
+++ b/src/lib/agent-routing-fast-path.ts
@@ -1,0 +1,267 @@
+/**
+ * Deterministic pre-router for agent selection.
+ *
+ * `AgentRouter.routeMessage` used to pay an LLM classification call on every
+ * single chat message. This module short-circuits that call for the traffic
+ * whose intent is already known, in two layers:
+ *
+ * 1. **Explicit hint** (`resolveExplicitAgentHint`) — the client told us which
+ *    agent it wants. UI-initiated turns ("record a session recap", "help")
+ *    know their own intent; there is nothing for a model to re-derive.
+ * 2. **Decisive rules** (`matchDecisiveRoute`) — exact, normalized matches on
+ *    phrases the product itself emits, plus a small set of anchored patterns
+ *    the routing prompt already maps unambiguously.
+ *
+ * Anything else falls through to the LLM classifier untouched.
+ *
+ * A third, non-short-circuiting layer (`matchAdvisoryRoute`) exists purely for
+ * measurement: it guesses with loose keyword heuristics that are *not* safe to
+ * route on, so we can log how often the classifier agrees with a cheap rule and
+ * decide which advisory rules are worth promoting to decisive. See
+ * `agent-routing-telemetry.ts`.
+ *
+ * Adding a decisive rule is a routing behavior change. The bar is that the
+ * message must have exactly one sensible destination — when in doubt, add it as
+ * advisory instead and read the logs.
+ */
+
+import {
+	CONTEXT_RECAP_PLACEHOLDER,
+	UI_INITIATED_PROMPTS,
+} from "@/app-constants";
+
+/** Where a routing decision came from. Recorded on every decision. */
+export type RoutingDecisionSource =
+	| "explicit-hint"
+	| "deterministic"
+	| "llm"
+	| "fallback";
+
+export interface FastPathMatch {
+	agent: string;
+	/** 0-100, mirroring `AgentIntent.confidence`. */
+	confidence: number;
+	reason: string;
+	/** Which rule fired, for telemetry and debugging. */
+	rule: string;
+}
+
+/**
+ * Normalize a message for exact-phrase comparison: trim, collapse internal
+ * whitespace, lowercase, and drop trailing sentence punctuation. Deliberately
+ * conservative — it does not strip words, so a phrase embedded in a longer
+ * message will not match.
+ */
+export function normalizeForMatching(message: string): string {
+	return message
+		.trim()
+		.replace(/\s+/g, " ")
+		.toLowerCase()
+		.replace(/[.!?\s]+$/, "");
+}
+
+/**
+ * Layer 1: read an explicit agent type supplied by the caller.
+ *
+ * Accepts the merged `data` blob carried on the last user message. The hint is
+ * validated against the live registry, so a stale or hostile client cannot
+ * route to an agent that does not exist — an unrecognized value is ignored and
+ * routing proceeds normally rather than failing.
+ */
+export function resolveExplicitAgentHint(
+	messageData: unknown,
+	registeredAgents: readonly string[]
+): string | null {
+	if (!messageData || typeof messageData !== "object") {
+		return null;
+	}
+	const hint = (messageData as { agentType?: unknown }).agentType;
+	if (typeof hint !== "string") {
+		return null;
+	}
+	const normalized = hint.trim();
+	return registeredAgents.includes(normalized) ? normalized : null;
+}
+
+/**
+ * Exact-phrase table. Keys are normalized message text; values are the agent
+ * the routing prompt already assigns to that exact phrase.
+ *
+ * The UI-initiated prompts are sourced from `UI_INITIATED_PROMPTS` rather than
+ * retyped, so editing the prompt in one place cannot silently break routing.
+ */
+const DECISIVE_PHRASES: ReadonlyArray<
+	readonly [phrase: string, agent: string, reason: string]
+> = [
+	[
+		normalizeForMatching(CONTEXT_RECAP_PLACEHOLDER),
+		"recap",
+		"Context recap sentinel",
+	],
+	[
+		normalizeForMatching(UI_INITIATED_PROMPTS.HELP),
+		"onboarding",
+		"UI help request",
+	],
+	[
+		normalizeForMatching(UI_INITIATED_PROMPTS.SESSION_RECAP),
+		"session-digest",
+		"UI session recap request",
+	],
+	[
+		normalizeForMatching(UI_INITIATED_PROMPTS.NEXT_STEPS_GM),
+		"recap",
+		"UI next steps request",
+	],
+	[
+		normalizeForMatching(UI_INITIATED_PROMPTS.NEXT_STEPS_PLAYER),
+		"recap",
+		"UI next steps request",
+	],
+	// Session plan readout: the routing prompt lists these verbatim as "recap".
+	["let's do a readout", "recap", "Session plan readout"],
+	["lets do a readout", "recap", "Session plan readout"],
+	["construct the readout", "recap", "Session plan readout"],
+	["give me the session plan", "recap", "Session plan readout"],
+	["i'm ready for the readout", "recap", "Session plan readout"],
+	["im ready for the readout", "recap", "Session plan readout"],
+	// Free-typed variants of the next-steps question.
+	["what should i do next", "recap", "Next steps question"],
+];
+
+const DECISIVE_PHRASE_LOOKUP: ReadonlyMap<
+	string,
+	{ agent: string; reason: string }
+> = new Map(
+	DECISIVE_PHRASES.map(([phrase, agent, reason]) => [phrase, { agent, reason }])
+);
+
+/**
+ * Layer 2: match a message we can route without a model call.
+ *
+ * Matching is whole-message equality on the normalized text, never substring
+ * containment — "what should I do next about the grappling rules" is genuinely
+ * ambiguous between `recap` and `rules-reference`, so it must reach the
+ * classifier. Returns null for anything not in the table.
+ */
+export function matchDecisiveRoute(userMessage: string): FastPathMatch | null {
+	const normalized = normalizeForMatching(userMessage);
+	if (!normalized) {
+		return null;
+	}
+	const hit = DECISIVE_PHRASE_LOOKUP.get(normalized);
+	if (!hit) {
+		return null;
+	}
+	return {
+		agent: hit.agent,
+		confidence: 100,
+		reason: hit.reason,
+		rule: `phrase:${normalized.slice(0, 40)}`,
+	};
+}
+
+/**
+ * Advisory rules — measurement only, never used to route.
+ *
+ * Each entry is a loose signal drawn from the routing prompt's own rule list.
+ * They are the candidates for promotion to decisive: if the classifier agrees
+ * with an advisory guess on nearly all traffic that matches it, that rule can
+ * short-circuit and save a model call.
+ */
+const ADVISORY_RULES: ReadonlyArray<{
+	rule: string;
+	agent: string;
+	pattern: RegExp;
+}> = [
+	{
+		rule: "advisory:rules-reference",
+		agent: "rules-reference",
+		pattern:
+			/\b(what does the rule say|rules? for|how does .{1,40} work in 5e|house rule|concentration check|action economy|grappl)/i,
+	},
+	{
+		rule: "advisory:encounter-builder",
+		agent: "encounter-builder",
+		pattern:
+			/\b(build (me )?an? encounter|scale (this|the) (encounter|fight)|monster lineup|difficulty encounter)/i,
+	},
+	{
+		rule: "advisory:loot-reward",
+		agent: "loot-reward",
+		pattern:
+			/\b(loot|treasure hoard|magic item reward|what (should|do) the (players|party) find)/i,
+	},
+	{
+		rule: "advisory:session-digest",
+		agent: "session-digest",
+		pattern:
+			/\b(session recap|session digest|what happened last session|record (the |a )?session)/i,
+	},
+	{
+		rule: "advisory:character-sheets",
+		agent: "character-sheets",
+		pattern: /\b(upload|import) (my )?character sheet\b/i,
+	},
+	{
+		rule: "advisory:character",
+		agent: "character",
+		pattern:
+			/\b(create|build|finish) (my |a )?(character|pc)\b|character backstory/i,
+	},
+	{
+		rule: "advisory:campaign-analysis",
+		agent: "campaign-analysis",
+		pattern:
+			/\b(assess my campaign|campaign readiness|how ready is my campaign)/i,
+	},
+	{
+		rule: "advisory:entity-graph",
+		agent: "entity-graph",
+		pattern:
+			/\b(extract entities|entity graph|detect communities|create (a )?relationship)/i,
+	},
+	{
+		rule: "advisory:resources",
+		agent: "resources",
+		pattern:
+			/\b(upload(ed)? (a |this )?(pdf|file)|file key|ingest|index this file)/i,
+	},
+	{
+		rule: "advisory:campaign",
+		agent: "campaign",
+		pattern:
+			/\b(show me( my)? campaigns|list campaigns|create a campaign|delete (my )?campaign)/i,
+	},
+	{
+		rule: "advisory:onboarding",
+		agent: "onboarding",
+		pattern:
+			/\b(how do i (use|upload|get started)|which boost|help me choose a boost|running out of capacity)/i,
+	},
+];
+
+/**
+ * Guess an agent from loose keyword signals, for logging only.
+ *
+ * Returns the first matching rule, or null when nothing matches. Confidence is
+ * intentionally low: these are hypotheses to be validated against the
+ * classifier, not routing decisions.
+ */
+export function matchAdvisoryRoute(userMessage: string): FastPathMatch | null {
+	const trimmed = userMessage.trim();
+	if (!trimmed) {
+		return null;
+	}
+	for (const { rule, agent, pattern } of ADVISORY_RULES) {
+		if (pattern.test(trimmed)) {
+			return {
+				agent,
+				confidence: 60,
+				reason: `Advisory keyword match (${agent})`,
+				rule,
+			};
+		}
+	}
+	return null;
+}

--- a/src/lib/agent-routing-telemetry.ts
+++ b/src/lib/agent-routing-telemetry.ts
@@ -1,0 +1,82 @@
+/**
+ * Structured logging for agent routing decisions.
+ *
+ * The point of this module is to answer the question that decides how far the
+ * deterministic fast path should go: **how often does the LLM classifier
+ * disagree with what a cheap rule would have chosen?**
+ *
+ * Every routing decision emits one `agent_routing_decision` line recording the
+ * chosen agent, the confidence, and where the decision came from. When the LLM
+ * branch runs we additionally evaluate the advisory rules (which never
+ * short-circuit) and log whether they agreed. Filtering the drain to
+ * `source=llm` and grouping by `advisoryAgreed` gives the disagreement rate per
+ * rule; grouping by `confidenceBucket` gives the confidence distribution.
+ *
+ * Gated behind the existing `LORESMITH_VERBOSE_LLM_USAGE` flag so routing logs
+ * follow the same on/off switch and drain conventions as token-spend logs
+ * rather than adding a second knob.
+ */
+
+import type { RoutingDecisionSource } from "@/lib/agent-routing-fast-path";
+import type { EnvWithSecrets } from "@/lib/env-utils";
+import { isVerboseLlmSpendEnabled } from "@/lib/llm-usage-verbose-log";
+import { createLogger } from "@/lib/logger";
+
+export type RoutingDecisionLog = {
+	source: RoutingDecisionSource;
+	agent: string;
+	confidence: number;
+	reason: string;
+	/** Identifier of the fast-path rule that fired, when one did. */
+	rule?: string;
+	/** What the advisory rules would have chosen, when the LLM branch ran. */
+	advisoryAgent?: string;
+	/** Whether the advisory guess matched the final agent. Undefined when no advisory rule matched. */
+	advisoryAgreed?: boolean;
+	/** Wall-clock cost of the decision, including the LLM call when one happened. */
+	latencyMs?: number;
+	model?: string;
+};
+
+/**
+ * Bucket a 0-100 confidence into a coarse band.
+ *
+ * Buckets rather than raw values because the useful question is distributional
+ * ("what share of routed traffic is high-confidence?"), and buckets aggregate
+ * cleanly in a log drain without a numeric aggregation step.
+ */
+export function confidenceBucket(confidence: number): string {
+	if (!Number.isFinite(confidence)) return "unknown";
+	if (confidence >= 90) return "90-100";
+	if (confidence >= 70) return "70-89";
+	if (confidence >= 50) return "50-69";
+	if (confidence >= 30) return "30-49";
+	return "0-29";
+}
+
+/**
+ * Emit one structured routing-decision log line.
+ *
+ * Never throws: routing must not fail because logging did.
+ */
+export function logRoutingDecision(
+	env: EnvWithSecrets | Record<string, unknown> | undefined,
+	decision: RoutingDecisionLog
+): void {
+	if (!isVerboseLlmSpendEnabled(env)) {
+		return;
+	}
+	try {
+		const log = createLogger(
+			env as Record<string, unknown> | undefined,
+			"[AgentRouting]"
+		);
+		log.info("agent_routing_decision", {
+			event: "agent_routing_decision",
+			...decision,
+			confidenceBucket: confidenceBucket(decision.confidence),
+		});
+	} catch {
+		// Logging is best-effort; a drain problem must not break routing.
+	}
+}

--- a/src/lib/llm-usage-intents.ts
+++ b/src/lib/llm-usage-intents.ts
@@ -15,6 +15,7 @@
  * | vision_image_extract | Vision image description for extraction |
  * | session_plan_readout | Session plan readout (stitch / single-shot plan LLM) |
  * | conversation_summary | Rolling summarization of older chat turns |
+ * | agent_routing | Agent selection classifier (per-message routing tax) |
  */
 export const LLM_SPEND_INTENT = {
 	user_prompt: "user_prompt",
@@ -28,6 +29,7 @@ export const LLM_SPEND_INTENT = {
 	vision_image_extract: "vision_image_extract",
 	session_plan_readout: "session_plan_readout",
 	conversation_summary: "conversation_summary",
+	agent_routing: "agent_routing",
 } as const;
 
 export type LlmSpendIntent =

--- a/src/lib/prompts/agent-routing-prompts.ts
+++ b/src/lib/prompts/agent-routing-prompts.ts
@@ -1,29 +1,35 @@
 /**
  * Agent Routing Prompts
  * Prompts for routing user messages to the appropriate specialized agent
+ *
+ * The prompt is split into a **cacheable prefix** (agent descriptions, routing
+ * rules, examples — identical on every request for a given deploy) and a
+ * **variable suffix** (this message and its recent context). The variable part
+ * used to sit in the middle of the template, which meant no reusable prefix
+ * existed at all. Keeping it strictly last is what makes a provider-side cache
+ * breakpoint possible; see `AgentRouter.callLLM`.
  */
 
+/** The stable and per-request halves of the routing prompt. */
+export interface AgentRoutingPromptParts {
+	/** Invariant for a given deploy — safe to place behind a cache breakpoint. */
+	cacheablePrefix: string;
+	/** This request's message and context. Must stay after the breakpoint. */
+	variableSuffix: string;
+}
+
 /**
- * Generate a prompt for routing a user message to the appropriate agent
- * @param agentDescriptions - Descriptions of all available agents
- * @param userMessage - The user's message to route
- * @param recentContext - Optional recent conversation context
- * @param registeredAgents - List of registered agent type names
- * @returns Formatted prompt string for agent routing
+ * Build the invariant half of the routing prompt.
+ *
+ * Derives entirely from the static agent registry, so the output is
+ * byte-identical across requests. Do not interpolate anything per-request here
+ * — a single changed byte invalidates the whole cached prefix.
  */
-export function formatAgentRoutingPrompt(
-	agentDescriptions: string,
-	userMessage: string,
-	recentContext: string | undefined,
-	_registeredAgents: string[]
-): string {
+export function formatAgentRoutingPrefix(agentDescriptions: string): string {
 	return `Based on the user's message, determine which agent should handle this request.
 
 Available agents:
 ${agentDescriptions}
-
-User message: "${userMessage}"
-${recentContext ? `Recent context: "${recentContext}"` : ""}
 
 Routing rules:
 - **Persisted LoreSmith chat (this campaign):** Route to **"campaign-context"** when fulfilling the request requires searching, recalling, summarizing, or paging through prior messages stored for this campaign in LoreSmith (any topic or downstream task). Prefer **"campaign-context"** over **"entity-graph"** whenever that archival chat work is part of the task, even if the user also mentions entities, PCs, or the graph.
@@ -44,7 +50,6 @@ Routing rules:
 - General help/how-to questions about using the application → "onboarding"
 - Boost/credits selection (which boost, help me choose, running out of capacity when adding documents, need more room for documents) → "onboarding"
 
-Respond with: agent_name|confidence|reason
 Format: agent_name|confidence|reason
 
 Examples:
@@ -71,6 +76,56 @@ Examples:
 - "which boost should I get?" / "help me choose a boost" / "I'm running out of capacity" → onboarding|90|Boost selection`;
 }
 
+/**
+ * Build the per-request half of the routing prompt.
+ */
+export function formatAgentRoutingSuffix(
+	userMessage: string,
+	recentContext: string | undefined
+): string {
+	const context = recentContext ? `\nRecent context: "${recentContext}"` : "";
+	return `User message: "${userMessage}"${context}
+
+Respond with: agent_name|confidence|reason`;
+}
+
+/**
+ * Build both halves of the routing prompt.
+ */
+export function formatAgentRoutingPromptParts(
+	agentDescriptions: string,
+	userMessage: string,
+	recentContext?: string
+): AgentRoutingPromptParts {
+	return {
+		cacheablePrefix: formatAgentRoutingPrefix(agentDescriptions),
+		variableSuffix: formatAgentRoutingSuffix(userMessage, recentContext),
+	};
+}
+
+/**
+ * Single-string form of the routing prompt.
+ *
+ * Retained for callers that cannot use a cache breakpoint (and for tests that
+ * assert on the prompt's routing rules). Prefer
+ * `formatAgentRoutingPromptParts` on any path that hits the provider.
+ */
+export function formatAgentRoutingPrompt(
+	agentDescriptions: string,
+	userMessage: string,
+	recentContext?: string
+): string {
+	const { cacheablePrefix, variableSuffix } = formatAgentRoutingPromptParts(
+		agentDescriptions,
+		userMessage,
+		recentContext
+	);
+	return `${cacheablePrefix}\n\n${variableSuffix}`;
+}
+
 export const AGENT_ROUTING_PROMPTS = {
 	formatAgentRoutingPrompt,
+	formatAgentRoutingPromptParts,
+	formatAgentRoutingPrefix,
+	formatAgentRoutingSuffix,
 };

--- a/tests/lib/agent-router-routing.test.ts
+++ b/tests/lib/agent-router-routing.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	CONTEXT_RECAP_PLACEHOLDER,
+	UI_INITIATED_PROMPTS,
+} from "../../src/app-constants";
+
+const generateTextMock = vi.fn();
+
+vi.mock("ai", () => ({
+	generateText: (...args: unknown[]) => generateTextMock(...args),
+}));
+
+vi.mock("../../src/lib/model-manager", () => ({
+	ModelManager: {
+		getInstance: () => ({
+			getApiKey: () => "test-key",
+			getModel: () => ({ modelId: "claude-haiku-4-5" }),
+		}),
+	},
+}));
+
+vi.mock("../../src/lib/model-config", () => ({
+	createModel: (modelId: string) => ({ modelId }),
+}));
+
+import { AgentRouter } from "../../src/lib/agent-router";
+
+const AGENTS = [
+	"campaign",
+	"recap",
+	"session-digest",
+	"onboarding",
+	"resources",
+	"rules-reference",
+] as const;
+
+function registerTestAgents() {
+	for (const agent of AGENTS) {
+		AgentRouter.registerAgent(
+			agent as never,
+			class {},
+			{},
+			`system prompt for ${agent}`,
+			`Handles ${agent} work`
+		);
+	}
+}
+
+describe("AgentRouter.routeMessage layering", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		registerTestAgents();
+		generateTextMock.mockResolvedValue({
+			text: "campaign|85|Campaign listing",
+			usage: { totalTokens: 120 },
+		});
+	});
+
+	it("uses an explicit client hint without calling the model", async () => {
+		const intent = await AgentRouter.routeMessage(
+			"anything at all",
+			undefined,
+			null,
+			undefined,
+			{ messageData: { agentType: "session-digest" } }
+		);
+
+		expect(intent.agent).toBe("session-digest");
+		expect(intent.source).toBe("explicit-hint");
+		expect(intent.confidence).toBe(100);
+		expect(generateTextMock).not.toHaveBeenCalled();
+	});
+
+	it("ignores an unregistered hint and falls through to the classifier", async () => {
+		const intent = await AgentRouter.routeMessage(
+			"show me campaigns",
+			undefined,
+			null,
+			undefined,
+			{ messageData: { agentType: "totally-made-up" } }
+		);
+
+		expect(intent.agent).toBe("campaign");
+		expect(intent.source).toBe("llm");
+		expect(generateTextMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("routes deterministically for the recap sentinel without calling the model", async () => {
+		const intent = await AgentRouter.routeMessage(CONTEXT_RECAP_PLACEHOLDER);
+
+		expect(intent.agent).toBe("recap");
+		expect(intent.source).toBe("deterministic");
+		expect(generateTextMock).not.toHaveBeenCalled();
+	});
+
+	it("routes deterministically for UI-initiated prompts without calling the model", async () => {
+		const help = await AgentRouter.routeMessage(UI_INITIATED_PROMPTS.HELP);
+		expect(help.agent).toBe("onboarding");
+		expect(help.source).toBe("deterministic");
+
+		const recap = await AgentRouter.routeMessage(
+			UI_INITIATED_PROMPTS.SESSION_RECAP
+		);
+		expect(recap.agent).toBe("session-digest");
+		expect(recap.source).toBe("deterministic");
+
+		expect(generateTextMock).not.toHaveBeenCalled();
+	});
+
+	it("calls the classifier for ambiguous messages", async () => {
+		generateTextMock.mockResolvedValue({
+			text: "rules-reference|95|Rules lookup",
+			usage: { totalTokens: 130 },
+		});
+
+		const intent = await AgentRouter.routeMessage(
+			"what should I do next about the grappling rules?"
+		);
+
+		expect(intent.agent).toBe("rules-reference");
+		expect(intent.confidence).toBe(95);
+		expect(intent.source).toBe("llm");
+		expect(generateTextMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to resources when the classifier names an unregistered agent", async () => {
+		generateTextMock.mockResolvedValue({
+			text: "nonexistent-agent|95|nope",
+			usage: { totalTokens: 100 },
+		});
+
+		const intent = await AgentRouter.routeMessage("something ambiguous here");
+
+		expect(intent.agent).toBe("resources");
+		expect(intent.confidence).toBe(30);
+		expect(intent.source).toBe("fallback");
+	});
+
+	it("falls back to resources when the classifier call throws", async () => {
+		generateTextMock.mockRejectedValue(new Error("provider down"));
+
+		const intent = await AgentRouter.routeMessage("something ambiguous here");
+
+		expect(intent.agent).toBe("resources");
+		expect(intent.source).toBe("fallback");
+	});
+});
+
+describe("AgentRouter classifier prompt structure", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		registerTestAgents();
+		generateTextMock.mockResolvedValue({
+			text: "campaign|85|Campaign listing",
+			usage: { totalTokens: 120 },
+		});
+	});
+
+	it("sends the stable block behind a cache breakpoint and the message after it", async () => {
+		await AgentRouter.routeMessage(
+			"an ambiguous message about several things",
+			"some recent context"
+		);
+
+		const call = generateTextMock.mock.calls[0][0] as {
+			system: string;
+			messages: Array<{
+				role: string;
+				content: Array<{
+					type: string;
+					text: string;
+					providerOptions?: Record<string, unknown>;
+				}>;
+			}>;
+		};
+
+		const [cacheable, variable] = call.messages[0].content;
+
+		expect(cacheable.providerOptions).toEqual({
+			anthropic: { cacheControl: { type: "ephemeral" } },
+		});
+		expect(cacheable.text).toContain("Routing rules:");
+		expect(cacheable.text).toContain("Handles recap work");
+		expect(cacheable.text).not.toContain("an ambiguous message");
+
+		expect(variable.providerOptions).toBeUndefined();
+		expect(variable.text).toContain(
+			"an ambiguous message about several things"
+		);
+		expect(variable.text).toContain("some recent context");
+	});
+
+	it("does not duplicate the agent registry into the system prompt", async () => {
+		await AgentRouter.routeMessage("an ambiguous message about several things");
+
+		const call = generateTextMock.mock.calls[0][0] as { system: string };
+
+		// The descriptions used to appear in both the system prompt and the user
+		// message, doubling the token cost of every routing call.
+		expect(call.system).not.toContain("Handles recap work");
+		expect(call.system).toContain("agent_type|confidence|reason");
+	});
+});

--- a/tests/lib/agent-routing-fast-path.test.ts
+++ b/tests/lib/agent-routing-fast-path.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import {
+	CONTEXT_RECAP_PLACEHOLDER,
+	UI_INITIATED_PROMPTS,
+} from "../../src/app-constants";
+import {
+	matchAdvisoryRoute,
+	matchDecisiveRoute,
+	normalizeForMatching,
+	resolveExplicitAgentHint,
+} from "../../src/lib/agent-routing-fast-path";
+
+const REGISTERED = [
+	"campaign",
+	"campaign-context",
+	"recap",
+	"campaign-analysis",
+	"character",
+	"character-sheets",
+	"entity-graph",
+	"onboarding",
+	"resources",
+	"session-digest",
+	"loot-reward",
+	"rules-reference",
+	"encounter-builder",
+];
+
+describe("resolveExplicitAgentHint", () => {
+	it("accepts a registered agent type", () => {
+		expect(resolveExplicitAgentHint({ agentType: "recap" }, REGISTERED)).toBe(
+			"recap"
+		);
+	});
+
+	it("tolerates surrounding whitespace", () => {
+		expect(
+			resolveExplicitAgentHint({ agentType: " session-digest " }, REGISTERED)
+		).toBe("session-digest");
+	});
+
+	it("ignores an unregistered agent type rather than routing to it", () => {
+		expect(
+			resolveExplicitAgentHint({ agentType: "not-an-agent" }, REGISTERED)
+		).toBeNull();
+	});
+
+	it("ignores non-string and missing hints", () => {
+		expect(resolveExplicitAgentHint({ agentType: 42 }, REGISTERED)).toBeNull();
+		expect(resolveExplicitAgentHint({}, REGISTERED)).toBeNull();
+		expect(resolveExplicitAgentHint(undefined, REGISTERED)).toBeNull();
+		expect(resolveExplicitAgentHint("recap", REGISTERED)).toBeNull();
+		expect(resolveExplicitAgentHint(null, REGISTERED)).toBeNull();
+	});
+});
+
+describe("normalizeForMatching", () => {
+	it("lowercases, collapses whitespace, and drops trailing punctuation", () => {
+		expect(normalizeForMatching("  What   Should I Do   Next?  ")).toBe(
+			"what should i do next"
+		);
+	});
+
+	it("does not remove interior words", () => {
+		expect(normalizeForMatching("what should I do next about rules")).toBe(
+			"what should i do next about rules"
+		);
+	});
+});
+
+describe("matchDecisiveRoute", () => {
+	it("routes the context recap sentinel to recap", () => {
+		expect(matchDecisiveRoute(CONTEXT_RECAP_PLACEHOLDER)?.agent).toBe("recap");
+	});
+
+	it("routes each UI-initiated prompt to its known agent", () => {
+		expect(matchDecisiveRoute(UI_INITIATED_PROMPTS.HELP)?.agent).toBe(
+			"onboarding"
+		);
+		expect(matchDecisiveRoute(UI_INITIATED_PROMPTS.SESSION_RECAP)?.agent).toBe(
+			"session-digest"
+		);
+		expect(matchDecisiveRoute(UI_INITIATED_PROMPTS.NEXT_STEPS_GM)?.agent).toBe(
+			"recap"
+		);
+		expect(
+			matchDecisiveRoute(UI_INITIATED_PROMPTS.NEXT_STEPS_PLAYER)?.agent
+		).toBe("recap");
+	});
+
+	it("routes session plan readout phrases to recap", () => {
+		for (const phrase of [
+			"let's do a readout",
+			"Construct the readout.",
+			"give me the session plan",
+			"I'm ready for the readout",
+		]) {
+			expect(matchDecisiveRoute(phrase)?.agent).toBe("recap");
+		}
+	});
+
+	it("reports full confidence and a reason for a match", () => {
+		const match = matchDecisiveRoute("what should I do next?");
+		expect(match).toMatchObject({ agent: "recap", confidence: 100 });
+		expect(match?.reason).toBeTruthy();
+		expect(match?.rule).toContain("phrase:");
+	});
+
+	// The safety property: a decisive rule must never fire on a message whose
+	// destination is genuinely ambiguous, so matching is whole-message only.
+	it("does not match a known phrase embedded in a longer message", () => {
+		expect(
+			matchDecisiveRoute(
+				"what should I do next about the grappling rules in 5e?"
+			)
+		).toBeNull();
+		expect(
+			matchDecisiveRoute("before we do a readout, what monsters are nearby?")
+		).toBeNull();
+	});
+
+	it("returns null for ordinary messages and empty input", () => {
+		expect(matchDecisiveRoute("who is Elara Moonwhisper?")).toBeNull();
+		expect(matchDecisiveRoute("build me an encounter")).toBeNull();
+		expect(matchDecisiveRoute("")).toBeNull();
+		expect(matchDecisiveRoute("   ")).toBeNull();
+	});
+});
+
+describe("matchAdvisoryRoute", () => {
+	it("guesses rules-reference for rules questions", () => {
+		expect(matchAdvisoryRoute("How does grappling work in 5e?")?.agent).toBe(
+			"rules-reference"
+		);
+	});
+
+	it("guesses encounter-builder for encounter requests", () => {
+		expect(
+			matchAdvisoryRoute(
+				"Build an encounter for a level 7 party near Ashfen Marsh"
+			)?.agent
+		).toBe("encounter-builder");
+	});
+
+	it("guesses loot-reward for loot questions", () => {
+		expect(
+			matchAdvisoryRoute(
+				"What should the players find after defeating the bandit captain?"
+			)?.agent
+		).toBe("loot-reward");
+	});
+
+	it("carries a rule id so disagreement can be attributed per rule", () => {
+		expect(matchAdvisoryRoute("upload my character sheet")?.rule).toBe(
+			"advisory:character-sheets"
+		);
+	});
+
+	it("returns null when nothing matches", () => {
+		expect(
+			matchAdvisoryRoute("tell me about the weather in Neverwinter")
+		).toBeNull();
+		expect(matchAdvisoryRoute("")).toBeNull();
+	});
+
+	it("never reports full confidence, since it must not be routed on", () => {
+		const match = matchAdvisoryRoute("How does grappling work in 5e?");
+		expect(match?.confidence).toBeLessThan(100);
+	});
+});

--- a/tests/lib/agent-routing-prompts.test.ts
+++ b/tests/lib/agent-routing-prompts.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { formatAgentRoutingPrompt } from "../../src/lib/prompts/agent-routing-prompts";
+import {
+	formatAgentRoutingPrompt,
+	formatAgentRoutingPromptParts,
+} from "../../src/lib/prompts/agent-routing-prompts";
 
 describe("agent routing prompts", () => {
 	it("includes rules-reference routing guidance and examples", () => {
 		const prompt = formatAgentRoutingPrompt(
 			"- rules-reference: Rules lookup agent",
 			"How does grappling work in 5e?",
-			undefined,
-			["rules-reference"]
+			undefined
 		);
 
 		expect(prompt).toContain(`→ "rules-reference"`);
@@ -20,13 +22,64 @@ describe("agent routing prompts", () => {
 		const prompt = formatAgentRoutingPrompt(
 			"- encounter-builder: Encounter generation agent",
 			"Build a medium-difficulty encounter for a level 7 party near Ashfen Marsh",
-			undefined,
-			["encounter-builder"]
+			undefined
 		);
 
 		expect(prompt).toContain(`→ "encounter-builder"`);
 		expect(prompt).toContain(
 			`"Build a medium-difficulty encounter for a level 7 party near Ashfen Marsh" → encounter-builder|95|Encounter generation`
 		);
+	});
+});
+
+describe("agent routing prompt parts", () => {
+	it("keeps the prefix byte-identical across requests", () => {
+		const first = formatAgentRoutingPromptParts(
+			"- recap: Recap agent",
+			"what happened last session?",
+			"earlier turns"
+		);
+		const second = formatAgentRoutingPromptParts(
+			"- recap: Recap agent",
+			"a completely different message",
+			undefined
+		);
+
+		expect(second.cacheablePrefix).toBe(first.cacheablePrefix);
+	});
+
+	it("keeps per-request content out of the cacheable prefix", () => {
+		const { cacheablePrefix, variableSuffix } = formatAgentRoutingPromptParts(
+			"- recap: Recap agent",
+			"UNIQUE_USER_MESSAGE",
+			"UNIQUE_RECENT_CONTEXT"
+		);
+
+		expect(cacheablePrefix).not.toContain("UNIQUE_USER_MESSAGE");
+		expect(cacheablePrefix).not.toContain("UNIQUE_RECENT_CONTEXT");
+		expect(variableSuffix).toContain("UNIQUE_USER_MESSAGE");
+		expect(variableSuffix).toContain("UNIQUE_RECENT_CONTEXT");
+	});
+
+	it("carries the agent descriptions and static rules in the prefix", () => {
+		const { cacheablePrefix } = formatAgentRoutingPromptParts(
+			"- recap: Recap agent",
+			"hello",
+			undefined
+		);
+
+		expect(cacheablePrefix).toContain("- recap: Recap agent");
+		expect(cacheablePrefix).toContain("Routing rules:");
+		expect(cacheablePrefix).toContain("Examples:");
+	});
+
+	it("omits the recent-context line when there is no context", () => {
+		const { variableSuffix } = formatAgentRoutingPromptParts(
+			"- recap: Recap agent",
+			"hello",
+			undefined
+		);
+
+		expect(variableSuffix).not.toContain("Recent context");
 	});
 });

--- a/tests/lib/agent-routing-telemetry.test.ts
+++ b/tests/lib/agent-routing-telemetry.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+	confidenceBucket,
+	logRoutingDecision,
+} from "../../src/lib/agent-routing-telemetry";
+
+describe("confidenceBucket", () => {
+	it("buckets the confidence range", () => {
+		expect(confidenceBucket(100)).toBe("90-100");
+		expect(confidenceBucket(90)).toBe("90-100");
+		expect(confidenceBucket(89)).toBe("70-89");
+		expect(confidenceBucket(70)).toBe("70-89");
+		expect(confidenceBucket(50)).toBe("50-69");
+		expect(confidenceBucket(30)).toBe("30-49");
+		expect(confidenceBucket(0)).toBe("0-29");
+	});
+
+	it("handles non-finite values", () => {
+		expect(confidenceBucket(Number.NaN)).toBe("unknown");
+	});
+});
+
+describe("logRoutingDecision", () => {
+	const decision = {
+		source: "llm" as const,
+		agent: "recap",
+		confidence: 90,
+		reason: "LLM-based routing",
+	};
+
+	it("is a no-op when verbose LLM logging is off", () => {
+		expect(() => logRoutingDecision(undefined, decision)).not.toThrow();
+		expect(() =>
+			logRoutingDecision({ LORESMITH_VERBOSE_LLM_USAGE: "false" }, decision)
+		).not.toThrow();
+	});
+
+	it("does not throw when logging is enabled", () => {
+		expect(() =>
+			logRoutingDecision(
+				{ LORESMITH_VERBOSE_LLM_USAGE: "true" },
+				{
+					...decision,
+					advisoryAgent: "rules-reference",
+					advisoryAgreed: false,
+					rule: "advisory:rules-reference",
+					latencyMs: 42,
+					model: "claude-haiku-4-5",
+				}
+			)
+		).not.toThrow();
+	});
+});


### PR DESCRIPTION
Closes #736.

Every chat message paid an LLM classification call before any actual work began, and the prompt for that call was rebuilt from scratch each time. This adds the three layers the issue proposed, cheapest first.

## What changed

**Layer 1 — skip routing when the caller already knows the intent.** UI-initiated turns pass an `agentType` in message data instead of describing their intent in prose for a model to re-derive. Wired at the four sites where the UI speaks for the user: context recap, help, session recap, next steps. The hint is validated against the live registry, so an unknown value is ignored rather than trusted.

**Layer 2 — deterministic pre-router** (`src/lib/agent-routing-fast-path.ts`). Whole-message matches on phrases the product itself emits (the `[Context recap requested]` sentinel, the UI prompts, session-plan readout phrasing). Matching is normalized whole-message equality, **never substring** — "what should I do next about the grappling rules" is genuinely ambiguous between `recap` and `rules-reference`, so it still reaches the classifier. This layer also covers chat-history replays and clients that predate the hint.

**Layer 3 — cached prefix, and one duplication bug.** `routeMessage` built a prompt containing all agent descriptions, then handed it to `callLLM` **as the user message** — and `callLLM` independently rebuilt the same descriptions into its system prompt. Every routing call shipped the registry twice. The prompt is now split into a `cacheablePrefix` (descriptions + rules + examples, byte-identical per deploy) and a `variableSuffix` (this message + recent context), with the prefix behind an `ephemeral` cache breakpoint following the existing pattern in `anthropic-provider.ts`.

**Measurement first**, as the issue asked. Every decision emits an `agent_routing_decision` log with the chosen agent, a bucketed confidence, and its source. When the classifier runs we *also* evaluate a set of **advisory** rules that deliberately never short-circuit — because once a rule short-circuits you can no longer observe what the model would have said. Filtering to `source=llm` and grouping by `advisoryAgreed` gives the disagreement rate per rule; that number is what should decide which advisory rules get promoted to decisive. Gated behind the existing \`LORESMITH_VERBOSE_LLM_USAGE\` flag rather than adding a second knob.

## Measured effect

Payload per classifier call, measured against the real registry (12 agent descriptions):

| | chars | ~tokens |
|---|---|---|
| before | 9,796 | ~2,648 |
| after | 7,414 | ~2,004 |

**~24% fewer tokens on every call that still reaches the model**, and zero tokens for calls the first two layers absorb.

## One honest caveat about the cache breakpoint

The cacheable prefix measures **~1,909 tokens**. Anthropic's minimum cacheable prefix on \`claude-haiku-4-5\` — the `PIPELINE_LIGHT` tier routing uses — is **4096 tokens**. Below the minimum the breakpoint is *silently ignored*: no error, no cost, and no cache either.

So layer 3's cache is **inert today**. I kept the breakpoint because it costs nothing and starts working the moment the prefix crosses that threshold (more agents) or the tier moves to a Sonnet/Opus model (1024 / 512 minimum). The saving that is real right now is the deduplication. This is documented in a comment at the breakpoint so nobody later assumes caching is active. If you'd rather not carry an inert breakpoint, say so and I'll strip it — the dedup and both fast-path layers stand on their own.

Also checked the issue's closing note: `callLLM` already uses `PIPELINE_LIGHT`, which resolves to `claude-haiku-4-5` on Anthropic. Already the cheap tier; no change needed.

## Behavior preserved

The character-onboarding override in `Chat.determineAgent` still runs **before** `routeMessage`, so a `recap` hint cannot bypass the incomplete-character-sheet guard. Fallback behavior on an unregistered agent name or a provider failure is unchanged.

## Verification

- `npm run check` — passes (biome, import paths, tsc)
- `npx vitest run` — 1562 tests / 172 files, all passing, no regressions
- 37 new tests across 4 files, including the no-false-positive cases that keep layer 2 safe
- Not run: Playwright e2e (CI will), and no live provider call — the classifier is mocked, so the cache-hit rate is reasoned from documented thresholds, not observed

## How to see this change

```bash
gh pr checkout 759
npm install            # only if dependencies changed
```

There is no user-visible difference — routing lands on the same agents, just without the model call for known intents. The behavior is proven by tests:

```bash
npx vitest run tests/lib/agent-router-routing.test.ts tests/lib/agent-routing-fast-path.test.ts
```

**What you should see:** `AgentRouter.routeMessage layering` asserts `generateText` is **not called** for an explicit hint or a decisive phrase, and **is called exactly once** for an ambiguous message — the before/after is the mock call count. `AgentRouter classifier prompt structure` asserts the stable block carries `cacheControl: { type: "ephemeral" }`, that the user message is not in it, and that the descriptions no longer appear in the system prompt.

To watch it on a running app, set `LORESMITH_VERBOSE_LLM_USAGE=true`, run the two-terminal setup from `docs/DEV_SETUP.md`, click **Next steps** in a campaign, and look for one `agent_routing_decision` line with `source=explicit-hint` and no accompanying `llm_token_spend` for routing. Type a free-form question instead and you'll get `source=llm` with `advisoryAgent`/`advisoryAgreed` populated. I did not run this locally — no provider key in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
