### PR TITLE
feat(llm): route queue-driven entity extraction through Anthropic Message Batches (#735)

### DIFF
--- a/complexity-baseline.json
+++ b/complexity-baseline.json
@@ -105,10 +105,6 @@
 			"ccn": 22,
 			"count": 1
 		},
-		"src/components/upload/LibraryEntityIndexingProgress.tsx::LibraryEntityIndexingProgress": {
-			"ccn": 18,
-			"count": 1
-		},
 		"src/dao/entity-dao.ts::createEntity": {
 			"ccn": 19,
 			"count": 1
@@ -285,10 +281,6 @@
 			"ccn": 47,
 			"count": 1
 		},
-		"src/services/campaign/entity-staging-service.ts::processChunk": {
-			"ccn": 17,
-			"count": 1
-		},
 		"src/services/campaign/entity-staging-service.ts::stageEntitiesFromResourceImpl": {
 			"ccn": 36,
 			"count": 1
@@ -302,7 +294,7 @@
 			"count": 1
 		},
 		"src/services/campaign/library-entity-discovery-queue-service.ts::processQueue": {
-			"ccn": 49,
+			"ccn": 47,
 			"count": 1
 		},
 		"src/services/character-sheet/character-sheet-parser-service.ts::mergeParsedResults": {
@@ -366,7 +358,7 @@
 			"count": 1
 		},
 		"src/services/llm/anthropic-provider.ts::generateStructuredOutput": {
-			"ccn": 19,
+			"ccn": 18,
 			"count": 1
 		},
 		"src/services/llm/llm-rate-limit-service.ts::checkLimit": {
@@ -387,10 +379,6 @@
 		},
 		"src/services/rag/entity-extraction-service.ts::(anonymous)": {
 			"ccn": 19,
-			"count": 1
-		},
-		"src/services/rag/entity-extraction-service.ts::extractEntities": {
-			"ccn": 20,
 			"count": 1
 		},
 		"src/services/rag/historical-context-service.ts::applyHistoricalOverlay": {

--- a/docs/LIBRARY_ENTITY_PIPELINE.md
+++ b/docs/LIBRARY_ENTITY_PIPELINE.md
@@ -16,6 +16,8 @@ This document describes how **library-scoped entity discovery** works, how it ti
 2. **Library entity discovery**  
    `LibraryEntityDiscoveryQueueService` processes rows in `library_entity_discovery` (`pending` → `processing` → `complete` | `failed`). On success, candidates and relationships are stored library-side for later copy into campaigns.
 
+   Each scheduled run handles a bounded window of chunks and requeues the row until the document is finished. When `LLM_BATCH_EXTRACTION_ENABLED=true`, that window's chunks are sent as one Anthropic message batch and collected on a later run instead of one request per chunk — see [LLM batch processing](./LLM_BATCH_PROCESSING.md). Waiting on a batch requeues the row at the same cursor and does not consume `retry_count`.
+
 3. **Campaign add**  
    When a resource is added to a campaign (`handleAddResourceToCampaign`):
 
@@ -90,3 +92,4 @@ Discovery failures are recorded on `library_entity_discovery` with retry metadat
 - [GraphRAG integration](./GRAPHRAG_INTEGRATION.md) — how staged entities feed the graph
 - [API reference](./API.md) — endpoint summary
 - [D1 indexes](./database/d1-indexes.md) — tables and indexes
+- [LLM batch processing](./LLM_BATCH_PROCESSING.md) — batching the extraction requests this pipeline makes

--- a/docs/LLM_BATCH_PROCESSING.md
+++ b/docs/LLM_BATCH_PROCESSING.md
@@ -1,0 +1,157 @@
+# LLM batch processing (Anthropic Message Batches)
+
+Queue-driven entity extraction can be routed through the [Anthropic Message
+Batches API](https://platform.claude.com/docs/en/build-with-claude/batch-processing)
+instead of one synchronous request per chunk. Batch pricing is roughly half the
+standard rate, and this workload already tolerates minutes of delay: the user
+uploads a file and gets a notification when indexing completes.
+
+Off by default. Set `LLM_BATCH_EXTRACTION_ENABLED=true` to turn it on.
+
+## Why this needs a state machine
+
+Anthropic allows a batch up to 24 hours; most finish within an hour. A Cloudflare
+Worker invocation cannot wait that long, so "submit → poll → resume" cannot be
+one async function. Instead:
+
+1. A cron tick **submits** the current chunk window as one batch and records it
+   in `llm_batch_jobs`. The discovery job stays queued.
+2. Later ticks **poll** the batch. Still running → the job stays queued.
+3. The tick that finds the batch `ended` **collects** the results and hands the
+   payloads back to the extraction pipeline, which merges, dedupes, embeds and
+   notifies exactly as it does for inline extraction.
+
+The existing `*/5 * * * *` cron (`CRON_SCHEDULE_FAST`) drives all three.
+
+### Polling is cheap on purpose
+
+A polling tick calls `peekPendingBatch()` **before** entering the staging
+pipeline, and requeues the job without going further if the batch is still
+running. This is load-bearing, not an optimization: staging front-loads content
+extraction plus 1–3 character-sheet-detection LLM calls before it ever plans
+chunks. Reaching the batch seam through staging on every poll would repeat those
+interactive calls once per tick for the life of the batch — easily enough to
+cancel out the batch discount. A waiting tick costs one D1 read, one Anthropic
+status GET, and one D1 write.
+
+## Components
+
+| Piece | File |
+| --- | --- |
+| Batch submission / poll / results client | `src/services/llm/anthropic-batch-provider.ts` |
+| State machine + fallback policy | `src/services/llm/entity-extraction-batch-service.ts` |
+| Feature flag, deadlines, timestamp parsing | `src/services/llm/llm-batch-config.ts` |
+| Persistence for in-flight batches | `src/dao/llm-batch-job-dao.ts`, `migrations/0032_llm_batch_jobs.sql` |
+| Seam into the extraction pipeline | `src/services/campaign/entity-extraction-batch-coordinator.ts` |
+| Owning queue job | `src/services/campaign/library-entity-discovery-queue-service.ts` |
+
+The synchronous path uses the AI SDK (`@ai-sdk/anthropic`), which has no batches
+support, so the batch path uses the official `@anthropic-ai/sdk` — mainly for
+decoding the JSONL results stream. It is imported lazily.
+
+## The coordinator seam
+
+Entity staging plans its chunks, then asks the coordinator what to do with them.
+The coordinator returns one of three verdicts, and staging does the rest:
+
+| Verdict | Staging behavior |
+| --- | --- |
+| `awaiting` | Return immediately with `awaitingBatch: true`, resume cursor unchanged. No model calls. |
+| `ready` | Use the supplied payload per chunk. Chunks missing from the map fall through to an inline call. |
+| `inline` | Extract every chunk inline — identical to the pre-batch behavior. |
+
+This keeps batch ids, deadlines, and cron ticks out of the extraction pipeline,
+and means everything downstream of extraction is shared by both paths.
+
+## Fallback: batching never wedges indexing
+
+Every failure resolves to inline extraction. There is no state in which a batch
+problem stops a file from being indexed:
+
+| Situation | Outcome |
+| --- | --- |
+| Flag off, or provider is not Anthropic | `inline` |
+| `llm_batch_jobs` table missing (Worker ahead of its migration) | `inline` |
+| Fewer than `LLM_BATCH_MIN_REQUESTS` chunks in the window | `inline` — batch overhead is not worth it |
+| Per-user batch request budget exhausted | `inline` |
+| Submit throws | Row marked `failed`, `inline` |
+| Poll throws | Row marked `failed`, `inline` |
+| Batch past `LLM_BATCH_DEADLINE_MINUTES` (default 180) | Batch canceled, row `expired`, `inline` |
+| File content or chunk window changed since submit | Batch canceled, row `canceled`, `inline` |
+| Some requests errored / expired / returned unparseable JSON | Only those chunks go inline; the rest use their batch results |
+| Worker lost mid-submit | Row swept to `failed` by `cleanupStaleBatchJobs`, `inline` |
+
+A partly-failed batch therefore costs only the requests that actually failed.
+
+## Single-flight
+
+A partial unique index on `(owner_kind, owner_key)` over non-terminal rows means
+one pipeline job can have at most one batch in flight. Two concurrent cron ticks
+cannot submit duplicate work: the losing insert is rejected and that tick runs
+inline (or waits, if the winner is still submitting).
+
+## Prompt caching
+
+Every request in a batch shares a byte-identical instruction prefix, marked
+`cache_control: ephemeral`; only the document chunk varies. The prefix is built
+by the same helper the synchronous path uses
+(`src/lib/llm-structured-output.ts`) so the two cannot drift — if they built
+different prompts, a chunk could extract cleanly inline and fail in a batch, and
+the batch→inline fallback would stop being a true fallback.
+
+## Rate limits and spend
+
+Batch requests draw on the org's `batchRequestsPerMinute` line, which is
+separate from the interactive RPM that per-tier `qph`/`qpd` limits derive from
+(`deriveBatchRequestBudget` in `src/config/anthropic-org-rate-budget.ts`). So
+background indexing does not spend the budget a user's chat needs, and vice
+versa.
+
+Token caps still apply. On collect, spend is recorded once via
+`recordBatchUsage`, which records token counts verbatim — including cache-write
+and cache-read input tokens, or every request after the first would be
+under-reported — with `queryCount: 0`, since the request volume was already
+gated against the batch budget line.
+
+## Retry accounting
+
+Per-file retry caps (`retriesPerFilePerDay` / `retriesPerFilePerMonth`) count
+**user-initiated retries of a file**, not model calls, so batching does not
+change them. Waiting on a batch is neither progress nor failure: the discovery
+job is requeued at the same cursor without touching `retry_count`, so a slow
+batch never burns a job's retry budget.
+
+## Progress UX
+
+Chunks in one batch complete together, so `PROGRESS:a/b` cannot advance until
+the batch lands — a correct-but-frozen bar reads as a stall. While a batch is in
+flight, `queue_message` carries a `BATCH:<chunkCount>:<submittedAt>` marker
+alongside the `PROGRESS` line, and the UI says how many chunks are queued for
+batch processing (`LibraryEntityIndexingProgress`).
+
+## Configuration
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| `LLM_BATCH_EXTRACTION_ENABLED` | off | Master switch. Anthropic provider only. |
+| `LLM_BATCH_MIN_REQUESTS` | 2 | Below this, extract inline. |
+| `LLM_BATCH_DEADLINE_MINUTES` | 180 | Abandon the batch and fall back after this. |
+| `LLM_BATCH_SUBMITTING_TIMEOUT_MINUTES` | 15 | Sweep rows abandoned mid-submit. |
+
+## Currently routed
+
+Only **library entity discovery** — the largest queue-driven LLM consumer, and
+the one the cron already resumes chunk-by-chunk. The coordinator interface is
+generic, so other non-interactive paths named in issue #735 (file content
+extraction, metadata generation, community summaries) can adopt it by supplying
+a coordinator; they are not routed yet.
+
+## Rollout
+
+1. Apply migrations (`npm run migrate:dev` / `migrate:prod:apply`).
+2. Set `LLM_BATCH_EXTRACTION_ENABLED=true`.
+3. Watch the `[EntityExtractionBatch]` logs: `batch_submitted`,
+   `batch_collected` (with `servedChunks` / `fallbackChunks`),
+   `batch_deadline_exceeded`, `batch_budget_declined`.
+4. To roll back, unset the flag. In-flight batches are collected or expire on
+   their own; new work goes inline immediately.

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,11 @@ Welcome to the LoreSmith AI documentation! This directory contains comprehensive
   - Changing models
   - Performance tuning
 
+- **[LLM batch processing](LLM_BATCH_PROCESSING.md)** - Routing queue-driven extraction through the Anthropic Message Batches API
+  - Submit / poll / collect across cron ticks
+  - Inline fallback policy
+  - Batch rate budget and spend accounting
+
 - **[Agent Design](AGENT_DESIGN.md)** - Agent routing and execution design
   - Agent routing flow
   - BaseAgent behavior
@@ -161,6 +166,7 @@ docs/
 ├── API.md                  # API reference
 ├── GRAPHRAG_INTEGRATION.md # GraphRAG details
 ├── LIBRARY_ENTITY_PIPELINE.md # Library discovery and campaign copy
+├── LLM_BATCH_PROCESSING.md # Anthropic message batches for queue work
 ├── AUTHENTICATION_FLOW.md  # Auth system
 ├── STORAGE_STRATEGY.md     # Storage architecture
 └── ...                     # Additional technical docs

--- a/migrations/0032_llm_batch_jobs.sql
+++ b/migrations/0032_llm_batch_jobs.sql
@@ -1,0 +1,70 @@
+-- Anthropic Message Batches API for queue-driven pipeline work (issue #735)
+--
+-- A batch is submitted in one worker invocation and collected in a later one
+-- (Anthropic allows up to 24h, a Worker invocation does not), so the in-flight
+-- batch has to outlive the request that created it. One row per submitted batch.
+--
+-- `owner_kind` + `owner_key` identify the pipeline job the batch belongs to
+-- (currently 'library_entity_discovery' + file_key). The UNIQUE index on
+-- (owner_kind, owner_key) over non-terminal rows is what makes submission
+-- single-flight: a second cron tick cannot submit a duplicate batch for a job
+-- that already has one in flight.
+--
+-- `requests` is a JSON array of {customId, chunkIndex} — the mapping needed to
+-- put an out-of-order batch result back on the right chunk. Batch results are
+-- keyed by custom_id and arrive in arbitrary order, never by position.
+CREATE TABLE IF NOT EXISTS llm_batch_jobs (
+  id TEXT PRIMARY KEY,
+  provider TEXT NOT NULL,
+  provider_batch_id TEXT,
+  owner_kind TEXT NOT NULL,
+  owner_key TEXT NOT NULL,
+  username TEXT NOT NULL,
+  model TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN (
+    'submitting',
+    'in_progress',
+    'collected',
+    'failed',
+    'expired',
+    'canceled'
+  )),
+  request_count INTEGER NOT NULL DEFAULT 0,
+  succeeded_count INTEGER NOT NULL DEFAULT 0,
+  errored_count INTEGER NOT NULL DEFAULT 0,
+  -- JSON array of {customId, chunkIndex}. Results are keyed by custom_id.
+  requests TEXT NOT NULL,
+  -- Guards against resuming a batch against different content: on collect, the
+  -- caller re-derives this and falls back to inline extraction on mismatch.
+  content_fingerprint TEXT,
+  chunk_window_start INTEGER,
+  chunk_window_end INTEGER,
+  total_chunks INTEGER,
+  -- Wall-clock deadline. Past it, the caller abandons the batch and falls back
+  -- to the synchronous per-item path so indexing never wedges.
+  deadline_at DATETIME NOT NULL,
+  last_polled_at DATETIME,
+  poll_count INTEGER NOT NULL DEFAULT 0,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  completed_at DATETIME
+);
+
+-- Single-flight per pipeline job: at most one non-terminal batch per owner.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_batch_jobs_owner_active
+  ON llm_batch_jobs(owner_kind, owner_key)
+  WHERE status IN ('submitting', 'in_progress');
+
+CREATE INDEX IF NOT EXISTS idx_llm_batch_jobs_status_created
+  ON llm_batch_jobs(status, created_at);
+
+-- Batch requests draw on a separate org budget line (batchRequestsPerMinute),
+-- so the budget check sums request_count over a recent window.
+CREATE INDEX IF NOT EXISTS idx_llm_batch_jobs_username_created
+  ON llm_batch_jobs(username, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_llm_batch_jobs_provider_batch_id
+  ON llm_batch_jobs(provider_batch_id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@ai-sdk/anthropic": "^4.0.18",
 				"@ai-sdk/openai": "^4.0.17",
 				"@ai-sdk/react": "^4.0.37",
+				"@anthropic-ai/sdk": "^0.115.0",
 				"@hono/swagger-ui": "^0.6.1",
 				"@hono/zod-openapi": "^1.4.0",
 				"@phosphor-icons/react": "^2.1.10",
@@ -72,7 +73,7 @@
 				"wrangler": "^4.56.0"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=22"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -196,6 +197,27 @@
 			},
 			"peerDependencies": {
 				"react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.115.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+			"integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@apidevtools/json-schema-ref-parser": {
@@ -7913,6 +7935,19 @@
 			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
 			"license": "(AFL-2.1 OR BSD-3-Clause)"
 		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/json-schema-to-typescript": {
 			"version": "15.0.4",
 			"resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
@@ -11635,6 +11670,12 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT"
 		},
 		"node_modules/ts-dedent": {
 			"version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
 		"@ai-sdk/anthropic": "^4.0.18",
 		"@ai-sdk/openai": "^4.0.17",
 		"@ai-sdk/react": "^4.0.37",
+		"@anthropic-ai/sdk": "^0.115.0",
 		"@hono/swagger-ui": "^0.6.1",
 		"@hono/zod-openapi": "^1.4.0",
 		"@phosphor-icons/react": "^2.1.10",

--- a/scripts/d1/d1-bootstrap.sql
+++ b/scripts/d1/d1-bootstrap.sql
@@ -909,6 +909,77 @@ CREATE INDEX IF NOT EXISTS idx_llm_cost_events_user_time
 CREATE INDEX IF NOT EXISTS idx_llm_cost_events_intent_time
   ON llm_cost_events(intent, created_at);
 
+-- Anthropic Message Batches API for queue-driven pipeline work (issue #735)
+--
+-- A batch is submitted in one worker invocation and collected in a later one
+-- (Anthropic allows up to 24h, a Worker invocation does not), so the in-flight
+-- batch has to outlive the request that created it. One row per submitted batch.
+--
+-- `owner_kind` + `owner_key` identify the pipeline job the batch belongs to
+-- (currently 'library_entity_discovery' + file_key). The UNIQUE index on
+-- (owner_kind, owner_key) over non-terminal rows is what makes submission
+-- single-flight: a second cron tick cannot submit a duplicate batch for a job
+-- that already has one in flight.
+--
+-- `requests` is a JSON array of {customId, chunkIndex} — the mapping needed to
+-- put an out-of-order batch result back on the right chunk. Batch results are
+-- keyed by custom_id and arrive in arbitrary order, never by position.
+CREATE TABLE IF NOT EXISTS llm_batch_jobs (
+  id TEXT PRIMARY KEY,
+  provider TEXT NOT NULL,
+  provider_batch_id TEXT,
+  owner_kind TEXT NOT NULL,
+  owner_key TEXT NOT NULL,
+  username TEXT NOT NULL,
+  model TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN (
+    'submitting',
+    'in_progress',
+    'collected',
+    'failed',
+    'expired',
+    'canceled'
+  )),
+  request_count INTEGER NOT NULL DEFAULT 0,
+  succeeded_count INTEGER NOT NULL DEFAULT 0,
+  errored_count INTEGER NOT NULL DEFAULT 0,
+  -- JSON array of {customId, chunkIndex}. Results are keyed by custom_id.
+  requests TEXT NOT NULL,
+  -- Guards against resuming a batch against different content: on collect, the
+  -- caller re-derives this and falls back to inline extraction on mismatch.
+  content_fingerprint TEXT,
+  chunk_window_start INTEGER,
+  chunk_window_end INTEGER,
+  total_chunks INTEGER,
+  -- Wall-clock deadline. Past it, the caller abandons the batch and falls back
+  -- to the synchronous per-item path so indexing never wedges.
+  deadline_at DATETIME NOT NULL,
+  last_polled_at DATETIME,
+  poll_count INTEGER NOT NULL DEFAULT 0,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  completed_at DATETIME
+);
+
+-- Single-flight per pipeline job: at most one non-terminal batch per owner.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_llm_batch_jobs_owner_active
+  ON llm_batch_jobs(owner_kind, owner_key)
+  WHERE status IN ('submitting', 'in_progress');
+
+CREATE INDEX IF NOT EXISTS idx_llm_batch_jobs_status_created
+  ON llm_batch_jobs(status, created_at);
+
+-- Batch requests draw on a separate org budget line (batchRequestsPerMinute),
+-- so the budget check sums request_count over a recent window.
+CREATE INDEX IF NOT EXISTS idx_llm_batch_jobs_username_created
+  ON llm_batch_jobs(username, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_llm_batch_jobs_provider_batch_id
+  ON llm_batch_jobs(provider_batch_id);
+
 -- Create a view for easy querying of analyzed files
 CREATE VIEW IF NOT EXISTS analyzed_files AS
 select 

--- a/src/components/upload/LibraryEntityIndexingProgress.tsx
+++ b/src/components/upload/LibraryEntityIndexingProgress.tsx
@@ -1,5 +1,6 @@
 import {
 	chunkProgressPercent,
+	parseEntityExtractionBatchState,
 	parseEntityExtractionProgress,
 } from "@/lib/entity-extraction-progress";
 import { FILE_UPLOAD_STATUS } from "@/lib/file/file-upload-status";
@@ -48,6 +49,42 @@ function ProgressBar(props: {
 }
 
 /**
+ * Discovery section: a chunk-percent bar once `PROGRESS:a/b` exists, otherwise a
+ * plain status line.
+ *
+ * Chunks sent as one Anthropic message batch complete together, so the percent
+ * cannot advance until the batch lands — a correct-but-frozen bar reads as a
+ * stall, so a pending batch is always named explicitly (issue #735).
+ */
+function DiscoveryProgress({ queueMessage }: { queueMessage?: string | null }) {
+	const prog = parseEntityExtractionProgress(queueMessage ?? null);
+	const batchState = parseEntityExtractionBatchState(queueMessage ?? null);
+	const pct = prog ? chunkProgressPercent(prog.processed, prog.total) : null;
+
+	if (pct === null || !prog) {
+		return (
+			<p className="text-xs text-neutral-600 dark:text-neutral-400">
+				{batchState
+					? `${batchState.chunkCount} chunks queued for batch processing…`
+					: "Extracting entities…"}
+			</p>
+		);
+	}
+
+	const chunks = `${prog.processed} of ${prog.total} chunks`;
+	const queued = batchState
+		? ` — ${batchState.chunkCount} queued for batch processing`
+		: "";
+	return (
+		<ProgressBar
+			pct={pct}
+			ariaLabel={`Entity extraction progress ${pct} percent`}
+			caption={`${pct}% extracted (${chunks})${queued}`}
+		/>
+	);
+}
+
+/**
  * Chunk-level ingestion (vectorize) and library entity discovery (PROGRESS:a/b in queue_message).
  */
 export function LibraryEntityIndexingProgress({
@@ -70,11 +107,6 @@ export function LibraryEntityIndexingProgress({
 
 	const discoveryInFlight =
 		discoveryStatus === "pending" || discoveryStatus === "processing";
-	const prog = parseEntityExtractionProgress(queueMessage ?? null);
-	const discPct =
-		discoveryInFlight && prog
-			? chunkProgressPercent(prog.processed, prog.total)
-			: null;
 
 	if (!showIngestion && !discoveryInFlight) {
 		return null;
@@ -93,17 +125,7 @@ export function LibraryEntityIndexingProgress({
 			)}
 			{discoveryInFlight && (
 				<div>
-					{discPct !== null && prog ? (
-						<ProgressBar
-							pct={discPct}
-							ariaLabel={`Entity extraction progress ${discPct} percent`}
-							caption={`${discPct}% extracted (${prog.processed} of ${prog.total} chunks)`}
-						/>
-					) : (
-						<p className="text-xs text-neutral-600 dark:text-neutral-400">
-							Extracting entities…
-						</p>
-					)}
+					<DiscoveryProgress queueMessage={queueMessage} />
 				</div>
 			)}
 		</div>

--- a/src/config/anthropic-org-rate-budget.ts
+++ b/src/config/anthropic-org-rate-budget.ts
@@ -117,3 +117,34 @@ export function deriveSubscriptionTierRates(): {
 
 	return { free, basic, pro };
 }
+
+/**
+ * Per-user share of the org's **batch** request budget.
+ *
+ * Batch submissions draw on `ANTHROPIC_ORG_LIMITS.batchRequestsPerMinute`, a
+ * budget line separate from the interactive RPM/ITPM the tier limits above are
+ * derived from. Charging batch work against the interactive budget would let
+ * background indexing starve a user's chat, so the batch path checks this
+ * instead (see
+ * {@link import("@/services/llm/llm-rate-limit-service").LLMRateLimitService.checkBatchRequestBudget}).
+ *
+ * Uses the same concurrency and headroom assumptions as the interactive split
+ * so both budgets move together when `expectedConcurrentActiveUsers` changes.
+ */
+export function deriveBatchRequestBudget(): {
+	/** Batch requests per minute available to one user. */
+	requestsPerMinutePerUser: number;
+	/** Org-wide ceiling, for reporting. */
+	requestsPerMinuteOrg: number;
+} {
+	const n = Math.max(
+		1,
+		Math.floor(ORG_RATE_BUDGET_ASSUMPTIONS.expectedConcurrentActiveUsers)
+	);
+	const headroom = ORG_RATE_BUDGET_ASSUMPTIONS.headroom;
+	const org = ANTHROPIC_ORG_LIMITS.batchRequestsPerMinute;
+	return {
+		requestsPerMinutePerUser: Math.max(1, Math.floor((org * headroom) / n)),
+		requestsPerMinuteOrg: org,
+	};
+}

--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -23,6 +23,7 @@ import { EntityImportanceDAO } from "./entity-importance-dao";
 import { FileDAO } from "./file/file-dao";
 import { FileRetryUsageDAO } from "./file-retry-usage-dao";
 import { GraphRebuildDirtyDAO } from "./graph-rebuild-dirty-dao";
+import { LlmBatchJobDAO } from "./llm-batch-job-dao";
 import { LLMCostEventDAO } from "./llm-cost-event-dao";
 import { LLMUsageDAO } from "./llm-usage-dao";
 import { MessageHistoryDAO } from "./message-history-dao";
@@ -63,6 +64,7 @@ export interface DAOFactory {
 	graphRebuildDirtyDAO: GraphRebuildDirtyDAO;
 	llmUsageDAO: LLMUsageDAO;
 	llmCostEventDAO: LLMCostEventDAO;
+	llmBatchJobDAO: LlmBatchJobDAO;
 	communityDAO: CommunityDAO;
 	communitySummaryDAO: CommunitySummaryDAO;
 	continuityFindingDAO: ContinuityFindingDAO;
@@ -109,6 +111,7 @@ export class DAOFactoryImpl implements DAOFactory {
 	public readonly graphRebuildDirtyDAO: GraphRebuildDirtyDAO;
 	public readonly llmUsageDAO: LLMUsageDAO;
 	public readonly llmCostEventDAO: LLMCostEventDAO;
+	public readonly llmBatchJobDAO: LlmBatchJobDAO;
 	public readonly communityDAO: CommunityDAO;
 	public readonly communitySummaryDAO: CommunitySummaryDAO;
 	public readonly continuityFindingDAO: ContinuityFindingDAO;
@@ -150,6 +153,7 @@ export class DAOFactoryImpl implements DAOFactory {
 		this.graphRebuildDirtyDAO = new GraphRebuildDirtyDAO(db);
 		this.llmUsageDAO = new LLMUsageDAO(db);
 		this.llmCostEventDAO = new LLMCostEventDAO(db);
+		this.llmBatchJobDAO = new LlmBatchJobDAO(db);
 		this.communityDAO = new CommunityDAO(db);
 		this.communitySummaryDAO = new CommunitySummaryDAO(db);
 		this.continuityFindingDAO = new ContinuityFindingDAO(db);

--- a/src/dao/llm-batch-job-dao.ts
+++ b/src/dao/llm-batch-job-dao.ts
@@ -1,0 +1,210 @@
+import { BaseDAOClass } from "@/dao/base-dao";
+import type {
+	LlmBatchJobRow,
+	LlmBatchRequestRef,
+	LlmBatchStatus,
+} from "@/types/llm-batch";
+
+/** Statuses a batch can still move out of (i.e. it occupies its owner slot). */
+const ACTIVE_STATUSES: LlmBatchStatus[] = ["submitting", "in_progress"];
+
+export interface CreateLlmBatchJobInput {
+	id: string;
+	provider: string;
+	ownerKind: string;
+	ownerKey: string;
+	username: string;
+	model: string;
+	requests: LlmBatchRequestRef[];
+	contentFingerprint: string | null;
+	chunkWindowStart: number;
+	chunkWindowEnd: number;
+	totalChunks: number;
+	deadlineAt: string;
+}
+
+/**
+ * Persistence for in-flight Anthropic message batches (issue #735).
+ *
+ * Every method is a no-op / empty result when the table is absent so a Worker
+ * deployed ahead of its migration degrades to the synchronous extraction path
+ * instead of throwing on every cron tick.
+ */
+export class LlmBatchJobDAO extends BaseDAOClass {
+	async isSchemaReady(): Promise<boolean> {
+		return this.hasTable("llm_batch_jobs");
+	}
+
+	/**
+	 * Claim the owner's batch slot. Returns null when the owner already has a
+	 * non-terminal batch (the partial unique index rejects the insert), which is
+	 * how concurrent cron ticks avoid submitting the same work twice.
+	 */
+	async createSubmitting(
+		input: CreateLlmBatchJobInput
+	): Promise<LlmBatchJobRow | null> {
+		const sql = `
+      INSERT OR IGNORE INTO llm_batch_jobs (
+        id, provider, owner_kind, owner_key, username, model, status,
+        request_count, requests, content_fingerprint,
+        chunk_window_start, chunk_window_end, total_chunks, deadline_at,
+        created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, 'submitting', ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+    `;
+		const changes = await this.executeReturningChanges(sql, [
+			input.id,
+			input.provider,
+			input.ownerKind,
+			input.ownerKey,
+			input.username,
+			input.model,
+			input.requests.length,
+			JSON.stringify(input.requests),
+			input.contentFingerprint,
+			input.chunkWindowStart,
+			input.chunkWindowEnd,
+			input.totalChunks,
+			input.deadlineAt,
+		]);
+		if (changes === 0) {
+			return null;
+		}
+		return this.getById(input.id);
+	}
+
+	async getById(id: string): Promise<LlmBatchJobRow | null> {
+		return this.queryFirst<LlmBatchJobRow>(
+			`SELECT * FROM llm_batch_jobs WHERE id = ?`,
+			[id]
+		);
+	}
+
+	/** The owner's in-flight batch, if any. */
+	async getActiveForOwner(
+		ownerKind: string,
+		ownerKey: string
+	): Promise<LlmBatchJobRow | null> {
+		const placeholders = ACTIVE_STATUSES.map(() => "?").join(", ");
+		return this.queryFirst<LlmBatchJobRow>(
+			`SELECT * FROM llm_batch_jobs
+       WHERE owner_kind = ? AND owner_key = ? AND status IN (${placeholders})
+       ORDER BY created_at DESC LIMIT 1`,
+			[ownerKind, ownerKey, ...ACTIVE_STATUSES]
+		);
+	}
+
+	async markInProgress(id: string, providerBatchId: string): Promise<void> {
+		await this.execute(
+			`UPDATE llm_batch_jobs
+       SET status = 'in_progress', provider_batch_id = ?, updated_at = datetime('now')
+       WHERE id = ?`,
+			[providerBatchId, id]
+		);
+	}
+
+	async recordPoll(
+		id: string,
+		counts: { succeeded: number; errored: number }
+	): Promise<void> {
+		await this.execute(
+			`UPDATE llm_batch_jobs
+       SET last_polled_at = datetime('now'),
+           poll_count = poll_count + 1,
+           succeeded_count = ?,
+           errored_count = ?,
+           updated_at = datetime('now')
+       WHERE id = ?`,
+			[counts.succeeded, counts.errored, id]
+		);
+	}
+
+	async markCollected(
+		id: string,
+		usage: { inputTokens: number; outputTokens: number }
+	): Promise<void> {
+		await this.execute(
+			`UPDATE llm_batch_jobs
+       SET status = 'collected',
+           input_tokens = ?,
+           output_tokens = ?,
+           completed_at = datetime('now'),
+           updated_at = datetime('now')
+       WHERE id = ?`,
+			[usage.inputTokens, usage.outputTokens, id]
+		);
+	}
+
+	async markTerminal(
+		id: string,
+		status: Extract<LlmBatchStatus, "failed" | "expired" | "canceled">,
+		error?: string
+	): Promise<void> {
+		await this.execute(
+			`UPDATE llm_batch_jobs
+       SET status = ?, last_error = ?, completed_at = datetime('now'), updated_at = datetime('now')
+       WHERE id = ?`,
+			[status, error ?? null, id]
+		);
+	}
+
+	/**
+	 * Batch requests submitted by a user within the last `windowSeconds`.
+	 * Backs the separate batch-request budget line (see
+	 * {@link import("@/config/anthropic-org-rate-budget").deriveBatchRequestBudget}),
+	 * so batch work is not charged against the interactive RPM share.
+	 */
+	async getRequestCountSince(
+		username: string,
+		windowSeconds: number
+	): Promise<number> {
+		const row = await this.queryFirst<{ total: number | null }>(
+			`SELECT SUM(request_count) AS total FROM llm_batch_jobs
+       WHERE username = ? AND created_at >= datetime('now', ?)`,
+			[username, `-${Math.max(1, Math.floor(windowSeconds))} seconds`]
+		);
+		return row?.total ?? 0;
+	}
+
+	/**
+	 * Rows stuck in `submitting` past `timeoutMinutes` — a submit that died
+	 * before the provider batch id was written. Nothing was necessarily sent, so
+	 * these are failed (not expired) and the owner is freed to retry inline.
+	 */
+	async getStaleSubmitting(timeoutMinutes: number): Promise<LlmBatchJobRow[]> {
+		return this.queryAll<LlmBatchJobRow>(
+			`SELECT * FROM llm_batch_jobs
+       WHERE status = 'submitting'
+         AND created_at <= datetime('now', ?)`,
+			[`-${Math.max(1, Math.floor(timeoutMinutes))} minutes`]
+		);
+	}
+
+	/** In-flight batches whose deadline has passed. */
+	async getPastDeadline(): Promise<LlmBatchJobRow[]> {
+		const placeholders = ACTIVE_STATUSES.map(() => "?").join(", ");
+		return this.queryAll<LlmBatchJobRow>(
+			`SELECT * FROM llm_batch_jobs
+       WHERE status IN (${placeholders}) AND deadline_at <= datetime('now')`,
+			ACTIVE_STATUSES
+		);
+	}
+
+	/** Parses the stored request mapping; `[]` when the column is unreadable. */
+	static parseRequests(row: LlmBatchJobRow): LlmBatchRequestRef[] {
+		try {
+			const parsed = JSON.parse(row.requests);
+			if (!Array.isArray(parsed)) {
+				return [];
+			}
+			return parsed.filter(
+				(entry): entry is LlmBatchRequestRef =>
+					!!entry &&
+					typeof entry === "object" &&
+					typeof (entry as LlmBatchRequestRef).customId === "string" &&
+					Number.isInteger((entry as LlmBatchRequestRef).chunkIndex)
+			);
+		} catch {
+			return [];
+		}
+	}
+}

--- a/src/lib/anthropic-model-options.ts
+++ b/src/lib/anthropic-model-options.ts
@@ -34,6 +34,30 @@ export function getAnthropicSonnet5ProviderOptions(
 }
 
 /**
+ * Same policy as {@link anthropicSamplingParams}, expressed in raw Messages API
+ * fields rather than AI SDK fields — for the Message Batches path, which builds
+ * request params directly instead of going through the AI SDK.
+ *
+ * On Sonnet 5+ `effort` lives inside `output_config`, and temperature is
+ * omitted because a non-default value is rejected with a 400.
+ */
+export function anthropicBatchModelParams(
+	modelId: string,
+	temperature?: number
+): {
+	temperature?: number;
+	output_config?: { effort: AnthropicEffort };
+} {
+	if (isSonnet5OrNewer(modelId)) {
+		return { output_config: { effort: DEFAULT_SONNET5_EFFORT } };
+	}
+	if (temperature === undefined) {
+		return {};
+	}
+	return { temperature };
+}
+
+/**
  * Build generateText / streamText sampling fields.
  * Omits temperature (and related) for Sonnet 5+; includes temperature otherwise.
  */

--- a/src/lib/entity-extraction-progress.ts
+++ b/src/lib/entity-extraction-progress.ts
@@ -52,6 +52,41 @@ export function entityExtractionProgressPercent(
 	return chunkProgressPercent(parsed.processed, parsed.total);
 }
 
+/**
+ * `BATCH:<chunkCount>:<submittedAtIso>` — set while the chunks in the current
+ * window are waiting on an Anthropic message batch (issue #735).
+ *
+ * Batching coarsens progress granularity: `PROGRESS:a/b` cannot advance until a
+ * whole batch lands, so a chunk-percent bar alone would look stalled for
+ * minutes. This marker lets the UI say what is actually happening instead.
+ */
+const BATCH_IN_MESSAGE = /BATCH:(\d+):(\S+)/;
+
+/** Line appended to `queue_message` while a batch is in flight. */
+export function formatBatchWaitingMarker(
+	chunkCount: number,
+	submittedAt: string
+): string {
+	return `BATCH:${chunkCount}:${submittedAt}`;
+}
+
+/**
+ * Parses the batch marker. Returns null when no batch is in flight, so callers
+ * can treat "no marker" as the ordinary per-chunk path.
+ */
+export function parseEntityExtractionBatchState(
+	value: string | null | undefined
+): { chunkCount: number; submittedAt: string } | null {
+	if (!value) return null;
+	const match = BATCH_IN_MESSAGE.exec(value);
+	if (!match) return null;
+	const chunkCount = Number.parseInt(match[1], 10);
+	if (!Number.isFinite(chunkCount) || chunkCount <= 0) {
+		return null;
+	}
+	return { chunkCount, submittedAt: match[2] };
+}
+
 /** Percent complete from chunk counts (same formula as PROGRESS:a/b). */
 export function chunkProgressPercent(
 	processed: number,

--- a/src/lib/llm-structured-output.ts
+++ b/src/lib/llm-structured-output.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared helpers for coaxing and parsing JSON out of a text completion.
+ *
+ * Used by both the synchronous Anthropic structured path and the Message
+ * Batches path (issue #735). They must stay in one place: if the two paths
+ * built different prompt prefixes or parsed output differently, a chunk could
+ * extract cleanly inline and fail in a batch (or vice versa), and the
+ * batch→inline fallback would stop being a true fallback.
+ */
+
+/** Prepended to every structured-output prompt. */
+export const STRUCTURED_JSON_INTRO =
+	"Respond with valid JSON only. Do not wrap the JSON in markdown fences.";
+
+/** Schema instruction block appended after the prompt, or "" when no schema. */
+export function structuredSchemaInstructions(
+	parsedSchema: Record<string, unknown> | null
+): string {
+	if (!parsedSchema) {
+		return "";
+	}
+	return `\n\nYou MUST return JSON that conforms to this JSON Schema:\n${JSON.stringify(parsedSchema)}`;
+}
+
+/**
+ * The full cacheable prefix for a structured request: intro + stable prompt +
+ * schema. Identical bytes across requests, so it is the part marked with
+ * `cache_control: ephemeral`.
+ */
+export function buildStructuredCacheablePrefix(
+	cacheablePrompt: string,
+	parsedSchema: Record<string, unknown> | null = null
+): string {
+	return `${STRUCTURED_JSON_INTRO}\n\n${cacheablePrompt}${structuredSchemaInstructions(parsedSchema)}`;
+}
+
+export function parseStructuredSchema(
+	schema?: string
+): Record<string, unknown> | null {
+	if (!schema?.trim()) {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse(schema) as Record<string, unknown>;
+		if (!parsed || typeof parsed !== "object") {
+			return null;
+		}
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+export function stripMarkdownCodeFence(text: string): string {
+	const trimmed = text.trim();
+	const fenceMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+	return fenceMatch ? fenceMatch[1].trim() : trimmed;
+}
+
+/** Outermost `{...}` span of a completion, or null when there is none. */
+export function extractJsonObjectText(text: string): string | null {
+	const stripped = stripMarkdownCodeFence(text);
+	const firstBrace = stripped.indexOf("{");
+	const lastBrace = stripped.lastIndexOf("}");
+	if (firstBrace >= 0 && lastBrace > firstBrace) {
+		return stripped.slice(firstBrace, lastBrace + 1);
+	}
+	return null;
+}

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -27,6 +27,7 @@ import {
 import { RebuildQueueService } from "./services/graph/rebuild-queue-service";
 import { RebuildTriggerService } from "./services/graph/rebuild-trigger-service";
 import { ShardEmbeddingQueueProcessor } from "./services/graph/shard-embedding-queue-processor";
+import { cleanupStaleBatchJobs } from "./services/llm/entity-extraction-batch-service";
 import type { RebuildQueueMessage } from "./types/rebuild-queue";
 import type { ShardEmbeddingQueueMessage } from "./types/shard-embedding-queue";
 
@@ -393,6 +394,15 @@ async function runFastScheduledTasks(
 	await processor.cleanupStaging();
 
 	await processPendingSyncQueueItems(env);
+
+	// Release batch rows that can never resolve (lost mid-submit, or past their
+	// deadline) before the discovery queue runs, so an abandoned batch does not
+	// keep its file from being extracted inline on this tick.
+	try {
+		await cleanupStaleBatchJobs(env);
+	} catch (error) {
+		log.error("llm_batch_stale_cleanup_failed", error);
+	}
 
 	await LibraryEntityDiscoveryQueueService.processPendingQueueItems(env);
 

--- a/src/services/campaign/entity-extraction-batch-coordinator.ts
+++ b/src/services/campaign/entity-extraction-batch-coordinator.ts
@@ -1,0 +1,46 @@
+/**
+ * The seam between entity staging and the Anthropic Message Batches path
+ * (issue #735).
+ *
+ * Staging plans its chunks, then asks the coordinator what to do with them.
+ * That keeps the batch state machine (submit in one Worker invocation, collect
+ * in a later one) entirely outside the staging pipeline: staging never learns
+ * about batch ids, deadlines, or cron ticks, and the merge / dedupe / embedding
+ * / notification stages downstream run identically either way.
+ */
+
+/** One chunk of the document, with its index in the full chunk list. */
+export interface PlannedChunk {
+	chunk: string;
+	globalIndex: number;
+}
+
+export interface ChunkBatchPlan {
+	chunks: PlannedChunk[];
+	/** Chunk count for the whole document, not just this run's window. */
+	totalChunks: number;
+	chunkWindowStart: number;
+	chunkWindowEnd: number;
+	sourceName: string;
+}
+
+export type ChunkBatchDecision =
+	/**
+	 * A batch is in flight (just submitted, or submitted earlier and not yet
+	 * finished). Staging returns without extracting; the owning queue job stays
+	 * pending and asks again on the next tick.
+	 */
+	| { status: "awaiting"; detail?: string }
+	/**
+	 * Batch results are in. `outputsByChunkIndex` holds the validated extraction
+	 * payload per chunk. Chunks absent from the map (batch-errored, expired, or
+	 * unparseable output) fall through to an inline call, so a partially failed
+	 * batch costs only the chunks that actually failed.
+	 */
+	| { status: "ready"; outputsByChunkIndex: Map<number, unknown> }
+	/** Do not batch this run — extract inline, exactly as before. */
+	| { status: "inline"; reason?: string };
+
+export interface EntityExtractionBatchCoordinator {
+	resolveChunkOutputs(plan: ChunkBatchPlan): Promise<ChunkBatchDecision>;
+}

--- a/src/services/campaign/entity-staging-service.ts
+++ b/src/services/campaign/entity-staging-service.ts
@@ -17,7 +17,10 @@ import {
 	truncateContentAtSentenceBoundary,
 } from "@/lib/file/text-chunking-utils";
 import { getLibrarySyntheticCampaignId } from "@/lib/library-entity-id";
-import { pickTokenBreakdown } from "@/lib/llm-usage-breakdown";
+import {
+	type LlmUsageReport,
+	pickTokenBreakdown,
+} from "@/lib/llm-usage-breakdown";
 import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
 import { notifyCampaignMembers } from "@/lib/notifications";
 import { R2Helper } from "@/lib/r2";
@@ -41,6 +44,7 @@ import {
 import { TelemetryService } from "@/services/telemetry/telemetry-service";
 import { SemanticDuplicateDetectionService } from "@/services/vectorize/semantic-duplicate-detection-service";
 import type { ContentExtractionProvider } from "./content-extraction-provider";
+import type { EntityExtractionBatchCoordinator } from "./entity-extraction-batch-coordinator";
 import { DirectFileContentExtractionProvider } from "./impl/direct-file-content-extraction-provider";
 import { generateVisualInspirationTitle } from "./visual-inspiration-title";
 
@@ -69,6 +73,15 @@ export interface EntityStagingResult {
 	nextChunkIndex?: number;
 	/** Anthropic JSON repair passes across all chunks in this staging run (observability). */
 	jsonRepairCount?: number;
+	/**
+	 * Set when this run submitted (or is still waiting on) an Anthropic message
+	 * batch and produced no entities yet. The caller must leave the job queued
+	 * and call again later — it is not a failure and not a completion.
+	 * Always accompanied by `completed: false`.
+	 */
+	awaitingBatch?: boolean;
+	/** Chunks in this run served from batch results instead of an inline call. */
+	batchServedChunks?: number;
 }
 
 export interface EntityStagingOptions {
@@ -96,6 +109,11 @@ export interface EntityStagingOptions {
 	resumeFromChunk?: number;
 	/** Maximum chunks to process for this invocation. */
 	maxChunksPerRun?: number;
+	/**
+	 * Routes this run's chunk extraction through the Anthropic Message Batches
+	 * API when supplied (issue #735). Omit for the synchronous per-chunk path.
+	 */
+	batchCoordinator?: EntityExtractionBatchCoordinator;
 	/** Optional callback for durable chunk checkpoints. */
 	onChunkCheckpoint?: (progress: {
 		/** Cumulative chunks finished for the document (not just this invocation). */
@@ -134,6 +152,186 @@ function cosineSimilarity(a: number[], b: number[]): number {
 	}
 	if (magA === 0 || magB === 0) return 0;
 	return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+}
+
+/**
+ * Merge one chunk's entities into the run's accumulator, keyed by entity id.
+ * The same entity often appears in several chunks of a document; content and
+ * metadata are shallow-merged and relations are unioned by target id.
+ */
+function mergeChunkEntities(
+	accumulator: Map<string, ExtractedEntity>,
+	chunkEntities: ExtractedEntity[]
+): void {
+	for (const entity of chunkEntities) {
+		const existing = accumulator.get(entity.id);
+		if (!existing) {
+			accumulator.set(entity.id, entity);
+			continue;
+		}
+		existing.content = {
+			...asMergeableObject(existing.content),
+			...asMergeableObject(entity.content),
+		};
+		const existingTargetIds = new Set(
+			existing.relations.map((r) => r.targetId)
+		);
+		for (const rel of entity.relations) {
+			if (!existingTargetIds.has(rel.targetId)) {
+				existing.relations.push(rel);
+				existingTargetIds.add(rel.targetId);
+			}
+		}
+		existing.metadata = { ...existing.metadata, ...entity.metadata };
+	}
+}
+
+function asMergeableObject(value: unknown): Record<string, unknown> {
+	return typeof value === "object" && value !== null
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+/**
+ * Decide whether a chunk needs full extraction, recording the chunk-gate
+ * telemetry either way.
+ *
+ * `"skip"` means the chunk contributes nothing and needs no model call: it is
+ * blank, or the cheap gate model judged it non-substantive. A chunk already
+ * served from an Anthropic message batch is never gated — its result is already
+ * paid for, so gating it could only throw the result away (issue #735).
+ */
+async function resolveChunkGate(params: {
+	env: Env;
+	telemetry: TelemetryService;
+	recordTelemetry: (fn: () => Promise<void>) => void;
+	campaignId: string;
+	chunk: string;
+	chunkIndex: number;
+	llmApiKey: string;
+	username: string;
+	fileKey?: string;
+	rateLimitService: ReturnType<typeof getLLMRateLimitService>;
+	servedFromBatch: boolean;
+}): Promise<"skip" | "run"> {
+	const {
+		env,
+		telemetry,
+		recordTelemetry,
+		campaignId,
+		chunk,
+		chunkIndex,
+		llmApiKey,
+		username,
+		fileKey,
+		rateLimitService,
+		servedFromBatch,
+	} = params;
+
+	if (chunk.trim().length === 0) {
+		recordTelemetry(() =>
+			telemetry.recordExtractionChunkGateSkip({
+				campaignId,
+				metadata: { emptyChunk: true },
+			})
+		);
+		return "skip";
+	}
+
+	if (servedFromBatch) {
+		recordTelemetry(() =>
+			telemetry.recordExtractionChunkGateRun({
+				campaignId,
+				metadata: { servedFromBatch: true },
+			})
+		);
+		return "run";
+	}
+
+	if (!(await isExtractionChunkGateEnabled(env))) {
+		recordTelemetry(() =>
+			telemetry.recordExtractionChunkGateRun({
+				campaignId,
+				metadata: { gateDisabled: true },
+			})
+		);
+		return "run";
+	}
+
+	const gateResult = await evaluateExtractionChunkGate({
+		chunkText: chunk,
+		llmApiKey,
+		username,
+		campaignId,
+		onUsage: async (usage, ctx) => {
+			await rateLimitService.recordUsage(
+				username,
+				usage.tokens,
+				usage.queryCount,
+				ctx?.model,
+				{
+					intent: LLM_SPEND_INTENT.entity_extraction,
+					source: "entity_staging:extraction_chunk_gate",
+					...pickTokenBreakdown(usage),
+					phase: "chunk_gate",
+					campaignId,
+					fileKey,
+					chunkIndex,
+				}
+			);
+		},
+	});
+	const gateErrorMetadata = gateResult.gateError
+		? { gateError: true }
+		: undefined;
+	recordTelemetry(() =>
+		telemetry.recordExtractionChunkGateLatency(gateResult.latencyMs, {
+			campaignId,
+			metadata: gateErrorMetadata,
+		})
+	);
+	if (!gateResult.runFullExtraction) {
+		recordTelemetry(() =>
+			telemetry.recordExtractionChunkGateSkip({ campaignId })
+		);
+		return "skip";
+	}
+	recordTelemetry(() =>
+		telemetry.recordExtractionChunkGateRun({
+			campaignId,
+			metadata: gateErrorMetadata,
+		})
+	);
+	return "run";
+}
+
+/**
+ * Classify a failed chunk so `processChunk` can choose between "treat as empty",
+ * "abort the whole run", and "retry".
+ */
+function classifyChunkError(error: unknown): {
+	isRateLimit: boolean;
+	isAuthenticationError: boolean;
+	isNoOutput: boolean;
+	message: string;
+} {
+	const message = error instanceof Error ? error.message : "Unknown error";
+	return {
+		message,
+		isRateLimit:
+			message.includes("rate limit") ||
+			message.includes("429") ||
+			message.includes("Too Many Requests"),
+		isAuthenticationError:
+			message.includes("invalid x-api-key") ||
+			message.includes("authentication_error") ||
+			message.includes("invalid api key") ||
+			message.includes("unauthorized") ||
+			(message.includes("401") && message.includes("api")),
+		isNoOutput:
+			message.includes("No output generated") ||
+			message.includes("AI_NoOutputGeneratedError"),
+	};
 }
 
 function isContextLengthError(error: unknown): boolean {
@@ -242,6 +440,7 @@ async function stageEntitiesFromResourceImpl(
 		attribution,
 		resumeFromChunk = 0,
 		maxChunksPerRun,
+		batchCoordinator,
 		onChunkCheckpoint,
 	} = options;
 	const libraryMode = libraryScope !== null;
@@ -603,10 +802,42 @@ async function stageEntitiesFromResourceImpl(
 			}));
 		const hasMoreChunks = endChunkExclusive < chunks.length;
 
+		// Anthropic Message Batches (issue #735): ask the coordinator whether this
+		// run's chunks are batchable, already batched, or should run inline. Any
+		// answer other than "ready" leaves the per-chunk path below untouched.
+		let batchOutputsByChunkIndex: Map<number, unknown> | null = null;
+		if (batchCoordinator && chunksToProcess.length > 0) {
+			const decision = await batchCoordinator.resolveChunkOutputs({
+				chunks: chunksToProcess,
+				totalChunks: chunks.length,
+				chunkWindowStart: startChunkIndex,
+				chunkWindowEnd: endChunkExclusive,
+				sourceName: normalizedResource.file_name || normalizedResource.id,
+			});
+			if (decision.status === "awaiting") {
+				// Batch is in flight. Report no progress so the resume cursor stays put
+				// and the caller re-enters this window once results are available.
+				return {
+					success: true,
+					entityCount: 0,
+					stagedEntities: [],
+					completed: false,
+					awaitingBatch: true,
+					nextChunkIndex: startChunkIndex,
+					totalChunks: chunks.length,
+					jsonRepairCount: 0,
+				};
+			}
+			if (decision.status === "ready") {
+				batchOutputsByChunkIndex = decision.outputsByChunkIndex;
+			}
+		}
+
 		// Extract entities from each chunk and merge results
 		const extractionService = new EntityExtractionService(llmApiKey);
 		const allExtractedEntities: Map<string, ExtractedEntity> = new Map();
 		let jsonRepairCount = 0;
+		let batchServedChunks = 0;
 
 		// Parallel chunk extraction; tuned for ~10 concurrent active users (lower TPM contention than ~100-user caps).
 		const CHUNK_CONCURRENCY = 5;
@@ -653,8 +884,14 @@ async function stageEntitiesFromResourceImpl(
 		): Promise<boolean> => {
 			const chunkNumber = chunkIndex + 1;
 			const retryCount = chunkRetryCounts.get(chunkIndex) || 0;
+			// Already paid for in a batch: no provider call, so no TPM slot and no
+			// gate (gating a result we already have would only discard it).
+			const batchOutput = batchOutputsByChunkIndex?.get(chunkIndex);
+			const servedFromBatch = batchOutput !== undefined;
 
-			await acquireChunkSlot();
+			if (!servedFromBatch) {
+				await acquireChunkSlot();
+			}
 
 			// Add exponential backoff delay for retries
 			if (isRetry && retryCount > 0) {
@@ -672,75 +909,26 @@ async function stageEntitiesFromResourceImpl(
 					void fn().catch(() => {});
 				};
 
-				const gateEnabled = await isExtractionChunkGateEnabled(env);
-				const trimmedChunk = chunk.trim();
-				if (trimmedChunk.length === 0) {
-					recordTelemetry(() =>
-						telemetry.recordExtractionChunkGateSkip({
-							campaignId,
-							metadata: { emptyChunk: true },
-						})
-					);
+				const gateVerdict = await resolveChunkGate({
+					env,
+					telemetry,
+					recordTelemetry,
+					campaignId,
+					chunk,
+					chunkIndex,
+					llmApiKey,
+					username,
+					fileKey: normalizedResource.file_key || undefined,
+					rateLimitService,
+					servedFromBatch,
+				});
+				if (gateVerdict === "skip") {
 					completedCount++;
 					await emitChunkCheckpoint();
 					return true;
 				}
 
-				if (!gateEnabled) {
-					recordTelemetry(() =>
-						telemetry.recordExtractionChunkGateRun({
-							campaignId,
-							metadata: { gateDisabled: true },
-						})
-					);
-				} else {
-					const gateResult = await evaluateExtractionChunkGate({
-						chunkText: chunk,
-						llmApiKey,
-						username,
-						campaignId,
-						onUsage: async (usage, ctx) => {
-							await rateLimitService.recordUsage(
-								username,
-								usage.tokens,
-								usage.queryCount,
-								ctx?.model,
-								{
-									intent: LLM_SPEND_INTENT.entity_extraction,
-									source: "entity_staging:extraction_chunk_gate",
-									...pickTokenBreakdown(usage),
-									phase: "chunk_gate",
-									campaignId,
-									fileKey: normalizedResource.file_key || undefined,
-									chunkIndex: chunkIndex,
-								}
-							);
-						},
-					});
-					recordTelemetry(() =>
-						telemetry.recordExtractionChunkGateLatency(gateResult.latencyMs, {
-							campaignId,
-							metadata: gateResult.gateError ? { gateError: true } : undefined,
-						})
-					);
-					if (!gateResult.runFullExtraction) {
-						recordTelemetry(() =>
-							telemetry.recordExtractionChunkGateSkip({ campaignId })
-						);
-						completedCount++;
-						await emitChunkCheckpoint();
-						return true;
-					}
-					recordTelemetry(() =>
-						telemetry.recordExtractionChunkGateRun({
-							campaignId,
-							metadata: gateResult.gateError ? { gateError: true } : undefined,
-						})
-					);
-				}
-
-				const chunkEntities = await extractionService.extractEntities({
-					content: chunk,
+				const extractionRequest = {
 					sourceName: normalizedResource.file_name || normalizedResource.id,
 					campaignId,
 					sourceId: normalizedResource.id,
@@ -750,7 +938,7 @@ async function stageEntitiesFromResourceImpl(
 					onJsonRepair: () => {
 						jsonRepairCount += 1;
 					},
-					onUsage: async (usage, ctx) => {
+					onUsage: async (usage: LlmUsageReport, ctx?: { model?: string }) => {
 						await rateLimitService.recordUsage(
 							username,
 							usage.tokens,
@@ -775,42 +963,29 @@ async function stageEntitiesFromResourceImpl(
 						shardStatus: "staging",
 						chunkIndex: chunkIndex,
 						totalChunks: chunks.length,
+						...(servedFromBatch && { extractionMode: "batch" }),
 					},
-				});
+				};
 
-				// Merge entities by ID (same entity ID = merge content/metadata)
-				for (const entity of chunkEntities) {
-					const existing = allExtractedEntities.get(entity.id);
-					if (existing) {
-						// Merge: combine content, merge relations, update metadata
-						existing.content = {
-							...(typeof existing.content === "object" &&
-							existing.content !== null
-								? existing.content
-								: {}),
-							...(typeof entity.content === "object" && entity.content !== null
-								? entity.content
-								: {}),
-						};
-						// Merge relations (avoid duplicates)
-						const existingTargetIds = new Set(
-							existing.relations.map((r) => r.targetId)
-						);
-						for (const rel of entity.relations) {
-							if (!existingTargetIds.has(rel.targetId)) {
-								existing.relations.push(rel);
-								existingTargetIds.add(rel.targetId);
-							}
-						}
-						// Update metadata
-						existing.metadata = {
-							...existing.metadata,
-							...entity.metadata,
-						};
-					} else {
-						allExtractedEntities.set(entity.id, entity);
-					}
+				// A batch already produced this chunk's payload in an earlier
+				// invocation; map it through the same normalization the inline path
+				// uses. Token spend for the batch is recorded once by the coordinator.
+				const chunkEntities = servedFromBatch
+					? await extractionService.mapExtractionPayload(
+							batchOutput as Parameters<
+								typeof extractionService.mapExtractionPayload
+							>[0],
+							extractionRequest
+						)
+					: await extractionService.extractEntities({
+							...extractionRequest,
+							content: chunk,
+						});
+				if (servedFromBatch) {
+					batchServedChunks += 1;
 				}
+
+				mergeChunkEntities(allExtractedEntities, chunkEntities);
 
 				// Success - remove from retry tracking if it was a retry
 				if (isRetry) {
@@ -820,22 +995,12 @@ async function stageEntitiesFromResourceImpl(
 				await emitChunkCheckpoint();
 				return true;
 			} catch (chunkError) {
-				// Log error
-				const errorMessage =
-					chunkError instanceof Error ? chunkError.message : "Unknown error";
-				const isRateLimit =
-					errorMessage.includes("rate limit") ||
-					errorMessage.includes("429") ||
-					errorMessage.includes("Too Many Requests");
-				const isAuthenticationError =
-					errorMessage.includes("invalid x-api-key") ||
-					errorMessage.includes("authentication_error") ||
-					errorMessage.includes("invalid api key") ||
-					errorMessage.includes("unauthorized") ||
-					(errorMessage.includes("401") && errorMessage.includes("api"));
-				const isNoOutput =
-					errorMessage.includes("No output generated") ||
-					errorMessage.includes("AI_NoOutputGeneratedError");
+				const {
+					message: errorMessage,
+					isRateLimit,
+					isAuthenticationError,
+					isNoOutput,
+				} = classifyChunkError(chunkError);
 
 				// No output from model: treat as empty chunk (0 entities), don't retry
 				if (isNoOutput) {
@@ -969,6 +1134,7 @@ async function stageEntitiesFromResourceImpl(
 					nextChunkIndex: endChunkExclusive,
 					totalChunks: chunks.length,
 					jsonRepairCount,
+					batchServedChunks,
 				};
 			}
 			const notificationDetail =
@@ -990,6 +1156,7 @@ async function stageEntitiesFromResourceImpl(
 				entityCount: 0,
 				stagedEntities: [],
 				jsonRepairCount,
+				batchServedChunks,
 				...(failedChunks.length > 0 && {
 					failedChunks,
 					successfulChunks,
@@ -1122,6 +1289,7 @@ async function stageEntitiesFromResourceImpl(
 					nextChunkIndex: endChunkExclusive,
 					totalChunks: chunks.length,
 					jsonRepairCount,
+					batchServedChunks,
 				};
 			}
 			const stagedForLib: NonNullable<EntityStagingResult["stagedEntities"]> =
@@ -1169,6 +1337,7 @@ async function stageEntitiesFromResourceImpl(
 				completed: true,
 				totalChunks: chunks.length,
 				jsonRepairCount,
+				batchServedChunks,
 				...(failedChunks.length > 0
 					? {
 							warning: `Some chunks failed to process: ${failedChunks.join(", ")}`,
@@ -1576,6 +1745,7 @@ async function stageEntitiesFromResourceImpl(
 			nextChunkIndex: hasMoreChunks ? endChunkExclusive : undefined,
 			totalChunks: chunks.length,
 			jsonRepairCount,
+			batchServedChunks,
 			...(failedChunks.length > 0
 				? {
 						warning: `Some chunks failed to process: ${failedChunks.join(", ")}`,

--- a/src/services/campaign/library-entity-discovery-queue-service.ts
+++ b/src/services/campaign/library-entity-discovery-queue-service.ts
@@ -4,7 +4,12 @@ import {
 	LibraryEntityDAO,
 	type LibraryEntityDiscoveryRow,
 } from "@/dao/library-entity-dao";
-import { parseEntityExtractionProgress } from "@/lib/entity-extraction-progress";
+import {
+	formatBatchWaitingMarker,
+	parseEntityExtractionBatchState,
+	parseEntityExtractionProgress,
+	queueMessageWithProgress,
+} from "@/lib/entity-extraction-progress";
 import { getEnvVar } from "@/lib/env-utils";
 import {
 	buildLibraryContentFingerprint,
@@ -16,6 +21,8 @@ import { createLogger } from "@/lib/logger";
 import type { Env } from "@/middleware/auth";
 import { stageLibraryEntitiesFromFile } from "@/services/campaign/entity-staging-service";
 import { processPendingCampaignEntityCopiesForFile } from "@/services/campaign/pending-campaign-entity-copy";
+import { EntityExtractionBatchService } from "@/services/llm/entity-extraction-batch-service";
+import { isBatchExtractionEnabled } from "@/services/llm/llm-batch-config";
 import { notifyLibraryDiscoveryTerminalFailure } from "@/services/support/library-pipeline-support";
 
 const MAX_CHUNKS_PER_RUN = 12;
@@ -71,6 +78,173 @@ async function recordDiscoveryError(
 		}
 	}
 	return out;
+}
+
+type DiscoveryLogger = ReturnType<typeof createLogger>;
+
+/**
+ * Build the Anthropic message-batch coordinator for this job, or undefined when
+ * batching is off (issue #735). `onStatus` keeps the `PROGRESS` cursor and adds
+ * a batch marker so the UI can say "queued" rather than looking stalled.
+ */
+async function buildBatchCoordinator(params: {
+	env: Env;
+	row: LibraryEntityDiscoveryRow;
+	libDao: LibraryEntityDAO;
+	llmApiKey: string;
+	fingerprint: string;
+}): Promise<EntityExtractionBatchService | undefined> {
+	const { env, row, libDao, llmApiKey, fingerprint } = params;
+	if (!(await isBatchExtractionEnabled(env))) {
+		return undefined;
+	}
+	return new EntityExtractionBatchService({
+		env,
+		username: row.username,
+		fileKey: row.file_key,
+		llmApiKey,
+		contentFingerprint: fingerprint,
+		onStatus: async (status) => {
+			if (status.kind !== "awaiting") {
+				return;
+			}
+			await libDao.updateDiscoveryQueueMessage(
+				row.file_key,
+				queueMessageWithProgress(
+					row.queue_message,
+					formatBatchWaitingMarker(status.chunkCount, status.submittedAt)
+				)
+			);
+		},
+	});
+}
+
+/**
+ * If the job's batch is still running, requeue it at the same cursor and report
+ * true so the caller skips staging entirely this tick.
+ */
+async function requeueIfBatchPending(params: {
+	libDao: LibraryEntityDAO;
+	row: LibraryEntityDiscoveryRow;
+	coordinator: EntityExtractionBatchService;
+	resumeFromChunk: number;
+	totalChunks: number;
+	log: DiscoveryLogger;
+}): Promise<boolean> {
+	const { libDao, row, coordinator, resumeFromChunk, totalChunks, log } =
+		params;
+	const pending = await coordinator.peekPendingBatch();
+	if (!pending.waiting) {
+		return false;
+	}
+	const marker = formatBatchWaitingMarker(
+		pending.chunkCount ?? 0,
+		pending.submittedAt ?? ""
+	);
+	await libDao.markDiscoveryPendingResume(
+		row.file_key,
+		totalChunks > 0
+			? queueMessageWithProgress(
+					`PROGRESS:${resumeFromChunk}/${totalChunks}`,
+					marker
+				)
+			: marker
+	);
+	log.info("library_entity_discovery_batch_pending", {
+		fileKey: row.file_key,
+		chunkCount: pending.chunkCount,
+	});
+	return true;
+}
+
+/**
+ * Requeue a job whose staging run submitted a batch and produced nothing yet.
+ * The resume cursor does not advance, and `retry_count` is untouched — waiting
+ * on a batch is neither progress nor failure.
+ */
+async function requeueAwaitingBatch(params: {
+	libDao: LibraryEntityDAO;
+	row: LibraryEntityDiscoveryRow;
+	resumeFromChunk: number;
+	totalChunks: number;
+	log: DiscoveryLogger;
+}): Promise<void> {
+	const { libDao, row, resumeFromChunk, totalChunks, log } = params;
+	// The coordinator's onStatus already wrote the batch marker; re-read it so
+	// requeueing preserves it alongside the resume cursor.
+	const currentMessage =
+		(await libDao.getDiscovery(row.file_key))?.queue_message ??
+		row.queue_message;
+	const batchState = parseEntityExtractionBatchState(currentMessage);
+	const marker = batchState
+		? formatBatchWaitingMarker(batchState.chunkCount, batchState.submittedAt)
+		: "";
+	const resumeMessage =
+		totalChunks > 0
+			? queueMessageWithProgress(
+					`PROGRESS:${resumeFromChunk}/${totalChunks}`,
+					marker
+				)
+			: (currentMessage ?? "");
+	await libDao.markDiscoveryPendingResume(row.file_key, resumeMessage);
+	log.info("library_entity_discovery_awaiting_batch", {
+		fileKey: row.file_key,
+		resumeFromChunk,
+		totalChunks,
+	});
+}
+
+function candidateConfidence(metadata: unknown): number | null {
+	if (typeof metadata !== "object" || metadata === null) {
+		return null;
+	}
+	const value = (metadata as Record<string, unknown>).confidence;
+	return typeof value === "number" ? value : null;
+}
+
+/** Write a completed run's candidates and (deduplicated) relationships. */
+async function persistDiscoveryResults(
+	libDao: LibraryEntityDAO,
+	row: LibraryEntityDiscoveryRow,
+	staged: NonNullable<
+		Awaited<ReturnType<typeof stageLibraryEntitiesFromFile>>["stagedEntities"]
+	>
+): Promise<void> {
+	for (const se of staged) {
+		await libDao.upsertCandidate({
+			id: crypto.randomUUID(),
+			fileKey: row.file_key,
+			username: row.username,
+			mergeKey: buildLibraryEntityMergeKey(se.entityType, se.name),
+			entityType: se.entityType,
+			name: se.name,
+			content: se.content,
+			metadata: se.metadata,
+			confidence: candidateConfidence(se.metadata),
+			extractionEntityId: se.id,
+			idSuffix: extractionIdSuffix(se.id),
+		});
+	}
+
+	await libDao.deleteRelationshipsForFile(row.file_key);
+
+	const relDedup = new Set<string>();
+	for (const se of staged) {
+		for (const rel of se.relations) {
+			const key = `${se.id}:${rel.targetId}:${rel.relationshipType}`;
+			if (relDedup.has(key)) continue;
+			relDedup.add(key);
+			await libDao.upsertRelationship({
+				id: crypto.randomUUID(),
+				fileKey: row.file_key,
+				fromExtractionEntityId: se.id,
+				toExtractionEntityId: rel.targetId,
+				relationshipType: rel.relationshipType,
+				strength: rel.strength ?? null,
+				metadata: rel.metadata ?? {},
+			});
+		}
+	}
 }
 
 /**
@@ -185,6 +359,40 @@ export class LibraryEntityDiscoveryQueueService {
 				const progress = parseEntityExtractionProgress(row.queue_message ?? "");
 				const resumeFromChunk = progress?.processed ?? 0;
 
+				const fingerprint = buildLibraryContentFingerprint(
+					fileRecord.file_size,
+					fileRecord.updated_at
+				);
+
+				// Anthropic Message Batches (issue #735). Any problem inside the
+				// coordinator resolves to inline extraction, so the flag is safe to
+				// flip either way.
+				const batchCoordinator = await buildBatchCoordinator({
+					env,
+					row,
+					libDao,
+					llmApiKey,
+					fingerprint,
+				});
+
+				// Waiting on a batch means there is nothing to extract this tick, and
+				// staging front-loads content extraction plus 1–3 character-sheet
+				// detection LLM calls before it plans chunks — so bail out first.
+				if (
+					batchCoordinator &&
+					(await requeueIfBatchPending({
+						libDao,
+						row,
+						coordinator: batchCoordinator,
+						resumeFromChunk,
+						totalChunks: progress?.total ?? 0,
+						log,
+					}))
+				) {
+					processed++;
+					continue;
+				}
+
 				const result = await stageLibraryEntitiesFromFile({
 					env,
 					username: row.username,
@@ -195,6 +403,7 @@ export class LibraryEntityDiscoveryQueueService {
 					openaiApiKey,
 					resumeFromChunk,
 					maxChunksPerRun: MAX_CHUNKS_PER_RUN,
+					batchCoordinator,
 					onChunkCheckpoint: async ({ processedChunks, totalChunks }) => {
 						await libDao.updateDiscoveryQueueMessage(
 							row.file_key,
@@ -202,6 +411,21 @@ export class LibraryEntityDiscoveryQueueService {
 						);
 					},
 				});
+
+				// Waiting on a batch is neither progress nor failure: requeue at the
+				// same cursor without touching retry_count, so a slow batch never
+				// burns the job's retry budget.
+				if (result.awaitingBatch) {
+					await requeueAwaitingBatch({
+						libDao,
+						row,
+						resumeFromChunk,
+						totalChunks: result.totalChunks ?? progress?.total ?? 0,
+						log,
+					});
+					processed++;
+					continue;
+				}
 
 				if (!result.success) {
 					const out = await recordDiscoveryError(
@@ -228,55 +452,8 @@ export class LibraryEntityDiscoveryQueueService {
 				}
 
 				const staged = result.stagedEntities ?? [];
-				for (const se of staged) {
-					const mergeKey = buildLibraryEntityMergeKey(se.entityType, se.name);
-					const idSuffix = extractionIdSuffix(se.id);
-					await libDao.upsertCandidate({
-						id: crypto.randomUUID(),
-						fileKey: row.file_key,
-						username: row.username,
-						mergeKey,
-						entityType: se.entityType,
-						name: se.name,
-						content: se.content,
-						metadata: se.metadata,
-						confidence:
-							typeof se.metadata === "object" &&
-							se.metadata !== null &&
-							typeof (se.metadata as Record<string, unknown>).confidence ===
-								"number"
-								? ((se.metadata as Record<string, unknown>)
-										.confidence as number)
-								: null,
-						extractionEntityId: se.id,
-						idSuffix,
-					});
-				}
+				await persistDiscoveryResults(libDao, row, staged);
 
-				await libDao.deleteRelationshipsForFile(row.file_key);
-
-				const relDedup = new Set<string>();
-				for (const se of staged) {
-					for (const rel of se.relations) {
-						const key = `${se.id}:${rel.targetId}:${rel.relationshipType}`;
-						if (relDedup.has(key)) continue;
-						relDedup.add(key);
-						await libDao.upsertRelationship({
-							id: crypto.randomUUID(),
-							fileKey: row.file_key,
-							fromExtractionEntityId: se.id,
-							toExtractionEntityId: rel.targetId,
-							relationshipType: rel.relationshipType,
-							strength: rel.strength ?? null,
-							metadata: rel.metadata ?? {},
-						});
-					}
-				}
-
-				const fingerprint = buildLibraryContentFingerprint(
-					fileRecord.file_size,
-					fileRecord.updated_at
-				);
 				await libDao.markDiscoveryComplete(row.file_key, fingerprint);
 
 				log.info("library_entity_discovery_complete", {

--- a/src/services/llm/anthropic-batch-provider.ts
+++ b/src/services/llm/anthropic-batch-provider.ts
@@ -1,0 +1,223 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { anthropicBatchModelParams } from "@/lib/anthropic-model-options";
+import { LLMProviderAPIKeyError } from "@/lib/errors";
+import { describeLlmFailure, wrapLlmError } from "@/lib/llm-error-utils";
+import type {
+	LLMBatchProvider,
+	LlmBatchProcessingStatus,
+	LlmBatchRequestInput,
+	LlmBatchResultEntry,
+	LlmBatchStatusResult,
+	LlmBatchSubmitResult,
+} from "@/types/llm-batch";
+
+/** Anthropic hard limits on a single batch (`POST /v1/messages/batches`). */
+export const ANTHROPIC_BATCH_MAX_REQUESTS = 100_000;
+export const ANTHROPIC_BATCH_MAX_BYTES = 256 * 1024 * 1024;
+
+/**
+ * Batch submission path for Anthropic, alongside the synchronous
+ * {@link import("./anthropic-provider").AnthropicProvider}.
+ *
+ * The synchronous path goes through the AI SDK (`@ai-sdk/anthropic`), which has
+ * no batches support, so this uses the official `@anthropic-ai/sdk` — notably
+ * for decoding the JSONL results stream. The SDK is imported lazily so it stays
+ * out of the hot request path's module graph.
+ */
+export class AnthropicBatchProvider implements LLMBatchProvider {
+	private client: Anthropic | null = null;
+
+	constructor(private readonly apiKey: string) {
+		if (!apiKey) {
+			throw new LLMProviderAPIKeyError(
+				"Anthropic API key is required for batch submission. Configure ANTHROPIC_API_KEY on the server."
+			);
+		}
+	}
+
+	private async getClient(): Promise<Anthropic> {
+		if (!this.client) {
+			const { default: AnthropicSdk } = await import("@anthropic-ai/sdk");
+			this.client = new AnthropicSdk({ apiKey: this.apiKey });
+		}
+		return this.client;
+	}
+
+	/**
+	 * Submits one batch. `cacheablePrefix` is marked `ephemeral` so the shared
+	 * extraction instructions are cached across every request in the batch, the
+	 * same split the synchronous structured path uses.
+	 */
+	async submitBatch(
+		requests: LlmBatchRequestInput[],
+		options: { model: string; schema?: string }
+	): Promise<LlmBatchSubmitResult> {
+		if (requests.length === 0) {
+			throw new Error("Cannot submit an empty batch");
+		}
+		if (requests.length > ANTHROPIC_BATCH_MAX_REQUESTS) {
+			throw new Error(
+				`Batch exceeds Anthropic's ${ANTHROPIC_BATCH_MAX_REQUESTS} request limit (${requests.length})`
+			);
+		}
+
+		const seen = new Set<string>();
+		for (const request of requests) {
+			if (seen.has(request.customId)) {
+				throw new Error(`Duplicate batch custom_id: ${request.customId}`);
+			}
+			seen.add(request.customId);
+		}
+
+		try {
+			const client = await this.getClient();
+			const modelParams = anthropicBatchModelParams(options.model);
+			const batch = await client.messages.batches.create({
+				requests: requests.map((request) => ({
+					custom_id: request.customId,
+					params: {
+						model: options.model,
+						max_tokens: request.maxTokens,
+						...modelParams,
+						messages: [
+							{
+								role: "user" as const,
+								content: [
+									{
+										type: "text" as const,
+										text: request.cacheablePrefix,
+										cache_control: { type: "ephemeral" as const },
+									},
+									{ type: "text" as const, text: request.variableSuffix },
+								],
+							},
+						],
+					},
+				})),
+			});
+
+			return {
+				providerBatchId: batch.id,
+				requestCount: requests.length,
+			};
+		} catch (error) {
+			throw wrapLlmError(
+				`Failed to submit Anthropic message batch: ${describeLlmFailure(error)}`,
+				error
+			);
+		}
+	}
+
+	async getBatchStatus(providerBatchId: string): Promise<LlmBatchStatusResult> {
+		try {
+			const client = await this.getClient();
+			const batch = await client.messages.batches.retrieve(providerBatchId);
+			return {
+				providerBatchId: batch.id,
+				processingStatus: batch.processing_status as LlmBatchProcessingStatus,
+				counts: {
+					processing: batch.request_counts.processing,
+					succeeded: batch.request_counts.succeeded,
+					errored: batch.request_counts.errored,
+					canceled: batch.request_counts.canceled,
+					expired: batch.request_counts.expired,
+				},
+			};
+		} catch (error) {
+			throw wrapLlmError(
+				`Failed to retrieve Anthropic message batch ${providerBatchId}: ${describeLlmFailure(error)}`,
+				error
+			);
+		}
+	}
+
+	/**
+	 * Streams the JSONL results. Entries come back in arbitrary order, so the
+	 * caller must key on `customId` rather than position.
+	 */
+	async getBatchResults(
+		providerBatchId: string
+	): Promise<LlmBatchResultEntry[]> {
+		try {
+			const client = await this.getClient();
+			const entries: LlmBatchResultEntry[] = [];
+
+			for await (const result of await client.messages.batches.results(
+				providerBatchId
+			)) {
+				const customId = result.custom_id;
+				if (result.result.type === "succeeded") {
+					const message = result.result.message;
+					const text = message.content
+						.filter(
+							(block): block is Anthropic.TextBlock => block.type === "text"
+						)
+						.map((block) => block.text)
+						.join("");
+					// `input_tokens` is the uncached remainder only — cache creation and
+					// cache read tokens are billed separately and must be added in, or
+					// batch spend is under-reported for every request after the first
+					// (which all read the shared cached prefix). They are also reported
+					// separately, because each prices at a different rate.
+					const cacheWriteTokens =
+						message.usage.cache_creation_input_tokens ?? 0;
+					const cachedInputTokens = message.usage.cache_read_input_tokens ?? 0;
+					entries.push({
+						customId,
+						outcome: "succeeded",
+						text,
+						inputTokens:
+							(message.usage.input_tokens ?? 0) +
+							cacheWriteTokens +
+							cachedInputTokens,
+						outputTokens: message.usage.output_tokens ?? 0,
+						cachedInputTokens,
+						cacheWriteTokens,
+					});
+					continue;
+				}
+				entries.push({
+					customId,
+					outcome: result.result.type,
+					error: describeBatchResultError(result.result),
+				});
+			}
+
+			return entries;
+		} catch (error) {
+			throw wrapLlmError(
+				`Failed to read Anthropic message batch results ${providerBatchId}: ${describeLlmFailure(error)}`,
+				error
+			);
+		}
+	}
+
+	async cancelBatch(providerBatchId: string): Promise<void> {
+		try {
+			const client = await this.getClient();
+			await client.messages.batches.cancel(providerBatchId);
+		} catch (error) {
+			throw wrapLlmError(
+				`Failed to cancel Anthropic message batch ${providerBatchId}: ${describeLlmFailure(error)}`,
+				error
+			);
+		}
+	}
+}
+
+function describeBatchResultError(result: {
+	type: string;
+	error?: unknown;
+}): string {
+	if (result.type === "errored" && result.error) {
+		const wrapper = result.error as {
+			error?: { type?: string; message?: string };
+		};
+		const inner = wrapper.error;
+		if (inner?.type || inner?.message) {
+			return `${inner.type ?? "error"}: ${inner.message ?? "unknown"}`;
+		}
+		return JSON.stringify(result.error);
+	}
+	return result.type;
+}

--- a/src/services/llm/anthropic-provider.ts
+++ b/src/services/llm/anthropic-provider.ts
@@ -5,6 +5,13 @@ import { anthropicSamplingParams } from "@/lib/anthropic-model-options";
 import { LLMProviderAPIKeyError } from "@/lib/errors";
 import { describeLlmFailure, wrapLlmError } from "@/lib/llm-error-utils";
 import {
+	buildStructuredCacheablePrefix,
+	extractJsonObjectText,
+	parseStructuredSchema,
+	STRUCTURED_JSON_INTRO,
+	structuredSchemaInstructions,
+} from "@/lib/llm-structured-output";
+import {
 	addTokenBreakdowns,
 	toTokenBreakdown,
 	totalUsageTokens,
@@ -15,40 +22,7 @@ import type {
 	StructuredOutputOptions,
 } from "./llm-provider";
 
-function parseStructuredSchema(
-	schema?: string
-): Record<string, unknown> | null {
-	if (!schema?.trim()) {
-		return null;
-	}
-	try {
-		const parsed = JSON.parse(schema) as Record<string, unknown>;
-		if (!parsed || typeof parsed !== "object") {
-			return null;
-		}
-		return parsed;
-	} catch (_error) {
-		return null;
-	}
-}
-
 const getUsageTokens = totalUsageTokens;
-
-function stripMarkdownCodeFence(text: string): string {
-	const trimmed = text.trim();
-	const fenceMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
-	return fenceMatch ? fenceMatch[1].trim() : trimmed;
-}
-
-function extractJsonObjectText(text: string): string | null {
-	const stripped = stripMarkdownCodeFence(text);
-	const firstBrace = stripped.indexOf("{");
-	const lastBrace = stripped.lastIndexOf("}");
-	if (firstBrace >= 0 && lastBrace > firstBrace) {
-		return stripped.slice(firstBrace, lastBrace + 1);
-	}
-	return null;
-}
 
 function truncateForPrompt(text: string, maxChars: number): string {
 	if (text.length <= maxChars) {
@@ -146,11 +120,7 @@ export class AnthropicProvider implements LLMProvider {
 		const temperature = options.temperature ?? this.defaultTemperature;
 		const maxTokens = options.maxTokens ?? this.defaultMaxTokens;
 		const parsedSchema = parseStructuredSchema(options.schema);
-		const schemaInstructions = parsedSchema
-			? `\n\nYou MUST return JSON that conforms to this JSON Schema:\n${JSON.stringify(parsedSchema)}`
-			: "";
-		const jsonIntro =
-			"Respond with valid JSON only. Do not wrap the JSON in markdown fences.";
+		const schemaInstructions = structuredSchemaInstructions(parsedSchema);
 
 		const anthropic = createAnthropic({ apiKey: this.apiKey });
 		const model = anthropic(modelId as any);
@@ -160,7 +130,10 @@ export class AnthropicProvider implements LLMProvider {
 		let singlePrompt: string | undefined;
 
 		if (parts) {
-			const cacheableFull = `${jsonIntro}\n\n${parts.cacheablePrefix}${schemaInstructions}`;
+			const cacheableFull = buildStructuredCacheablePrefix(
+				parts.cacheablePrefix,
+				parsedSchema
+			);
 			const userMessage: ModelMessage = {
 				role: "user",
 				content: [
@@ -181,7 +154,7 @@ export class AnthropicProvider implements LLMProvider {
 			};
 			messages = [userMessage];
 		} else {
-			singlePrompt = `${jsonIntro}\n\n${prompt}${schemaInstructions}`;
+			singlePrompt = `${STRUCTURED_JSON_INTRO}\n\n${prompt}${schemaInstructions}`;
 		}
 
 		try {

--- a/src/services/llm/entity-extraction-batch-service.ts
+++ b/src/services/llm/entity-extraction-batch-service.ts
@@ -1,0 +1,593 @@
+import { getDAOFactory } from "@/dao/dao-factory";
+import { LlmBatchJobDAO } from "@/dao/llm-batch-job-dao";
+import { buildStructuredCacheablePrefix } from "@/lib/llm-structured-output";
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
+import { createLogger } from "@/lib/logger";
+import type { Env } from "@/middleware/auth";
+import type {
+	ChunkBatchDecision,
+	ChunkBatchPlan,
+	EntityExtractionBatchCoordinator,
+} from "@/services/campaign/entity-extraction-batch-coordinator";
+import { AnthropicBatchProvider } from "@/services/llm/anthropic-batch-provider";
+import {
+	batchDeadlineFrom,
+	LLM_BATCH_MIN_REQUESTS,
+	LLM_BATCH_SUBMITTING_TIMEOUT_MINUTES,
+	parseBatchTimestampMs,
+} from "@/services/llm/llm-batch-config";
+import { getLLMRateLimitService } from "@/services/llm/llm-rate-limit-service";
+import {
+	buildExtractionPromptParts,
+	extractionModelId,
+	MAX_EXTRACTION_RESPONSE_TOKENS,
+	parseExtractionResponseText,
+} from "@/services/rag/entity-extraction-service";
+import {
+	LLM_BATCH_OWNER_KIND,
+	type LlmBatchJobRow,
+	type LlmBatchRequestInput,
+	type LlmBatchRequestRef,
+} from "@/types/llm-batch";
+
+/** Status the coordinator reports so the caller can keep the UI honest. */
+export type BatchCoordinatorStatus =
+	| {
+			kind: "awaiting";
+			chunkCount: number;
+			submittedAt: string;
+			justSubmitted: boolean;
+	  }
+	| { kind: "collected"; servedChunks: number; fallbackChunks: number }
+	| { kind: "inline"; reason: string };
+
+export interface EntityExtractionBatchCoordinatorContext {
+	env: Env;
+	username: string;
+	/** Owner key — the library file this discovery job belongs to. */
+	fileKey: string;
+	llmApiKey: string;
+	/**
+	 * Content identity at submit time. A batch is only collected against the same
+	 * fingerprint it was submitted for; otherwise the chunk boundaries it was
+	 * built from may no longer exist and the results are discarded.
+	 */
+	contentFingerprint: string | null;
+	onStatus?: (status: BatchCoordinatorStatus) => Promise<void> | void;
+}
+
+/**
+ * Routes entity-extraction chunks through the Anthropic Message Batches API
+ * (issue #735).
+ *
+ * The whole point is that this runs across *several* Worker invocations: one
+ * cron tick submits, later ticks poll, and the tick that finds the batch ended
+ * hands the payloads back to staging. Everything here is therefore written to
+ * be safely re-entrant, and every failure path returns `inline` so a batch
+ * problem degrades to the current synchronous behavior instead of stalling a
+ * user's indexing.
+ */
+export class EntityExtractionBatchService
+	implements EntityExtractionBatchCoordinator
+{
+	private readonly dao: LlmBatchJobDAO;
+
+	constructor(
+		private readonly ctx: EntityExtractionBatchCoordinatorContext,
+		private readonly provider = new AnthropicBatchProvider(ctx.llmApiKey)
+	) {
+		this.dao = new LlmBatchJobDAO(ctx.env.DB);
+	}
+
+	/**
+	 * Cheap "is this job still waiting on a batch?" check, answerable without a
+	 * chunk plan — so a caller can skip the expensive pre-extraction work
+	 * (content extraction, character-sheet detection) on a tick where there is
+	 * nothing to do but wait.
+	 *
+	 * This matters a lot: the staging pipeline runs 1–3 interactive LLM calls for
+	 * character-sheet detection before it ever plans chunks. Reaching the batch
+	 * seam through staging on every poll would repeat those calls once per cron
+	 * tick for the life of the batch, charging the interactive budget for work
+	 * that is already paid for — enough to cancel out the batch discount.
+	 *
+	 * Only "a batch exists and has not ended" counts as waiting. Deadline and
+	 * plan-mismatch handling needs the plan, so it stays in
+	 * {@link resolveChunkOutputs}.
+	 */
+	async peekPendingBatch(): Promise<{
+		waiting: boolean;
+		chunkCount?: number;
+		submittedAt?: string;
+	}> {
+		if (!(await this.dao.isSchemaReady())) {
+			return { waiting: false };
+		}
+		const row = await this.dao.getActiveForOwner(
+			LLM_BATCH_OWNER_KIND.library_entity_discovery,
+			this.ctx.fileKey
+		);
+		if (!row) {
+			return { waiting: false };
+		}
+		// Past its deadline, or missing an id: resolveChunkOutputs must run so it
+		// can cancel, mark the row, and fall back inline.
+		if (this.pastDeadline(row) || !row.provider_batch_id) {
+			return { waiting: false };
+		}
+		// Mid-submit by another invocation — wait rather than racing it.
+		if (row.status === "submitting") {
+			const createdMs = parseBatchTimestampMs(row.created_at);
+			const ageMinutes =
+				createdMs === null
+					? Number.POSITIVE_INFINITY
+					: (Date.now() - createdMs) / 60_000;
+			return ageMinutes >= LLM_BATCH_SUBMITTING_TIMEOUT_MINUTES
+				? { waiting: false }
+				: {
+						waiting: true,
+						chunkCount: row.request_count,
+						submittedAt: row.created_at,
+					};
+		}
+
+		try {
+			const status = await this.provider.getBatchStatus(row.provider_batch_id);
+			await this.dao.recordPoll(row.id, {
+				succeeded: status.counts.succeeded,
+				errored: status.counts.errored,
+			});
+			if (status.processingStatus === "ended") {
+				return { waiting: false };
+			}
+			return {
+				waiting: true,
+				chunkCount: row.request_count,
+				submittedAt: row.created_at,
+			};
+		} catch (error) {
+			// Let resolveChunkOutputs deal with it (and fall back inline).
+			createLogger(this.ctx.env, "[EntityExtractionBatch]").warn(
+				"batch_peek_failed",
+				{
+					fileKey: this.ctx.fileKey,
+					error: error instanceof Error ? error.message : String(error),
+				}
+			);
+			return { waiting: false };
+		}
+	}
+
+	async resolveChunkOutputs(plan: ChunkBatchPlan): Promise<ChunkBatchDecision> {
+		const log = createLogger(this.ctx.env, "[EntityExtractionBatch]");
+
+		if (!(await this.dao.isSchemaReady())) {
+			return this.inline("batch_table_missing");
+		}
+
+		const existing = await this.dao.getActiveForOwner(
+			LLM_BATCH_OWNER_KIND.library_entity_discovery,
+			this.ctx.fileKey
+		);
+
+		if (existing) {
+			try {
+				return await this.resolveExisting(existing, plan);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				log.error("batch_resolve_failed", {
+					fileKey: this.ctx.fileKey,
+					batchId: existing.id,
+					error: message,
+				});
+				// Free the slot so the next tick can either resubmit or run inline
+				// rather than getting stuck behind an unresolvable batch.
+				await this.dao.markTerminal(existing.id, "failed", message);
+				return this.inline("batch_resolve_failed");
+			}
+		}
+
+		return this.trySubmit(plan);
+	}
+
+	/** Poll (and possibly collect) a batch submitted by an earlier invocation. */
+	private async resolveExisting(
+		row: LlmBatchJobRow,
+		plan: ChunkBatchPlan
+	): Promise<ChunkBatchDecision> {
+		const log = createLogger(this.ctx.env, "[EntityExtractionBatch]");
+
+		// A row still in `submitting` means the invocation that created it died
+		// before recording a provider batch id. Nothing can be collected from it.
+		if (row.status === "submitting") {
+			const createdMs = parseBatchTimestampMs(row.created_at);
+			// Unparseable timestamp: treat as abandoned. Freeing the slot costs at
+			// worst a duplicate batch, whereas waiting forever would wedge indexing.
+			const ageMinutes =
+				createdMs === null
+					? Number.POSITIVE_INFINITY
+					: (Date.now() - createdMs) / 60_000;
+			if (ageMinutes >= LLM_BATCH_SUBMITTING_TIMEOUT_MINUTES) {
+				await this.dao.markTerminal(
+					row.id,
+					"failed",
+					"Submit did not complete (worker lost mid-submit)"
+				);
+				return this.inline("stale_submitting_row");
+			}
+			// Another invocation may still be mid-submit; do not race it.
+			return this.awaiting(row, false);
+		}
+
+		if (!row.provider_batch_id) {
+			await this.dao.markTerminal(
+				row.id,
+				"failed",
+				"Missing provider batch id"
+			);
+			return this.inline("missing_provider_batch_id");
+		}
+
+		// Content changed under us, or the resume window moved: the stored chunk
+		// boundaries no longer describe `plan`, so results cannot be trusted.
+		if (!this.planMatches(row, plan)) {
+			log.warn("batch_plan_mismatch", {
+				fileKey: this.ctx.fileKey,
+				batchId: row.id,
+			});
+			await this.cancelQuietly(row.provider_batch_id);
+			await this.dao.markTerminal(
+				row.id,
+				"canceled",
+				"Chunk window or content fingerprint changed since submission"
+			);
+			return this.inline("plan_mismatch");
+		}
+
+		if (this.pastDeadline(row)) {
+			log.warn("batch_deadline_exceeded", {
+				fileKey: this.ctx.fileKey,
+				batchId: row.id,
+				deadlineAt: row.deadline_at,
+			});
+			await this.cancelQuietly(row.provider_batch_id);
+			await this.dao.markTerminal(
+				row.id,
+				"expired",
+				`Batch exceeded its ${row.deadline_at} deadline; falling back to inline extraction`
+			);
+			return this.inline("deadline_exceeded");
+		}
+
+		const status = await this.provider.getBatchStatus(row.provider_batch_id);
+		await this.dao.recordPoll(row.id, {
+			succeeded: status.counts.succeeded,
+			errored: status.counts.errored,
+		});
+
+		if (status.processingStatus !== "ended") {
+			return this.awaiting(row, false);
+		}
+
+		return this.collect(row, plan);
+	}
+
+	/** Read an ended batch's results and map them back onto chunk indexes. */
+	private async collect(
+		row: LlmBatchJobRow,
+		plan: ChunkBatchPlan
+	): Promise<ChunkBatchDecision> {
+		const log = createLogger(this.ctx.env, "[EntityExtractionBatch]");
+		const refs = LlmBatchJobDAO.parseRequests(row);
+		const chunkIndexByCustomId = new Map<string, number>(
+			refs.map((ref: LlmBatchRequestRef) => [ref.customId, ref.chunkIndex])
+		);
+		const plannedIndexes = new Set(plan.chunks.map((c) => c.globalIndex));
+
+		const results = await this.provider.getBatchResults(row.provider_batch_id!);
+
+		const outputsByChunkIndex = new Map<number, unknown>();
+		let inputTokens = 0;
+		let outputTokens = 0;
+		let cachedInputTokens = 0;
+		let cacheWriteTokens = 0;
+		const failedChunkIndexes: number[] = [];
+
+		for (const result of results) {
+			// Results arrive in arbitrary order — always key by custom_id.
+			const chunkIndex = chunkIndexByCustomId.get(result.customId);
+			if (chunkIndex === undefined || !plannedIndexes.has(chunkIndex)) {
+				continue;
+			}
+
+			if (result.outcome !== "succeeded") {
+				failedChunkIndexes.push(chunkIndex);
+				continue;
+			}
+
+			inputTokens += result.inputTokens;
+			outputTokens += result.outputTokens;
+			cachedInputTokens += result.cachedInputTokens;
+			cacheWriteTokens += result.cacheWriteTokens;
+
+			let payload: unknown = null;
+			try {
+				payload = parseExtractionResponseText(result.text);
+			} catch (error) {
+				log.warn("batch_result_unparseable", {
+					fileKey: this.ctx.fileKey,
+					chunkIndex,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				payload = null;
+			}
+			if (payload === null) {
+				// No usable JSON: re-extract this chunk inline (where a JSON repair
+				// pass is available) rather than silently dropping its entities.
+				failedChunkIndexes.push(chunkIndex);
+				continue;
+			}
+			outputsByChunkIndex.set(chunkIndex, payload);
+		}
+
+		await this.recordBatchSpend(row, {
+			inputTokens,
+			outputTokens,
+			cachedInputTokens,
+			cacheWriteTokens,
+		});
+		await this.dao.markCollected(row.id, { inputTokens, outputTokens });
+
+		const fallbackChunks = plan.chunks.length - outputsByChunkIndex.size;
+		log.info("batch_collected", {
+			fileKey: this.ctx.fileKey,
+			batchId: row.id,
+			servedChunks: outputsByChunkIndex.size,
+			fallbackChunks,
+			failedChunkIndexes,
+			inputTokens,
+			outputTokens,
+		});
+		await this.ctx.onStatus?.({
+			kind: "collected",
+			servedChunks: outputsByChunkIndex.size,
+			fallbackChunks,
+		});
+
+		// Chunks missing from the map fall through to an inline call in staging, so
+		// a partly-failed batch costs only the requests that actually failed.
+		return { status: "ready", outputsByChunkIndex };
+	}
+
+	/** Submit this run's chunks as one batch, or decline and stay inline. */
+	private async trySubmit(plan: ChunkBatchPlan): Promise<ChunkBatchDecision> {
+		const log = createLogger(this.ctx.env, "[EntityExtractionBatch]");
+
+		if (plan.chunks.length < LLM_BATCH_MIN_REQUESTS) {
+			return this.inline("below_min_batch_size");
+		}
+
+		const rateLimitService = getLLMRateLimitService(this.ctx.env);
+		const budget = await rateLimitService.checkBatchRequestBudget(
+			this.ctx.username,
+			plan.chunks.length
+		);
+		if (!budget.allowed) {
+			log.info("batch_budget_declined", {
+				fileKey: this.ctx.fileKey,
+				reason: budget.reason,
+			});
+			return this.inline("batch_budget_exhausted");
+		}
+
+		const model = extractionModelId();
+		const jobId = crypto.randomUUID();
+		const requests: LlmBatchRequestInput[] = [];
+		const refs: LlmBatchRequestRef[] = [];
+
+		for (const planned of plan.chunks) {
+			const customId = `chunk-${planned.globalIndex}`;
+			const parts = buildExtractionPromptParts(plan.sourceName, planned.chunk);
+			requests.push({
+				customId,
+				// Byte-identical across every request in the batch, so the shared
+				// extraction instructions cache after the first one.
+				cacheablePrefix: buildStructuredCacheablePrefix(parts.cacheablePrefix),
+				variableSuffix: parts.variableSuffix,
+				maxTokens: MAX_EXTRACTION_RESPONSE_TOKENS,
+			});
+			refs.push({ customId, chunkIndex: planned.globalIndex });
+		}
+
+		// Claim the owner's single-flight slot before talking to Anthropic: if two
+		// cron ticks race, the loser gets null here and never submits.
+		const claimed = await this.dao.createSubmitting({
+			id: jobId,
+			provider: "anthropic",
+			ownerKind: LLM_BATCH_OWNER_KIND.library_entity_discovery,
+			ownerKey: this.ctx.fileKey,
+			username: this.ctx.username,
+			model,
+			requests: refs,
+			contentFingerprint: this.ctx.contentFingerprint,
+			chunkWindowStart: plan.chunkWindowStart,
+			chunkWindowEnd: plan.chunkWindowEnd,
+			totalChunks: plan.totalChunks,
+			deadlineAt: batchDeadlineFrom(new Date()),
+		});
+		if (!claimed) {
+			return this.inline("owner_slot_taken");
+		}
+
+		try {
+			const submitted = await this.provider.submitBatch(requests, { model });
+			await this.dao.markInProgress(claimed.id, submitted.providerBatchId);
+			log.info("batch_submitted", {
+				fileKey: this.ctx.fileKey,
+				batchId: claimed.id,
+				providerBatchId: submitted.providerBatchId,
+				requestCount: submitted.requestCount,
+				model,
+			});
+			return this.awaiting(claimed, true);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			log.error("batch_submit_failed", {
+				fileKey: this.ctx.fileKey,
+				batchId: claimed.id,
+				error: message,
+			});
+			await this.dao.markTerminal(claimed.id, "failed", message);
+			return this.inline("submit_failed");
+		}
+	}
+
+	/**
+	 * Batch token spend is recorded once, when results are collected, and not
+	 * charged against the interactive query budget — see
+	 * {@link import("./llm-rate-limit-service").LLMRateLimitService.recordBatchUsage}.
+	 *
+	 * The input/output split is passed through rather than just the total: cost
+	 * attribution prices output at roughly 5x input, and cache reads at a tenth
+	 * of it, so a total-only record is stored unpriced and batch spend would be
+	 * missing from the very dashboard that reports it.
+	 */
+	private async recordBatchSpend(
+		row: LlmBatchJobRow,
+		usage: {
+			inputTokens: number;
+			outputTokens: number;
+			cachedInputTokens: number;
+			cacheWriteTokens: number;
+		}
+	): Promise<void> {
+		const tokens = usage.inputTokens + usage.outputTokens;
+		if (tokens <= 0) {
+			return;
+		}
+		try {
+			await getLLMRateLimitService(this.ctx.env).recordBatchUsage(
+				this.ctx.username,
+				tokens,
+				row.model,
+				{
+					intent: LLM_SPEND_INTENT.entity_extraction,
+					source: "entity_extraction_batch:collect",
+					// `inputTokens` is the all-in figure; promptTokens is the uncached
+					// remainder, so the three input lines sum to it without double-count.
+					promptTokens: Math.max(
+						0,
+						usage.inputTokens - usage.cachedInputTokens - usage.cacheWriteTokens
+					),
+					completionTokens: usage.outputTokens,
+					cachedInputTokens: usage.cachedInputTokens,
+					cacheWriteTokens: usage.cacheWriteTokens,
+					phase: "extract_entities",
+					fileKey: this.ctx.fileKey,
+					batchRequestCount: row.request_count,
+					providerBatchId: row.provider_batch_id ?? undefined,
+				}
+			);
+		} catch (error) {
+			createLogger(this.ctx.env, "[EntityExtractionBatch]").error(
+				"batch_usage_record_failed",
+				error
+			);
+		}
+	}
+
+	private planMatches(row: LlmBatchJobRow, plan: ChunkBatchPlan): boolean {
+		if (row.content_fingerprint !== this.ctx.contentFingerprint) {
+			return false;
+		}
+		return (
+			row.chunk_window_start === plan.chunkWindowStart &&
+			row.chunk_window_end === plan.chunkWindowEnd &&
+			row.total_chunks === plan.totalChunks
+		);
+	}
+
+	private pastDeadline(row: LlmBatchJobRow): boolean {
+		const deadline = parseBatchTimestampMs(row.deadline_at);
+		if (deadline === null) {
+			// Without a readable deadline the cron sweep is the backstop; do not
+			// expire a batch that may still be running.
+			return false;
+		}
+		return Date.now() > deadline;
+	}
+
+	private async cancelQuietly(providerBatchId: string): Promise<void> {
+		try {
+			await this.provider.cancelBatch(providerBatchId);
+		} catch {
+			// Cancellation is best effort — an uncancelable batch just expires.
+		}
+	}
+
+	private async awaiting(
+		row: LlmBatchJobRow,
+		justSubmitted: boolean
+	): Promise<ChunkBatchDecision> {
+		const submittedAt = row.created_at;
+		await this.ctx.onStatus?.({
+			kind: "awaiting",
+			chunkCount: row.request_count,
+			submittedAt,
+			justSubmitted,
+		});
+		return {
+			status: "awaiting",
+			detail: `batch ${row.id} (${row.request_count} requests)`,
+		};
+	}
+
+	private async inline(reason: string): Promise<ChunkBatchDecision> {
+		await this.ctx.onStatus?.({ kind: "inline", reason });
+		return { status: "inline", reason };
+	}
+}
+
+/**
+ * Sweep batch rows that can never resolve so their owners are not blocked:
+ * rows abandoned mid-submit, and in-flight rows past their deadline. Called
+ * from the fast cron alongside the other queue maintenance.
+ */
+export async function cleanupStaleBatchJobs(env: Env): Promise<{
+	failedSubmitting: number;
+	expired: number;
+}> {
+	const dao = getDAOFactory(env).llmBatchJobDAO;
+	if (!(await dao.isSchemaReady())) {
+		return { failedSubmitting: 0, expired: 0 };
+	}
+	const log = createLogger(env, "[EntityExtractionBatch]");
+
+	const stale = await dao.getStaleSubmitting(
+		LLM_BATCH_SUBMITTING_TIMEOUT_MINUTES
+	);
+	for (const row of stale) {
+		await dao.markTerminal(
+			row.id,
+			"failed",
+			"Submit did not complete (worker lost mid-submit)"
+		);
+	}
+
+	const overdue = await dao.getPastDeadline();
+	for (const row of overdue) {
+		await dao.markTerminal(
+			row.id,
+			"expired",
+			`Batch exceeded its ${row.deadline_at} deadline`
+		);
+	}
+
+	if (stale.length > 0 || overdue.length > 0) {
+		log.info("batch_stale_cleanup", {
+			failedSubmitting: stale.length,
+			expired: overdue.length,
+		});
+	}
+	return { failedSubmitting: stale.length, expired: overdue.length };
+}

--- a/src/services/llm/llm-batch-config.ts
+++ b/src/services/llm/llm-batch-config.ts
@@ -1,0 +1,73 @@
+import { MODEL_CONFIG } from "@/app-constants";
+import type { EnvWithSecrets } from "@/lib/env-utils";
+import { getEnvVar } from "@/lib/env-utils";
+
+/**
+ * Anthropic Message Batches routing for queue-driven pipeline work (issue #735).
+ *
+ * Off by default: set `LLM_BATCH_EXTRACTION_ENABLED=true` to route library
+ * entity discovery through batches. Every guard below degrades to the existing
+ * synchronous per-chunk path, so a disabled flag, a missing migration, a failed
+ * submit, or a blown deadline all mean "extract inline", never "stop indexing".
+ */
+
+/** Below this, a batch's overhead (extra cron round-trips) outweighs the discount. */
+export const LLM_BATCH_MIN_REQUESTS = 2;
+
+/**
+ * Wall-clock budget for a batch before the owner abandons it and falls back to
+ * inline extraction. Anthropic's own ceiling is 24h and most batches finish
+ * within an hour; 3h keeps a stuck batch from delaying a user's indexing for a
+ * day while still leaving generous room for normal completion.
+ */
+export const LLM_BATCH_DEADLINE_MINUTES = 180;
+
+/**
+ * A row stuck in `submitting` this long lost its worker mid-submit. It is swept
+ * to `failed` so the owner's single-flight slot is released.
+ */
+export const LLM_BATCH_SUBMITTING_TIMEOUT_MINUTES = 15;
+
+/** Window used for the per-user batch-request rate check. */
+export const LLM_BATCH_BUDGET_WINDOW_SECONDS = 60;
+
+export async function isBatchExtractionEnabled(
+	env: EnvWithSecrets
+): Promise<boolean> {
+	if (MODEL_CONFIG.PROVIDER.DEFAULT !== "anthropic") {
+		return false;
+	}
+	const raw = await getEnvVar(env, "LLM_BATCH_EXTRACTION_ENABLED", false);
+	const value = raw.trim().toLowerCase();
+	return value === "1" || value === "true" || value === "yes";
+}
+
+/** ISO timestamp `LLM_BATCH_DEADLINE_MINUTES` from `now`. */
+export function batchDeadlineFrom(now: Date): string {
+	return new Date(
+		now.getTime() + LLM_BATCH_DEADLINE_MINUTES * 60 * 1000
+	).toISOString();
+}
+
+/**
+ * Parse a timestamp off an `llm_batch_jobs` row to epoch ms.
+ *
+ * The table mixes two formats: `created_at`/`updated_at` are written by D1's
+ * `datetime('now')` as bare UTC (`YYYY-MM-DD HH:MM:SS`, no zone), while
+ * `deadline_at` is an ISO string from {@link batchDeadlineFrom}. A bare value
+ * must be read as UTC — parsing it as local time shifts every comparison by the
+ * host's offset, which silently expires or extends batches.
+ *
+ * Returns null when the value cannot be parsed, so callers decide what a
+ * missing timestamp means rather than getting a misleading number.
+ */
+export function parseBatchTimestampMs(value: string): number | null {
+	const trimmed = value.trim();
+	const normalized = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?$/.test(
+		trimmed
+	)
+		? `${trimmed.replace(" ", "T")}Z`
+		: trimmed.replace(" ", "T");
+	const parsed = Date.parse(normalized);
+	return Number.isFinite(parsed) ? parsed : null;
+}

--- a/src/services/llm/llm-rate-limit-service.ts
+++ b/src/services/llm/llm-rate-limit-service.ts
@@ -1,4 +1,5 @@
 import type { TextGenerationTier } from "@/app-constants";
+import { deriveBatchRequestBudget } from "@/config/anthropic-org-rate-budget";
 import { estimateCostUsd } from "@/config/model-pricing";
 import { getDAOFactory } from "@/dao/dao-factory";
 import type { CostEventInsert } from "@/dao/llm-cost-event-dao";
@@ -10,6 +11,7 @@ import { logVerboseLlmSpend } from "@/lib/llm-usage-verbose-log";
 import { createLogger } from "@/lib/logger";
 import type { Env } from "@/middleware/auth";
 import { getSubscriptionService } from "@/services/billing/subscription-service";
+import { LLM_BATCH_BUDGET_WINDOW_SECONDS } from "@/services/llm/llm-batch-config";
 
 /**
  * Attribution for a unit of LLM spend. `intent` is required; everything else is
@@ -368,6 +370,70 @@ export class LLMRateLimitService {
 			reason: result.reason,
 			nextResetAt: result.nextResetAt,
 		};
+	}
+
+	/**
+	 * Check the **batch** request budget before submitting a message batch.
+	 *
+	 * Batch requests draw on `ANTHROPIC_ORG_LIMITS.batchRequestsPerMinute`, which
+	 * is separate from the interactive RPM the per-tier `qph`/`qpd` limits are
+	 * derived from — so background indexing is not charged against the budget a
+	 * user's chat spends, and vice versa. Token caps are still enforced: batch
+	 * token usage is recorded by {@link recordBatchUsage} and so counts toward
+	 * `tph`/`tpd` and the free-tier monthly/lifetime caps.
+	 */
+	async checkBatchRequestBudget(
+		username: string,
+		requestCount: number,
+		isAdmin: boolean = false
+	): Promise<CheckLimitResult> {
+		if (isAdmin) {
+			return { allowed: true };
+		}
+
+		const dao = getDAOFactory(this.env).llmBatchJobDAO;
+		if (!(await dao.isSchemaReady())) {
+			// No batch table means the batch path is inert; nothing to gate.
+			return { allowed: true };
+		}
+
+		const { requestsPerMinutePerUser } = deriveBatchRequestBudget();
+		const recent = await dao.getRequestCountSince(
+			username,
+			LLM_BATCH_BUDGET_WINDOW_SECONDS
+		);
+
+		if (recent + requestCount > requestsPerMinutePerUser) {
+			return {
+				allowed: false,
+				reason: `Batch request budget (${requestsPerMinutePerUser} per minute) would be exceeded: ${recent} already submitted, ${requestCount} requested.`,
+				limitType: "hour",
+			};
+		}
+		return { allowed: true };
+	}
+
+	/**
+	 * Record token spend for a completed batch.
+	 *
+	 * Tokens are recorded verbatim (the row is also the analytics source of
+	 * truth), but `queryCount` is 0: the batch's request volume was already
+	 * gated by {@link checkBatchRequestBudget} against the separate batch budget
+	 * line, and counting it again here would double-charge it to the interactive
+	 * query budget.
+	 */
+	async recordBatchUsage(
+		username: string,
+		tokens: number,
+		model: string | undefined,
+		meta: LlmSpendLogMeta & { batchRequestCount: number }
+	): Promise<void> {
+		const { batchRequestCount, ...logMeta } = meta;
+		await this.recordUsage(username, tokens, 0, model, {
+			...logMeta,
+			batchRequestCount,
+			billingMode: "batch",
+		});
 	}
 
 	async recordUsage(

--- a/src/services/rag/entity-extraction-service.ts
+++ b/src/services/rag/entity-extraction-service.ts
@@ -10,6 +10,7 @@ import {
 	type RelationshipType,
 } from "@/lib/entity/relationship-types";
 import { EntityExtractionError, LLMProviderAPIKeyError } from "@/lib/errors";
+import { extractJsonObjectText } from "@/lib/llm-structured-output";
 import type { LlmUsageReport } from "@/lib/llm-usage-breakdown";
 import { RPG_EXTRACTION_PROMPTS } from "@/lib/prompts/rpg-extraction-prompts";
 import { parseOrThrow } from "@/lib/zod-utils";
@@ -23,7 +24,7 @@ import type { TelemetryService } from "@/services/telemetry/telemetry-service";
  * Entity extraction uses PIPELINE_STRUCTURED (e.g. claude-sonnet-5 on Anthropic).
  * Higher Anthropic budget leaves room for Sonnet 5 adaptive thinking + JSON.
  */
-const MAX_EXTRACTION_RESPONSE_TOKENS =
+export const MAX_EXTRACTION_RESPONSE_TOKENS =
 	MODEL_CONFIG.PROVIDER.DEFAULT === "anthropic" ? 16384 : 16384;
 
 // Zod schema for entity extraction response
@@ -108,6 +109,77 @@ export interface ExtractedEntity {
 	relations: ExtractedRelationship[];
 }
 
+/** Model tier + response budget shared by the inline and batch extraction paths. */
+export function extractionModelId(): string {
+	return getGenerationModelForProvider("PIPELINE_STRUCTURED");
+}
+
+/**
+ * Split the extraction prompt into the stable instruction prefix (identical for
+ * every chunk of every document from the same source name — the part worth
+ * caching) and the chunk-specific suffix.
+ *
+ * Exported so the Message Batches path builds byte-identical prompts to the
+ * inline path; see {@link import("@/lib/llm-structured-output")}.
+ */
+export function buildExtractionPromptParts(
+	sourceName: string,
+	content: string
+): StructuredPromptParts & { fullPrompt: string } {
+	const prompt =
+		RPG_EXTRACTION_PROMPTS.formatStructuredContentPrompt(sourceName);
+	return {
+		cacheablePrefix: `${prompt}\n\nCONTENT START\n`,
+		variableSuffix: `${content}\nCONTENT END`,
+		fullPrompt: `${prompt}\n\nCONTENT START\n${content}\nCONTENT END`,
+	};
+}
+
+/**
+ * Validate a raw extraction payload (already-parsed JSON) against the schema.
+ * The batch path uses this on text returned by a batch result so both paths
+ * agree on what counts as usable model output.
+ */
+export function validateExtractionPayload(
+	payload: unknown
+): z.infer<typeof EntityExtractionSchema> {
+	return parseOrThrow(EntityExtractionSchema, payload, {
+		logPrefix: "[EntityExtractionService]",
+		messagePrefix: "Schema validation failed",
+		customError: (msg) => new EntityExtractionError(msg),
+	});
+}
+
+/**
+ * Parse the raw text a batch result returned into a validated extraction
+ * payload. Returns null for output that is empty or contains no JSON object —
+ * the same "treat this chunk as empty" outcome the inline path produces for
+ * unusable model output, rather than failing the whole document.
+ *
+ * Unlike the inline path there is no JSON-repair retry: a repair pass is an
+ * extra interactive request, which would defeat the point of batching. A chunk
+ * whose batch output cannot be parsed is reported to the caller so it can be
+ * re-extracted inline.
+ */
+export function parseExtractionResponseText(
+	text: string
+): z.infer<typeof EntityExtractionSchema> | null {
+	if (!text || text.trim().length === 0) {
+		return null;
+	}
+	const jsonText = extractJsonObjectText(text);
+	if (!jsonText) {
+		return null;
+	}
+	let payload: unknown;
+	try {
+		payload = JSON.parse(jsonText);
+	} catch {
+		return null;
+	}
+	return validateExtractionPayload(payload);
+}
+
 export class EntityExtractionService {
 	constructor(
 		private readonly llmApiKey: string | null = null,
@@ -124,36 +196,51 @@ export class EntityExtractionService {
 			);
 		}
 
-		const prompt = RPG_EXTRACTION_PROMPTS.formatStructuredContentPrompt(
-			options.sourceName
+		const promptParts = buildExtractionPromptParts(
+			options.sourceName,
+			options.content
 		);
-
-		const fullPrompt = `${prompt}
-
-CONTENT START
-${options.content}
-CONTENT END`;
 
 		const structuredPromptParts: StructuredPromptParts | undefined =
 			MODEL_CONFIG.PROVIDER.DEFAULT === "anthropic"
 				? {
-						cacheablePrefix: `${prompt}\n\nCONTENT START\n`,
-						variableSuffix: `${options.content}\nCONTENT END`,
+						cacheablePrefix: promptParts.cacheablePrefix,
+						variableSuffix: promptParts.variableSuffix,
 					}
 				: undefined;
 
 		// Use OpenAIProvider to generate structured JSON output
-		const parsed = await this.callStructuredModel(fullPrompt, apiKey, {
-			username: options.username,
-			onUsage: options.onUsage,
-			onJsonRepair: options.onJsonRepair,
-			structuredPromptParts,
-		});
+		const parsed = await this.callStructuredModel(
+			promptParts.fullPrompt,
+			apiKey,
+			{
+				username: options.username,
+				onUsage: options.onUsage,
+				onJsonRepair: options.onJsonRepair,
+				structuredPromptParts,
+			}
+		);
 
 		if (!parsed) {
 			return [];
 		}
 
+		return this.mapExtractionPayload(parsed, options);
+	}
+
+	/**
+	 * Turn a validated extraction payload into {@link ExtractedEntity}s and record
+	 * extraction telemetry.
+	 *
+	 * Split out of {@link extractEntities} so a payload produced by a message
+	 * batch — where the model call happened in an earlier Worker invocation —
+	 * goes through exactly the same normalization, ID scoping, and telemetry as
+	 * an inline extraction.
+	 */
+	async mapExtractionPayload(
+		parsed: z.infer<typeof EntityExtractionSchema>,
+		options: Omit<ExtractEntitiesOptions, "content"> & { content?: string }
+	): Promise<ExtractedEntity[]> {
 		const results: ExtractedEntity[] = [];
 		const entityCountsByType: Record<string, number> = {};
 
@@ -169,49 +256,13 @@ CONTENT END`;
 				if (!entry || typeof entry !== "object") {
 					continue;
 				}
-
-				const record = entry as Record<string, unknown>;
-				// Make entity IDs campaign-scoped from the start
-				const baseId =
-					typeof record.id === "string" && record.id.length > 0
-						? record.id
-						: crypto.randomUUID();
-				const entityId = `${options.campaignId}_${baseId}`;
-
-				// Extract name from standard fields - all entities should have name, title, or display_name
-				// The LLM is instructed to always provide at least one of these fields
-				const nameFields = ["name", "title", "display_name"];
-
-				// Check "id" as a last resort (before falling back to generated name)
-				nameFields.push("id");
-
-				const name =
-					this.getFirstString(record, nameFields) || `${type}-${entityId}`;
-
-				// Log warning if entity doesn't have a proper name field (shouldn't happen if LLM follows instructions)
-				if (!this.getFirstString(record, ["name", "title", "display_name"])) {
-				}
-
-				const relations = Array.isArray(record.relations)
-					? this.normalizeRelationships(record.relations)
-					: [];
-
-				if (relations.length > 0) {
-				}
-
-				results.push({
-					id: entityId,
-					entityType: type,
-					name,
-					content: record,
-					metadata: {
-						...options.metadata,
-						sourceId: options.sourceId,
-						sourceType: options.sourceType,
-						campaignId: options.campaignId,
-					},
-					relations,
-				});
+				results.push(
+					this.toExtractedEntity(
+						type,
+						entry as Record<string, unknown>,
+						options
+					)
+				);
 			}
 		}
 
@@ -308,11 +359,7 @@ CONTENT END`;
 			});
 
 			// Validate the result against our Zod schema (LLM output may be malformed)
-			return parseOrThrow(EntityExtractionSchema, result, {
-				logPrefix: "[EntityExtractionService]",
-				messagePrefix: "Schema validation failed",
-				customError: (msg) => new EntityExtractionError(msg),
-			});
+			return validateExtractionPayload(result);
 		} catch (error) {
 			const errorMessage =
 				error instanceof Error ? error.message : "Unknown error";
@@ -334,6 +381,43 @@ CONTENT END`;
 			}
 			throw new EntityExtractionError(errorMessage);
 		}
+	}
+
+	/**
+	 * One extracted entity from one raw record. IDs are campaign-scoped from the
+	 * start, and the name falls back through title / display_name / id before a
+	 * generated one, because the model is only asked to supply one of them.
+	 */
+	private toExtractedEntity(
+		type: StructuredEntityType,
+		record: Record<string, unknown>,
+		options: Omit<ExtractEntitiesOptions, "content"> & { content?: string }
+	): ExtractedEntity {
+		const baseId =
+			typeof record.id === "string" && record.id.length > 0
+				? record.id
+				: crypto.randomUUID();
+		const entityId = `${options.campaignId}_${baseId}`;
+
+		const name =
+			this.getFirstString(record, ["name", "title", "display_name", "id"]) ||
+			`${type}-${entityId}`;
+
+		return {
+			id: entityId,
+			entityType: type,
+			name,
+			content: record,
+			metadata: {
+				...options.metadata,
+				sourceId: options.sourceId,
+				sourceType: options.sourceType,
+				campaignId: options.campaignId,
+			},
+			relations: Array.isArray(record.relations)
+				? this.normalizeRelationships(record.relations)
+				: [],
+		};
 	}
 
 	private normalizeRelationships(

--- a/src/services/retry-limit-service.ts
+++ b/src/services/retry-limit-service.ts
@@ -7,6 +7,19 @@ export interface RetryLimitResult {
 	reason?: string;
 }
 
+/**
+ * Per-file retry caps (`retriesPerFilePerDay` / `retriesPerFilePerMonth`) for
+ * user-initiated retries of a file.
+ *
+ * These count **user retries of a whole file**, not individual model calls, so
+ * routing extraction through the Anthropic Message Batches API (issue #735)
+ * does not change the accounting — provided a partly-failed batch never
+ * surfaces to the user as a failed file. It does not: chunks a batch fails to
+ * return are re-extracted inline within the same pipeline run, and a batch that
+ * errors, expires, or blows its deadline falls back to the synchronous path
+ * without touching either this counter or the discovery job's `retry_count`.
+ * See `EntityExtractionBatchService`.
+ */
 export class RetryLimitService {
 	/**
 	 * Check if user can retry (read-only, does not increment).

--- a/src/types/llm-batch.ts
+++ b/src/types/llm-batch.ts
@@ -1,0 +1,140 @@
+/**
+ * Types for the Anthropic Message Batches path used by queue-driven pipeline
+ * work (issue #735).
+ *
+ * Batch pricing is a large discount on exactly the workload this app already
+ * runs asynchronously: entity extraction behind a queue, where the user is
+ * notified when indexing completes and latency of minutes is expected.
+ */
+
+/** Pipeline job kinds that can own a batch. */
+export const LLM_BATCH_OWNER_KIND = {
+	library_entity_discovery: "library_entity_discovery",
+} as const;
+
+export type LlmBatchOwnerKind =
+	(typeof LLM_BATCH_OWNER_KIND)[keyof typeof LLM_BATCH_OWNER_KIND];
+
+/**
+ * `submitting` exists so a crashed submit cannot leave an orphan row that
+ * blocks the owner forever — it is swept by the stale-batch cleanup.
+ * `collected`, `failed`, `expired`, `canceled` are terminal.
+ */
+export type LlmBatchStatus =
+	| "submitting"
+	| "in_progress"
+	| "collected"
+	| "failed"
+	| "expired"
+	| "canceled";
+
+/** One request inside a batch, mapped back to the chunk it came from. */
+export interface LlmBatchRequestRef {
+	customId: string;
+	chunkIndex: number;
+}
+
+export interface LlmBatchJobRow {
+	id: string;
+	provider: string;
+	provider_batch_id: string | null;
+	owner_kind: string;
+	owner_key: string;
+	username: string;
+	model: string;
+	status: LlmBatchStatus;
+	request_count: number;
+	succeeded_count: number;
+	errored_count: number;
+	/** JSON array of {@link LlmBatchRequestRef}. */
+	requests: string;
+	content_fingerprint: string | null;
+	chunk_window_start: number | null;
+	chunk_window_end: number | null;
+	total_chunks: number | null;
+	deadline_at: string;
+	last_polled_at: string | null;
+	poll_count: number;
+	input_tokens: number;
+	output_tokens: number;
+	last_error: string | null;
+	created_at: string;
+	updated_at: string;
+	completed_at: string | null;
+}
+
+/** A single prompt to send as one request in a batch. */
+export interface LlmBatchRequestInput {
+	customId: string;
+	/** Stable prefix eligible for prompt caching (identical across requests). */
+	cacheablePrefix: string;
+	/** Per-request suffix (the document chunk). */
+	variableSuffix: string;
+	maxTokens: number;
+}
+
+export interface LlmBatchSubmitResult {
+	providerBatchId: string;
+	requestCount: number;
+}
+
+export type LlmBatchProcessingStatus = "in_progress" | "ended" | "canceling";
+
+export interface LlmBatchStatusResult {
+	providerBatchId: string;
+	processingStatus: LlmBatchProcessingStatus;
+	counts: {
+		processing: number;
+		succeeded: number;
+		errored: number;
+		canceled: number;
+		expired: number;
+	};
+}
+
+/**
+ * One decoded batch result. `succeeded` carries the model's raw text; the
+ * caller parses it with the same JSON extraction the synchronous path uses so
+ * both paths agree on malformed-output handling.
+ */
+export type LlmBatchResultEntry =
+	| {
+			customId: string;
+			outcome: "succeeded";
+			text: string;
+			/** All input tokens: uncached + cache-write + cache-read. */
+			inputTokens: number;
+			outputTokens: number;
+			/**
+			 * Cache-read and cache-write shares of `inputTokens`, kept separate
+			 * because they price differently (~0.1x and ~1.25x the input rate).
+			 * Folding them into one figure would misprice every batch after the
+			 * first, which reads a warm prefix.
+			 */
+			cachedInputTokens: number;
+			cacheWriteTokens: number;
+	  }
+	| {
+			customId: string;
+			outcome: "errored" | "canceled" | "expired";
+			error: string;
+	  };
+
+/**
+ * Batch submission surface on the provider layer, alongside the synchronous
+ * `generateStructuredOutput` / `generateSummary` methods on {@link
+ * import("@/services/llm/llm-provider").LLMProvider}.
+ */
+export interface LLMBatchProvider {
+	submitBatch(
+		requests: LlmBatchRequestInput[],
+		options: { model: string; schema?: string }
+	): Promise<LlmBatchSubmitResult>;
+
+	getBatchStatus(providerBatchId: string): Promise<LlmBatchStatusResult>;
+
+	/** Results arrive in arbitrary order — always key by `customId`. */
+	getBatchResults(providerBatchId: string): Promise<LlmBatchResultEntry[]>;
+
+	cancelBatch(providerBatchId: string): Promise<void>;
+}

--- a/tests/dao/llm-batch-job-dao.test.ts
+++ b/tests/dao/llm-batch-job-dao.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { LlmBatchJobDAO } from "@/dao/llm-batch-job-dao";
+import type { LlmBatchJobRow } from "@/types/llm-batch";
+
+function row(requests: string): LlmBatchJobRow {
+	return {
+		id: "job-1",
+		provider: "anthropic",
+		provider_batch_id: "msgbatch_1",
+		owner_kind: "library_entity_discovery",
+		owner_key: "library/alice/f.pdf",
+		username: "alice",
+		model: "claude-sonnet-5",
+		status: "in_progress",
+		request_count: 2,
+		succeeded_count: 0,
+		errored_count: 0,
+		requests,
+		content_fingerprint: null,
+		chunk_window_start: 0,
+		chunk_window_end: 2,
+		total_chunks: 2,
+		deadline_at: "2026-07-26 10:00:00",
+		last_polled_at: null,
+		poll_count: 0,
+		input_tokens: 0,
+		output_tokens: 0,
+		last_error: null,
+		created_at: "2026-07-26 09:00:00",
+		updated_at: "2026-07-26 09:00:00",
+		completed_at: null,
+	};
+}
+
+describe("LlmBatchJobDAO.parseRequests", () => {
+	it("parses the stored custom_id → chunk index mapping", () => {
+		expect(
+			LlmBatchJobDAO.parseRequests(
+				row(
+					JSON.stringify([
+						{ customId: "chunk-0", chunkIndex: 0 },
+						{ customId: "chunk-7", chunkIndex: 7 },
+					])
+				)
+			)
+		).toEqual([
+			{ customId: "chunk-0", chunkIndex: 0 },
+			{ customId: "chunk-7", chunkIndex: 7 },
+		]);
+	});
+
+	it("drops malformed entries rather than mapping a result to the wrong chunk", () => {
+		expect(
+			LlmBatchJobDAO.parseRequests(
+				row(
+					JSON.stringify([
+						{ customId: "chunk-0", chunkIndex: 0 },
+						{ customId: "chunk-1" },
+						{ chunkIndex: 2 },
+						{ customId: "chunk-3", chunkIndex: 1.5 },
+						null,
+					])
+				)
+			)
+		).toEqual([{ customId: "chunk-0", chunkIndex: 0 }]);
+	});
+
+	it("returns an empty list for unreadable JSON instead of throwing", () => {
+		expect(LlmBatchJobDAO.parseRequests(row("{not json"))).toEqual([]);
+		expect(LlmBatchJobDAO.parseRequests(row('"a string"'))).toEqual([]);
+	});
+});

--- a/tests/lib/entity-extraction-progress.test.ts
+++ b/tests/lib/entity-extraction-progress.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
 	entityExtractionProgressPercent,
+	formatBatchWaitingMarker,
+	parseEntityExtractionBatchState,
 	parseEntityExtractionProgress,
 	queueMessageWithProgress,
 } from "@/lib/entity-extraction-progress";
@@ -54,5 +56,36 @@ describe("queueMessageWithProgress", () => {
 
 	it("returns detail only when no prior PROGRESS", () => {
 		expect(queueMessageWithProgress(null, "oops")).toBe("oops");
+	});
+});
+
+describe("batch marker (issue #735)", () => {
+	it("round-trips a batch waiting marker", () => {
+		const marker = formatBatchWaitingMarker(8, "2026-07-26T10:00:00.000Z");
+		expect(parseEntityExtractionBatchState(marker)).toEqual({
+			chunkCount: 8,
+			submittedAt: "2026-07-26T10:00:00.000Z",
+		});
+	});
+
+	it("coexists with a PROGRESS line without breaking either parser", () => {
+		const message = queueMessageWithProgress(
+			"PROGRESS:4/12",
+			formatBatchWaitingMarker(8, "2026-07-26T10:00:00.000Z")
+		);
+		expect(parseEntityExtractionProgress(message)).toEqual({
+			processed: 4,
+			total: 12,
+		});
+		expect(parseEntityExtractionBatchState(message)).toEqual({
+			chunkCount: 8,
+			submittedAt: "2026-07-26T10:00:00.000Z",
+		});
+	});
+
+	it("returns null when no batch is in flight", () => {
+		expect(parseEntityExtractionBatchState(null)).toBeNull();
+		expect(parseEntityExtractionBatchState("PROGRESS:4/12")).toBeNull();
+		expect(parseEntityExtractionBatchState("BATCH:0:now")).toBeNull();
 	});
 });

--- a/tests/services/campaign/entity-staging-batch.test.ts
+++ b/tests/services/campaign/entity-staging-batch.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ContentExtractionProvider } from "@/services/campaign/content-extraction-provider";
+import type {
+	ChunkBatchDecision,
+	EntityExtractionBatchCoordinator,
+} from "@/services/campaign/entity-extraction-batch-coordinator";
+import { stageLibraryEntitiesFromFile } from "@/services/campaign/entity-staging-service";
+
+/**
+ * Covers the batch seam in entity staging (issue #735): what each coordinator
+ * verdict does to the per-chunk extraction path.
+ */
+
+const mockState = vi.hoisted(() => ({
+	inlineCalls: [] as string[],
+	mappedPayloads: [] as unknown[],
+}));
+
+vi.mock("@/dao/dao-factory", () => ({ getDAOFactory: vi.fn() }));
+
+vi.mock("@/services/llm/llm-rate-limit-service", () => ({
+	getLLMRateLimitService: vi.fn().mockReturnValue({
+		recordUsage: vi.fn().mockResolvedValue(undefined),
+	}),
+}));
+
+vi.mock("@/lib/notifications", () => ({
+	notifyCampaignMembers: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/services/rag/entity-extraction-service", () => ({
+	EntityExtractionService: vi.fn().mockImplementation(function (this: any) {
+		this.extractEntities = vi
+			.fn()
+			.mockImplementation(async (opts: { content: string }) => {
+				mockState.inlineCalls.push(opts.content);
+				return [];
+			});
+		this.mapExtractionPayload = vi
+			.fn()
+			.mockImplementation(async (payload: unknown) => {
+				mockState.mappedPayloads.push(payload);
+				return [];
+			});
+	}),
+}));
+
+vi.mock("@/services/character-sheet/character-sheet-detection-service", () => ({
+	CharacterSheetDetectionService: vi.fn().mockImplementation(function (
+		this: any
+	) {
+		this.detectCharacterSheet = vi
+			.fn()
+			.mockResolvedValue({ confidence: 0.1, characterName: null });
+		this.isConfidentDetection = () => false;
+	}),
+}));
+
+vi.mock("@/services/campaign/visual-inspiration-title", () => ({
+	generateVisualInspirationTitle: vi.fn().mockResolvedValue("title"),
+}));
+
+vi.mock("@/services/rag/extraction-chunk-gate", () => ({
+	isExtractionChunkGateEnabled: vi.fn().mockResolvedValue(false),
+	evaluateExtractionChunkGate: vi
+		.fn()
+		.mockResolvedValue({ runFullExtraction: true, latencyMs: 1 }),
+}));
+
+import { getDAOFactory } from "@/dao/dao-factory";
+import { isExtractionChunkGateEnabled } from "@/services/rag/extraction-chunk-gate";
+
+/** Long enough that MAX_CHUNK_SIZE (12000 on Anthropic) splits it into several chunks. */
+const LONG_CONTENT = "Goblin ambush in the woods. ".repeat(1300);
+
+function coordinator(decision: ChunkBatchDecision) {
+	const resolveChunkOutputs = vi.fn().mockResolvedValue(decision);
+	return {
+		coordinator: { resolveChunkOutputs } as EntityExtractionBatchCoordinator,
+		resolveChunkOutputs,
+	};
+}
+
+/**
+ * A coordinator that answers `ready` with payloads for the chunks `serve`
+ * selects out of the actual plan — so a test states "batch served all but one"
+ * without hard-coding how many chunks the content happens to split into.
+ */
+function readyCoordinator(serve: (index: number, total: number) => boolean) {
+	// `totalChunks` is only present on some staging return paths, so record the
+	// plan's chunk count here and assert against that instead.
+	const observed = { plannedChunks: 0, servedChunks: 0 };
+	const resolveChunkOutputs = vi
+		.fn()
+		.mockImplementation(async (plan: { chunks: { globalIndex: number }[] }) => {
+			observed.plannedChunks = plan.chunks.length;
+			const outputsByChunkIndex = new Map<number, unknown>();
+			for (const chunk of plan.chunks) {
+				if (serve(chunk.globalIndex, plan.chunks.length)) {
+					outputsByChunkIndex.set(chunk.globalIndex, {
+						monsters: [{ name: `chunk-${chunk.globalIndex}` }],
+					});
+				}
+			}
+			observed.servedChunks = outputsByChunkIndex.size;
+			return { status: "ready", outputsByChunkIndex };
+		});
+	return {
+		coordinator: { resolveChunkOutputs } as EntityExtractionBatchCoordinator,
+		resolveChunkOutputs,
+		observed,
+	};
+}
+
+function contentProvider(content = LONG_CONTENT): ContentExtractionProvider {
+	return {
+		extractContent: async () => ({
+			success: true,
+			content,
+			metadata: { isPDF: false },
+		}),
+	};
+}
+
+async function stage(
+	batchCoordinator?: EntityExtractionBatchCoordinator,
+	content?: string
+) {
+	return stageLibraryEntitiesFromFile({
+		env: { DB: {} } as any,
+		username: "alice",
+		fileKey: "library/alice/monsters.pdf",
+		resource: {
+			id: "library/alice/monsters.pdf",
+			file_key: "library/alice/monsters.pdf",
+			file_name: "monsters.pdf",
+			campaign_id: "lib-synthetic",
+		},
+		campaignRagBasePath: "library/alice/",
+		llmApiKey: "sk-test",
+		contentExtractionProvider: contentProvider(content),
+		batchCoordinator,
+	});
+}
+
+describe("entity staging — Anthropic message batch seam", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockState.inlineCalls = [];
+		mockState.mappedPayloads = [];
+		(getDAOFactory as any).mockReturnValue({
+			entityDAO: {},
+			entityImportanceDAO: {},
+		});
+		(isExtractionChunkGateEnabled as any).mockResolvedValue(false);
+	});
+
+	it("makes no model calls and reports awaitingBatch while a batch is in flight", async () => {
+		const { coordinator: coord } = coordinator({ status: "awaiting" });
+
+		const result = await stage(coord);
+
+		expect(result.awaitingBatch).toBe(true);
+		expect(result.completed).toBe(false);
+		expect(result.entityCount).toBe(0);
+		expect(mockState.inlineCalls).toHaveLength(0);
+	});
+
+	it("keeps the resume cursor put while awaiting, so no chunk is skipped", async () => {
+		const { coordinator: coord } = coordinator({ status: "awaiting" });
+
+		const result = await stage(coord);
+
+		expect(result.nextChunkIndex).toBe(0);
+		expect(result.totalChunks).toBeGreaterThan(1);
+	});
+
+	it("uses batch payloads instead of calling the model when results are ready", async () => {
+		const { coordinator: coord, observed } = readyCoordinator(() => true);
+
+		const result = await stage(coord);
+
+		expect(observed.plannedChunks).toBeGreaterThan(1);
+		expect(mockState.inlineCalls).toHaveLength(0);
+		expect(mockState.mappedPayloads).toHaveLength(observed.plannedChunks);
+		expect(result.batchServedChunks).toBe(observed.plannedChunks);
+		expect(result.awaitingBatch).toBeUndefined();
+	});
+
+	it("re-extracts inline only the chunks the batch did not return", async () => {
+		// Batch returned everything except chunk 1.
+		const { coordinator: coord, observed } = readyCoordinator(
+			(index) => index !== 1
+		);
+
+		const result = await stage(coord);
+
+		expect(mockState.inlineCalls).toHaveLength(1);
+		expect(result.batchServedChunks).toBe(observed.plannedChunks - 1);
+		expect(mockState.mappedPayloads).toHaveLength(observed.plannedChunks - 1);
+	});
+
+	it("runs every chunk inline when the coordinator declines to batch", async () => {
+		const { coordinator: coord } = coordinator({
+			status: "inline",
+			reason: "below_min_batch_size",
+		});
+
+		const result = await stage(coord);
+
+		expect(mockState.inlineCalls.length).toBeGreaterThanOrEqual(3);
+		expect(mockState.mappedPayloads).toHaveLength(0);
+		expect(result.batchServedChunks).toBe(0);
+	});
+
+	it("skips the chunk gate for batch-served chunks but keeps it for inline fallbacks", async () => {
+		(isExtractionChunkGateEnabled as any).mockResolvedValue(true);
+		const { evaluateExtractionChunkGate } = await import(
+			"@/services/rag/extraction-chunk-gate"
+		);
+		const { coordinator: coord } = readyCoordinator((index) => index !== 1);
+
+		await stage(coord);
+
+		// Only the one chunk that fell back inline is gated.
+		expect(evaluateExtractionChunkGate).toHaveBeenCalledTimes(1);
+	});
+
+	it("behaves exactly as before when no coordinator is supplied", async () => {
+		const result = await stage(undefined);
+
+		expect(mockState.inlineCalls.length).toBeGreaterThanOrEqual(3);
+		expect(result.awaitingBatch).toBeUndefined();
+		expect(result.batchServedChunks).toBe(0);
+	});
+
+	it("passes the resume window and chunk plan to the coordinator", async () => {
+		const { coordinator: coord, resolveChunkOutputs } = coordinator({
+			status: "inline",
+		});
+
+		await stage(coord);
+
+		const plan = resolveChunkOutputs.mock.calls[0][0];
+		expect(plan.sourceName).toBe("monsters.pdf");
+		expect(plan.chunkWindowStart).toBe(0);
+		expect(plan.chunkWindowEnd).toBe(plan.totalChunks);
+		expect(
+			plan.chunks.map((c: { globalIndex: number }) => c.globalIndex)
+		).toEqual(Array.from({ length: plan.totalChunks }, (_, i) => i));
+	});
+
+	it("does not consult the coordinator when there are no chunks to process", async () => {
+		const { coordinator: coord, resolveChunkOutputs } = coordinator({
+			status: "awaiting",
+		});
+
+		await stage(coord, "");
+
+		expect(resolveChunkOutputs).not.toHaveBeenCalled();
+	});
+});

--- a/tests/services/llm/anthropic-batch-provider.test.ts
+++ b/tests/services/llm/anthropic-batch-provider.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	ANTHROPIC_BATCH_MAX_REQUESTS,
+	AnthropicBatchProvider,
+} from "@/services/llm/anthropic-batch-provider";
+import type { LlmBatchRequestInput } from "@/types/llm-batch";
+
+const create = vi.fn();
+const retrieve = vi.fn();
+const results = vi.fn();
+const cancel = vi.fn();
+
+vi.mock("@anthropic-ai/sdk", () => ({
+	default: class {
+		messages = { batches: { create, retrieve, results, cancel } };
+		constructor(public opts: unknown) {}
+	},
+}));
+
+function request(
+	customId: string,
+	overrides: Partial<LlmBatchRequestInput> = {}
+): LlmBatchRequestInput {
+	return {
+		customId,
+		cacheablePrefix: "shared instructions",
+		variableSuffix: `body of ${customId}`,
+		maxTokens: 16384,
+		...overrides,
+	};
+}
+
+describe("AnthropicBatchProvider", () => {
+	beforeEach(() => {
+		create.mockReset().mockResolvedValue({ id: "msgbatch_abc" });
+		retrieve.mockReset();
+		results.mockReset();
+		cancel.mockReset().mockResolvedValue(undefined);
+	});
+
+	it("requires an API key", () => {
+		expect(() => new AnthropicBatchProvider("")).toThrow(/API key is required/);
+	});
+
+	it("submits one request per input, keyed by custom_id", async () => {
+		const provider = new AnthropicBatchProvider("sk-test");
+
+		const result = await provider.submitBatch(
+			[request("chunk-0"), request("chunk-1")],
+			{ model: "claude-sonnet-5" }
+		);
+
+		expect(result).toEqual({
+			providerBatchId: "msgbatch_abc",
+			requestCount: 2,
+		});
+		const body = create.mock.calls[0][0];
+		expect(
+			body.requests.map((r: { custom_id: string }) => r.custom_id)
+		).toEqual(["chunk-0", "chunk-1"]);
+	});
+
+	it("marks the shared prefix ephemeral and leaves the per-chunk suffix uncached", async () => {
+		const provider = new AnthropicBatchProvider("sk-test");
+
+		await provider.submitBatch([request("chunk-0")], {
+			model: "claude-sonnet-5",
+		});
+
+		const [content] = create.mock.calls[0][0].requests.map(
+			(r: { params: { messages: { content: unknown[] }[] } }) =>
+				r.params.messages[0].content
+		);
+		expect(content[0]).toMatchObject({
+			text: "shared instructions",
+			cache_control: { type: "ephemeral" },
+		});
+		expect(content[1]).toEqual({
+			type: "text",
+			text: "body of chunk-0",
+		});
+	});
+
+	it("sends effort instead of temperature on Sonnet 5", async () => {
+		const provider = new AnthropicBatchProvider("sk-test");
+
+		await provider.submitBatch([request("chunk-0")], {
+			model: "claude-sonnet-5",
+		});
+
+		const params = create.mock.calls[0][0].requests[0].params;
+		expect(params.output_config).toEqual({ effort: "medium" });
+		expect(params.temperature).toBeUndefined();
+	});
+
+	it("rejects an empty batch", async () => {
+		const provider = new AnthropicBatchProvider("sk-test");
+		await expect(provider.submitBatch([], { model: "m" })).rejects.toThrow(
+			/empty batch/
+		);
+	});
+
+	it("rejects duplicate custom_ids, which would make results unmappable", async () => {
+		const provider = new AnthropicBatchProvider("sk-test");
+		await expect(
+			provider.submitBatch([request("chunk-0"), request("chunk-0")], {
+				model: "m",
+			})
+		).rejects.toThrow(/Duplicate batch custom_id/);
+	});
+
+	it("rejects a batch above Anthropic's request ceiling", async () => {
+		const provider = new AnthropicBatchProvider("sk-test");
+		const tooMany = Array.from(
+			{ length: ANTHROPIC_BATCH_MAX_REQUESTS + 1 },
+			(_, i) => request(`chunk-${i}`)
+		);
+		await expect(provider.submitBatch(tooMany, { model: "m" })).rejects.toThrow(
+			/request limit/
+		);
+	});
+
+	it("reports processing status and counts", async () => {
+		retrieve.mockResolvedValue({
+			id: "msgbatch_abc",
+			processing_status: "in_progress",
+			request_counts: {
+				processing: 2,
+				succeeded: 1,
+				errored: 0,
+				canceled: 0,
+				expired: 0,
+			},
+		});
+		const provider = new AnthropicBatchProvider("sk-test");
+
+		const status = await provider.getBatchStatus("msgbatch_abc");
+
+		expect(status.processingStatus).toBe("in_progress");
+		expect(status.counts.succeeded).toBe(1);
+	});
+
+	it("sums uncached, cache-write and cache-read input tokens", async () => {
+		results.mockResolvedValue([
+			{
+				custom_id: "chunk-0",
+				result: {
+					type: "succeeded",
+					message: {
+						content: [{ type: "text", text: '{"ok":true}' }],
+						usage: {
+							input_tokens: 10,
+							cache_creation_input_tokens: 100,
+							cache_read_input_tokens: 1000,
+							output_tokens: 7,
+						},
+					},
+				},
+			},
+		]);
+		const provider = new AnthropicBatchProvider("sk-test");
+
+		const entries = await provider.getBatchResults("msgbatch_abc");
+
+		expect(entries).toEqual([
+			{
+				customId: "chunk-0",
+				outcome: "succeeded",
+				text: '{"ok":true}',
+				inputTokens: 1110,
+				outputTokens: 7,
+				// Reported separately as well as summed: cache reads price at ~0.1x
+				// and cache writes at ~1.25x the uncached input rate.
+				cachedInputTokens: 1000,
+				cacheWriteTokens: 100,
+			},
+		]);
+	});
+
+	it("concatenates multiple text blocks and ignores non-text blocks", async () => {
+		results.mockResolvedValue([
+			{
+				custom_id: "chunk-0",
+				result: {
+					type: "succeeded",
+					message: {
+						content: [
+							{ type: "thinking", thinking: "" },
+							{ type: "text", text: '{"a":1' },
+							{ type: "text", text: "}" },
+						],
+						usage: { input_tokens: 1, output_tokens: 1 },
+					},
+				},
+			},
+		]);
+		const provider = new AnthropicBatchProvider("sk-test");
+
+		const entries = await provider.getBatchResults("msgbatch_abc");
+
+		expect(entries[0]).toMatchObject({ text: '{"a":1}' });
+	});
+
+	it("surfaces errored, expired and canceled outcomes with a reason", async () => {
+		results.mockResolvedValue([
+			{
+				custom_id: "chunk-0",
+				result: {
+					type: "errored",
+					error: { error: { type: "overloaded_error", message: "busy" } },
+				},
+			},
+			{ custom_id: "chunk-1", result: { type: "expired" } },
+			{ custom_id: "chunk-2", result: { type: "canceled" } },
+		]);
+		const provider = new AnthropicBatchProvider("sk-test");
+
+		const entries = await provider.getBatchResults("msgbatch_abc");
+
+		expect(entries[0]).toEqual({
+			customId: "chunk-0",
+			outcome: "errored",
+			error: "overloaded_error: busy",
+		});
+		expect(entries[1]).toMatchObject({ outcome: "expired" });
+		expect(entries[2]).toMatchObject({ outcome: "canceled" });
+	});
+
+	it("wraps provider failures with context", async () => {
+		create.mockRejectedValue(new Error("529 overloaded"));
+		const provider = new AnthropicBatchProvider("sk-test");
+
+		await expect(
+			provider.submitBatch([request("chunk-0")], { model: "m" })
+		).rejects.toThrow(/Failed to submit Anthropic message batch/);
+	});
+
+	it("cancels a batch", async () => {
+		const provider = new AnthropicBatchProvider("sk-test");
+		await provider.cancelBatch("msgbatch_abc");
+		expect(cancel).toHaveBeenCalledWith("msgbatch_abc");
+	});
+});

--- a/tests/services/llm/entity-extraction-batch-service.test.ts
+++ b/tests/services/llm/entity-extraction-batch-service.test.ts
@@ -1,0 +1,699 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChunkBatchPlan } from "@/services/campaign/entity-extraction-batch-coordinator";
+import {
+	cleanupStaleBatchJobs,
+	EntityExtractionBatchService,
+} from "@/services/llm/entity-extraction-batch-service";
+import type {
+	LLMBatchProvider,
+	LlmBatchJobRow,
+	LlmBatchResultEntry,
+} from "@/types/llm-batch";
+
+const FILE_KEY = "library/alice/monsters.pdf";
+const FINGERPRINT = "1024:2026-07-01T00:00:00Z";
+
+/** In-memory stand-in for `llm_batch_jobs`, matching the DAO's contract. */
+class FakeBatchStore {
+	rows: LlmBatchJobRow[] = [];
+	schemaReady = true;
+
+	row(overrides: Partial<LlmBatchJobRow> = {}): LlmBatchJobRow {
+		return {
+			id: "job-1",
+			provider: "anthropic",
+			provider_batch_id: "msgbatch_1",
+			owner_kind: "library_entity_discovery",
+			owner_key: FILE_KEY,
+			username: "alice",
+			model: "claude-sonnet-5",
+			status: "in_progress",
+			request_count: 3,
+			succeeded_count: 0,
+			errored_count: 0,
+			requests: JSON.stringify([
+				{ customId: "chunk-0", chunkIndex: 0 },
+				{ customId: "chunk-1", chunkIndex: 1 },
+				{ customId: "chunk-2", chunkIndex: 2 },
+			]),
+			content_fingerprint: FINGERPRINT,
+			chunk_window_start: 0,
+			chunk_window_end: 3,
+			total_chunks: 3,
+			deadline_at: new Date(Date.now() + 3_600_000).toISOString(),
+			last_polled_at: null,
+			poll_count: 0,
+			input_tokens: 0,
+			output_tokens: 0,
+			last_error: null,
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			completed_at: null,
+			...overrides,
+		};
+	}
+}
+
+const store = new FakeBatchStore();
+
+vi.mock("@/dao/llm-batch-job-dao", async () => {
+	const actual = await vi.importActual<
+		typeof import("@/dao/llm-batch-job-dao")
+	>("@/dao/llm-batch-job-dao");
+	class MockDAO {
+		static parseRequests = actual.LlmBatchJobDAO.parseRequests;
+		async isSchemaReady() {
+			return store.schemaReady;
+		}
+		async getActiveForOwner(_kind: string, key: string) {
+			return (
+				store.rows.find(
+					(r) =>
+						r.owner_key === key &&
+						(r.status === "submitting" || r.status === "in_progress")
+				) ?? null
+			);
+		}
+		async createSubmitting(input: {
+			id: string;
+			ownerKey: string;
+			requests: { customId: string; chunkIndex: number }[];
+			contentFingerprint: string | null;
+			chunkWindowStart: number;
+			chunkWindowEnd: number;
+			totalChunks: number;
+			model: string;
+			username: string;
+			deadlineAt: string;
+		}) {
+			const clash = await this.getActiveForOwner("", input.ownerKey);
+			if (clash) return null;
+			const created = store.row({
+				id: input.id,
+				status: "submitting",
+				provider_batch_id: null,
+				request_count: input.requests.length,
+				requests: JSON.stringify(input.requests),
+				content_fingerprint: input.contentFingerprint,
+				chunk_window_start: input.chunkWindowStart,
+				chunk_window_end: input.chunkWindowEnd,
+				total_chunks: input.totalChunks,
+				deadline_at: input.deadlineAt,
+			});
+			store.rows.push(created);
+			return created;
+		}
+		async markInProgress(id: string, providerBatchId: string) {
+			const row = store.rows.find((r) => r.id === id);
+			if (row) {
+				row.status = "in_progress";
+				row.provider_batch_id = providerBatchId;
+			}
+		}
+		async recordPoll() {}
+		async markCollected(id: string) {
+			const row = store.rows.find((r) => r.id === id);
+			if (row) row.status = "collected";
+		}
+		async markTerminal(
+			id: string,
+			status: "failed" | "expired" | "canceled",
+			error?: string
+		) {
+			const row = store.rows.find((r) => r.id === id);
+			if (row) {
+				row.status = status;
+				row.last_error = error ?? null;
+			}
+		}
+		async getStaleSubmitting(timeoutMinutes: number) {
+			const cutoff = Date.now() - timeoutMinutes * 60_000;
+			return store.rows.filter(
+				(r) =>
+					r.status === "submitting" && Date.parse(r.created_at + "Z") <= cutoff
+			);
+		}
+		async getPastDeadline() {
+			return store.rows.filter(
+				(r) =>
+					(r.status === "submitting" || r.status === "in_progress") &&
+					Date.parse(r.deadline_at) <= Date.now()
+			);
+		}
+	}
+	return { ...actual, LlmBatchJobDAO: MockDAO };
+});
+
+// cleanupStaleBatchJobs reaches the DAO through the factory rather than
+// constructing it directly, so route the factory at the same fake store.
+vi.mock("@/dao/dao-factory", async () => {
+	const { LlmBatchJobDAO } = await import("@/dao/llm-batch-job-dao");
+	return {
+		getDAOFactory: () => ({
+			llmBatchJobDAO: new LlmBatchJobDAO({} as never),
+		}),
+	};
+});
+
+const checkBatchRequestBudget = vi.fn(async () => ({ allowed: true }));
+const recordBatchUsage = vi.fn(async () => {});
+
+vi.mock("@/services/llm/llm-rate-limit-service", () => ({
+	getLLMRateLimitService: () => ({
+		checkBatchRequestBudget,
+		recordBatchUsage,
+	}),
+}));
+
+vi.mock("@/lib/logger", () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+function payloadText(name: string): string {
+	return JSON.stringify({
+		meta: { source: { doc: "monsters.pdf" } },
+		monsters: [{ id: name, name }],
+	});
+}
+
+function fakeProvider(
+	overrides: Partial<LLMBatchProvider> = {}
+): LLMBatchProvider {
+	return {
+		submitBatch: vi.fn(async () => ({
+			providerBatchId: "msgbatch_new",
+			requestCount: 3,
+		})),
+		getBatchStatus: vi.fn(async () => ({
+			providerBatchId: "msgbatch_1",
+			processingStatus: "ended" as const,
+			counts: {
+				processing: 0,
+				succeeded: 3,
+				errored: 0,
+				canceled: 0,
+				expired: 0,
+			},
+		})),
+		getBatchResults: vi.fn(async () => [] as LlmBatchResultEntry[]),
+		cancelBatch: vi.fn(async () => {}),
+		...overrides,
+	};
+}
+
+function plan(chunkCount = 3): ChunkBatchPlan {
+	return {
+		chunks: Array.from({ length: chunkCount }, (_, i) => ({
+			chunk: `chunk body ${i}`,
+			globalIndex: i,
+		})),
+		totalChunks: chunkCount,
+		chunkWindowStart: 0,
+		chunkWindowEnd: chunkCount,
+		sourceName: "monsters.pdf",
+	};
+}
+
+function service(provider: LLMBatchProvider, onStatus?: () => void) {
+	return new EntityExtractionBatchService(
+		{
+			env: { DB: {} } as never,
+			username: "alice",
+			fileKey: FILE_KEY,
+			llmApiKey: "sk-test",
+			contentFingerprint: FINGERPRINT,
+			onStatus,
+		},
+		provider
+	);
+}
+
+describe("EntityExtractionBatchService", () => {
+	beforeEach(() => {
+		store.rows = [];
+		store.schemaReady = true;
+		checkBatchRequestBudget.mockResolvedValue({ allowed: true });
+	});
+
+	it("submits a batch and reports awaiting on the first pass", async () => {
+		const provider = fakeProvider();
+		const decision = await service(provider).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("awaiting");
+		expect(provider.submitBatch).toHaveBeenCalledTimes(1);
+		expect(store.rows[0].status).toBe("in_progress");
+		expect(store.rows[0].provider_batch_id).toBe("msgbatch_new");
+	});
+
+	it("marks the shared instruction prefix as cacheable and keeps it identical across requests", async () => {
+		const provider = fakeProvider();
+		await service(provider).resolveChunkOutputs(plan());
+
+		const [requests] = (provider.submitBatch as ReturnType<typeof vi.fn>).mock
+			.calls[0];
+		const prefixes = new Set(
+			(requests as { cacheablePrefix: string }[]).map((r) => r.cacheablePrefix)
+		);
+		expect(prefixes.size).toBe(1);
+		// Each request's own chunk must be in the variable half, not the prefix.
+		expect([...prefixes][0]).not.toContain("chunk body 0");
+		expect(
+			(requests as { variableSuffix: string }[])[0].variableSuffix
+		).toContain("chunk body 0");
+	});
+
+	it("gives every request a distinct custom_id tied to its chunk index", async () => {
+		const provider = fakeProvider();
+		await service(provider).resolveChunkOutputs(plan());
+
+		const [requests] = (provider.submitBatch as ReturnType<typeof vi.fn>).mock
+			.calls[0];
+		expect((requests as { customId: string }[]).map((r) => r.customId)).toEqual(
+			["chunk-0", "chunk-1", "chunk-2"]
+		);
+	});
+
+	it("stays awaiting while the provider batch is still in progress", async () => {
+		store.rows.push(store.row());
+		const provider = fakeProvider({
+			getBatchStatus: vi.fn(async () => ({
+				providerBatchId: "msgbatch_1",
+				processingStatus: "in_progress" as const,
+				counts: {
+					processing: 3,
+					succeeded: 0,
+					errored: 0,
+					canceled: 0,
+					expired: 0,
+				},
+			})),
+		});
+
+		const decision = await service(provider).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("awaiting");
+		expect(provider.getBatchResults).not.toHaveBeenCalled();
+	});
+
+	it("maps ended results back onto chunk indexes regardless of arrival order", async () => {
+		store.rows.push(store.row());
+		const provider = fakeProvider({
+			getBatchResults: vi.fn(async () => [
+				{
+					customId: "chunk-2",
+					outcome: "succeeded" as const,
+					text: payloadText("c2"),
+					inputTokens: 10,
+					outputTokens: 5,
+				},
+				{
+					customId: "chunk-0",
+					outcome: "succeeded" as const,
+					text: payloadText("c0"),
+					inputTokens: 10,
+					outputTokens: 5,
+				},
+				{
+					customId: "chunk-1",
+					outcome: "succeeded" as const,
+					text: payloadText("c1"),
+					inputTokens: 10,
+					outputTokens: 5,
+				},
+			]),
+		});
+
+		const decision = await service(provider).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("ready");
+		if (decision.status !== "ready") return;
+		expect([...decision.outputsByChunkIndex.keys()].sort()).toEqual([0, 1, 2]);
+		const chunk0 = decision.outputsByChunkIndex.get(0) as {
+			monsters: { name: string }[];
+		};
+		expect(chunk0.monsters[0].name).toBe("c0");
+	});
+
+	it("omits only the chunks that actually failed, so the rest are not re-run", async () => {
+		store.rows.push(store.row());
+		const provider = fakeProvider({
+			getBatchResults: vi.fn(async () => [
+				{
+					customId: "chunk-0",
+					outcome: "succeeded" as const,
+					text: payloadText("c0"),
+					inputTokens: 10,
+					outputTokens: 5,
+				},
+				{
+					customId: "chunk-1",
+					outcome: "errored" as const,
+					error: "overloaded_error: try again",
+				},
+				// Unparseable output also falls back rather than dropping entities.
+				{
+					customId: "chunk-2",
+					outcome: "succeeded" as const,
+					text: "I could not produce JSON.",
+					inputTokens: 10,
+					outputTokens: 5,
+				},
+			]),
+		});
+
+		const decision = await service(provider).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("ready");
+		if (decision.status !== "ready") return;
+		expect([...decision.outputsByChunkIndex.keys()]).toEqual([0]);
+	});
+
+	it("records batch token spend once, including cached input tokens", async () => {
+		store.rows.push(store.row());
+		const provider = fakeProvider({
+			getBatchResults: vi.fn(async () => [
+				{
+					customId: "chunk-0",
+					outcome: "succeeded" as const,
+					text: payloadText("c0"),
+					inputTokens: 100,
+					outputTokens: 20,
+					cachedInputTokens: 60,
+					cacheWriteTokens: 15,
+				},
+				{
+					customId: "chunk-1",
+					outcome: "succeeded" as const,
+					text: payloadText("c1"),
+					inputTokens: 30,
+					outputTokens: 10,
+					cachedInputTokens: 20,
+					cacheWriteTokens: 0,
+				},
+			]),
+		});
+
+		await service(provider).resolveChunkOutputs(plan());
+
+		expect(recordBatchUsage).toHaveBeenCalledTimes(1);
+		expect(recordBatchUsage).toHaveBeenCalledWith(
+			"alice",
+			160,
+			"claude-sonnet-5",
+			expect.objectContaining({ batchRequestCount: 3 })
+		);
+	});
+
+	// Cost attribution prices output at ~5x input and cache reads at ~0.1x, and
+	// stores an event unpriced when the split is missing. Recording only the
+	// total would leave every batch out of the spend dashboard.
+	it("passes the input/output split through so batch spend can be priced", async () => {
+		store.rows.push(store.row());
+		const provider = fakeProvider({
+			getBatchResults: vi.fn(async () => [
+				{
+					customId: "chunk-0",
+					outcome: "succeeded" as const,
+					text: payloadText("c0"),
+					inputTokens: 100,
+					outputTokens: 20,
+					cachedInputTokens: 60,
+					cacheWriteTokens: 15,
+				},
+			]),
+		});
+
+		await service(provider).resolveChunkOutputs(plan());
+
+		const meta = recordBatchUsage.mock.calls[0]?.[3] as Record<string, number>;
+		// The three input lines partition inputTokens — no double counting.
+		expect(meta.promptTokens).toBe(25);
+		expect(meta.cachedInputTokens).toBe(60);
+		expect(meta.cacheWriteTokens).toBe(15);
+		expect(
+			meta.promptTokens + meta.cachedInputTokens + meta.cacheWriteTokens
+		).toBe(100);
+		expect(meta.completionTokens).toBe(20);
+	});
+
+	it("falls back to inline when the batch has blown its deadline", async () => {
+		store.rows.push(
+			store.row({ deadline_at: new Date(Date.now() - 60_000).toISOString() })
+		);
+		const provider = fakeProvider();
+
+		const decision = await service(provider).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("inline");
+		expect(provider.cancelBatch).toHaveBeenCalledWith("msgbatch_1");
+		expect(store.rows[0].status).toBe("expired");
+	});
+
+	it("discards a batch whose content fingerprint no longer matches", async () => {
+		store.rows.push(store.row({ content_fingerprint: "stale-fingerprint" }));
+		const provider = fakeProvider();
+
+		const decision = await service(provider).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("inline");
+		expect(store.rows[0].status).toBe("canceled");
+	});
+
+	it("discards a batch whose chunk window no longer matches the plan", async () => {
+		store.rows.push(store.row({ chunk_window_end: 12, total_chunks: 12 }));
+
+		const decision = await service(fakeProvider()).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("inline");
+		expect(store.rows[0].status).toBe("canceled");
+	});
+
+	it("falls back to inline for a single-chunk run rather than paying batch latency", async () => {
+		const provider = fakeProvider();
+
+		const decision = await service(provider).resolveChunkOutputs(plan(1));
+
+		expect(decision.status).toBe("inline");
+		expect(provider.submitBatch).not.toHaveBeenCalled();
+	});
+
+	it("falls back to inline when the separate batch request budget is exhausted", async () => {
+		checkBatchRequestBudget.mockResolvedValue({
+			allowed: false,
+			reason: "Batch request budget would be exceeded",
+		});
+		const provider = fakeProvider();
+
+		const decision = await service(provider).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("inline");
+		expect(provider.submitBatch).not.toHaveBeenCalled();
+	});
+
+	it("falls back to inline and frees the owner slot when submission fails", async () => {
+		const provider = fakeProvider({
+			submitBatch: vi.fn(async () => {
+				throw new Error("529 overloaded");
+			}),
+		});
+
+		const decision = await service(provider).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("inline");
+		expect(store.rows[0].status).toBe("failed");
+	});
+
+	it("falls back to inline when the batch table has not been migrated", async () => {
+		store.schemaReady = false;
+		const provider = fakeProvider();
+
+		const decision = await service(provider).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("inline");
+		expect(provider.submitBatch).not.toHaveBeenCalled();
+	});
+
+	it("falls back to inline when polling throws, releasing the batch", async () => {
+		store.rows.push(store.row());
+		const provider = fakeProvider({
+			getBatchStatus: vi.fn(async () => {
+				throw new Error("404 not_found_error");
+			}),
+		});
+
+		const decision = await service(provider).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("inline");
+		expect(store.rows[0].status).toBe("failed");
+	});
+
+	it("sweeps a row abandoned mid-submit so its owner is not blocked forever", async () => {
+		store.rows.push(
+			store.row({
+				status: "submitting",
+				provider_batch_id: null,
+				created_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+			})
+		);
+
+		const decision = await service(fakeProvider()).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("inline");
+		expect(store.rows[0].status).toBe("failed");
+	});
+
+	it("does not race an in-flight submit from a concurrent invocation", async () => {
+		store.rows.push(
+			store.row({ status: "submitting", provider_batch_id: null })
+		);
+
+		const decision = await service(fakeProvider()).resolveChunkOutputs(plan());
+
+		expect(decision.status).toBe("awaiting");
+		expect(store.rows[0].status).toBe("submitting");
+	});
+
+	// peekPendingBatch exists so a waiting tick can skip staging entirely —
+	// staging front-loads character-sheet detection LLM calls that would
+	// otherwise repeat on every poll for the life of the batch.
+	describe("peekPendingBatch", () => {
+		it("reports waiting without needing a chunk plan", async () => {
+			store.rows.push(store.row());
+			const provider = fakeProvider({
+				getBatchStatus: vi.fn(async () => ({
+					providerBatchId: "msgbatch_1",
+					processingStatus: "in_progress" as const,
+					counts: {
+						processing: 3,
+						succeeded: 0,
+						errored: 0,
+						canceled: 0,
+						expired: 0,
+					},
+				})),
+			});
+
+			const pending = await service(provider).peekPendingBatch();
+
+			expect(pending.waiting).toBe(true);
+			expect(pending.chunkCount).toBe(3);
+		});
+
+		it("is not waiting when the batch has ended, so results get collected", async () => {
+			store.rows.push(store.row());
+
+			const pending = await service(fakeProvider()).peekPendingBatch();
+
+			expect(pending.waiting).toBe(false);
+		});
+
+		it("is not waiting when there is no batch in flight", async () => {
+			const provider = fakeProvider();
+
+			const pending = await service(provider).peekPendingBatch();
+
+			expect(pending.waiting).toBe(false);
+			expect(provider.getBatchStatus).not.toHaveBeenCalled();
+		});
+
+		it("is not waiting past the deadline, so the fallback can run", async () => {
+			store.rows.push(
+				store.row({ deadline_at: new Date(Date.now() - 1000).toISOString() })
+			);
+
+			const pending = await service(fakeProvider()).peekPendingBatch();
+
+			expect(pending.waiting).toBe(false);
+		});
+
+		it("is not waiting when the batch table is absent", async () => {
+			store.schemaReady = false;
+
+			const pending = await service(fakeProvider()).peekPendingBatch();
+
+			expect(pending.waiting).toBe(false);
+		});
+
+		it("waits on a fresh submitting row but not a stale one", async () => {
+			store.rows.push(
+				store.row({ status: "submitting", provider_batch_id: "msgbatch_1" })
+			);
+			expect((await service(fakeProvider()).peekPendingBatch()).waiting).toBe(
+				true
+			);
+
+			store.rows[0].created_at = new Date(
+				Date.now() - 60 * 60 * 1000
+			).toISOString();
+			expect((await service(fakeProvider()).peekPendingBatch()).waiting).toBe(
+				false
+			);
+		});
+
+		it("defers to the full resolve when the status check throws", async () => {
+			store.rows.push(store.row());
+			const provider = fakeProvider({
+				getBatchStatus: vi.fn(async () => {
+					throw new Error("529 overloaded");
+				}),
+			});
+
+			const pending = await service(provider).peekPendingBatch();
+
+			expect(pending.waiting).toBe(false);
+		});
+	});
+
+	it("reports awaiting status to the caller so progress UX can show it", async () => {
+		const onStatus = vi.fn();
+		const provider = fakeProvider();
+
+		await service(provider, onStatus as never).resolveChunkOutputs(plan());
+
+		expect(onStatus).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: "awaiting", justSubmitted: true })
+		);
+	});
+});
+
+describe("cleanupStaleBatchJobs", () => {
+	beforeEach(() => {
+		store.rows = [];
+		store.schemaReady = true;
+	});
+
+	it("is a no-op when the batch table is absent", async () => {
+		store.schemaReady = false;
+
+		const result = await cleanupStaleBatchJobs({ DB: {} } as never);
+
+		expect(result).toEqual({ failedSubmitting: 0, expired: 0 });
+	});
+
+	it("fails rows abandoned mid-submit and expires rows past their deadline", async () => {
+		store.rows.push(
+			store.row({
+				id: "abandoned",
+				status: "submitting",
+				provider_batch_id: null,
+				created_at: "2020-01-01 00:00:00",
+			}),
+			store.row({
+				id: "overdue",
+				owner_key: "library/alice/other.pdf",
+				deadline_at: "2020-01-01 00:00:00",
+			})
+		);
+
+		const result = await cleanupStaleBatchJobs({ DB: {} } as never);
+
+		expect(result).toEqual({ failedSubmitting: 1, expired: 1 });
+		expect(store.rows.find((r) => r.id === "abandoned")?.status).toBe("failed");
+		expect(store.rows.find((r) => r.id === "overdue")?.status).toBe("expired");
+	});
+});

--- a/tests/services/llm/llm-batch-config.test.ts
+++ b/tests/services/llm/llm-batch-config.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { deriveBatchRequestBudget } from "@/config/anthropic-org-rate-budget";
+import {
+	batchDeadlineFrom,
+	LLM_BATCH_DEADLINE_MINUTES,
+	parseBatchTimestampMs,
+} from "@/services/llm/llm-batch-config";
+
+describe("parseBatchTimestampMs", () => {
+	it("reads a bare D1 datetime as UTC, not local time", () => {
+		expect(parseBatchTimestampMs("2026-07-26 10:00:00")).toBe(
+			Date.parse("2026-07-26T10:00:00Z")
+		);
+	});
+
+	it("reads an ISO timestamp with an explicit zone", () => {
+		expect(parseBatchTimestampMs("2026-07-26T10:00:00.000Z")).toBe(
+			Date.parse("2026-07-26T10:00:00.000Z")
+		);
+	});
+
+	it("returns null for an unparseable value so callers can decide", () => {
+		expect(parseBatchTimestampMs("not a date")).toBeNull();
+		expect(parseBatchTimestampMs("")).toBeNull();
+	});
+});
+
+describe("batchDeadlineFrom", () => {
+	it("is the configured number of minutes ahead", () => {
+		const now = new Date("2026-07-26T10:00:00.000Z");
+		expect(parseBatchTimestampMs(batchDeadlineFrom(now))).toBe(
+			now.getTime() + LLM_BATCH_DEADLINE_MINUTES * 60_000
+		);
+	});
+});
+
+describe("deriveBatchRequestBudget", () => {
+	it("derives a positive per-user share of the org batch line", () => {
+		const budget = deriveBatchRequestBudget();
+		expect(budget.requestsPerMinuteOrg).toBeGreaterThan(0);
+		expect(budget.requestsPerMinutePerUser).toBeGreaterThan(0);
+		expect(budget.requestsPerMinutePerUser).toBeLessThan(
+			budget.requestsPerMinuteOrg
+		);
+	});
+});


### PR DESCRIPTION
Closes #735

## What

Adds a batch submission path to the provider layer and routes **library entity discovery** through the [Anthropic Message Batches API](https://platform.claude.com/docs/en/build-with-claude/batch-processing), behind `LLM_BATCH_EXTRACTION_ENABLED` (**off by default**).

Batch pricing is roughly half the standard rate, on a workload that is already queue-driven and notification-based — the user uploads a file and gets a notification when indexing completes, so latency of minutes is expected.

## Why it's a state machine, not an async function

Anthropic allows a batch up to 24 hours; a Worker invocation can't wait that long. So submit → poll → collect is durable state in a new `llm_batch_jobs` table, driven by the existing `*/5 * * * *` cron:

1. A tick **submits** the current chunk window as one batch. The discovery job stays queued.
2. Later ticks **poll**. Still running → stays queued.
3. The tick that finds it `ended` **collects** and hands payloads back to the extraction pipeline, which merges, dedupes, embeds and notifies exactly as for inline extraction.

## The seam

Rather than splitting the 1,600-line `stageEntitiesFromResourceImpl` into submit/resume halves, staging plans its chunks and then asks a coordinator what to do with them. The coordinator returns one of three verdicts:

| Verdict | Staging behavior |
| --- | --- |
| `awaiting` | Return with `awaitingBatch: true`, cursor unchanged, no model calls |
| `ready` | Use the supplied payload per chunk; chunks missing from the map fall through to an inline call |
| `inline` | Extract every chunk inline — identical to pre-batch behavior |

Batch ids, deadlines and cron ticks stay out of the extraction pipeline, and everything downstream of extraction is shared by both paths.

## Details worth a reviewer's attention

- **Batching can never wedge indexing.** Flag off, missing migration, budget exhausted, submit throws, poll throws, deadline blown, content changed, worker lost mid-submit — every one resolves to inline extraction. Table in `docs/LLM_BATCH_PROCESSING.md`.
- **Single-flight is enforced by the database**, not by application logic: a partial unique index on `(owner_kind, owner_key)` over non-terminal rows. Verified against local D1 — a second concurrent submit is rejected, and a new batch is allowed only once the first goes terminal.
- **Polling is deliberately cheap.** `peekPendingBatch()` runs *before* staging, because staging front-loads content extraction plus 1–3 character-sheet-detection LLM calls before it plans chunks. Reaching the batch seam through staging on every poll would repeat those interactive calls once per tick for the life of the batch — easily enough to cancel out the discount. A waiting tick costs one D1 read, one status GET, one D1 write.
- **Partial failure is per-request.** Chunks a batch errors on, expires, or returns unparseable JSON for are re-extracted inline; the rest use their batch results.
- **Retry accounting is unchanged.** Per-file retry caps count user retries of a file, not model calls. Waiting on a batch requeues at the same cursor without touching `retry_count`, so a slow batch never burns a job's retry budget. Documented on `RetryLimitService`.
- **Rate budget uses the separate line.** `batchRequestsPerMinute` was already declared but unused; `deriveBatchRequestBudget()` now derives a per-user share from it, so background indexing doesn't spend the budget a user's chat needs. Token spend is recorded once on collect with `queryCount: 0` — including cache-write and cache-read input tokens, or every request after the first is under-reported.
- **Progress UX.** Chunks in one batch complete together, so `PROGRESS:a/b` can't advance until it lands. A `BATCH:<n>:<submittedAt>` marker rides alongside, and the UI says how many chunks are queued instead of showing a frozen bar.
- **Prompt prefixes come from one shared helper** (`src/lib/llm-structured-output.ts`). If the two paths built different prompts, a chunk could extract cleanly inline and fail in a batch — and the batch→inline fallback would stop being a true fallback.

Two bugs found while testing and fixed: the table mixes D1 `datetime('now')` (bare UTC) and ISO timestamps, and naive parsing both read bare values as local time and produced `NaN` for ISO ones — which the staleness check treated as "abandoned", killing healthy batches. Second, the poll-before-staging issue above.

## Scope

Only library entity discovery is routed — the largest queue-driven LLM consumer, and the one the cron already resumes chunk-by-chunk. The coordinator interface is generic; the other paths named in the issue (file content extraction, metadata generation, community summaries) can adopt it by supplying a coordinator and are **not** routed here.

Net complexity went *down* while adding the feature: three functions dropped below the CCN-15 threshold entirely and two were reduced (`processQueue` 49→47, `generateStructuredOutput` 19→18), locked into `complexity-baseline.json`.

## Rebased onto #760 (cost attribution)

`main` gained per-agent/per-intent cost attribution while this was open. That
branch prices spend from the **input/output token split** and deliberately stores
an event *unpriced* rather than guessing a ratio — so a spend source that reports
only a total goes missing from the dashboard silently, with no error. Three parts
of the rebase are therefore semantic, not textual, and are worth a look:

- **Migration renumbered `0031` → `0032`.** #760 took `0031`. Duplicate migration
  numbers merge without a conflict marker, so this one is easy to miss.
- **Chunk-gate spend kept its token split.** #760 added `...pickTokenBreakdown(usage)`
  to the chunk-gate `recordUsage`; this branch had moved that block into the new
  `resolveChunkGate` helper. Taking either side wholesale compiles and drops the
  split. It is now inside the helper.
- **Batch collect now reports the split.** `recordBatchSpend` passed only a total,
  which would have stored every batch cost event unpriced — the one number this
  feature exists to demonstrate. It now passes prompt / completion / cache-read /
  cache-write separately, because cache reads price at ~0.1x and cache writes at
  ~1.25x the uncached input rate; folding them into one figure misprices every
  request after the first, which is most of them against a shared cached prefix.
  `LlmBatchResultEntry` carries the two cache fields alongside the `inputTokens`
  total, and a test pins the partition:
  `promptTokens + cachedInputTokens + cacheWriteTokens == inputTokens`.

## Verification

- `npm run validate` (biome + import paths + tsc + coverage) — passes; branches 72.49% vs 70% threshold
- `npx vitest run` — 1732 tests / 187 files pass, incl. 58 in the five new batch test files
- `npm run build` — passes; the new server-only `@anthropic-ai/sdk` stays out of the client bundle
- `node scripts/check/check-complexity.mjs` — passes
- Migration applied to local D1; single-flight behavior verified directly against SQLite
- Local reset from `d1-bootstrap.sql` recreates the table (bootstrap updated alongside the migration)
- e2e (Playwright) not run locally

## How to see this change

```bash
gh pr checkout <PR#>
npm install            # @anthropic-ai/sdk was added
```

This is off by default and server-side, so the meaningful check is the tests plus a schema check.

**Behavior is unchanged with the flag off** — proven by these specific tests:

```bash
npx vitest run tests/services/campaign/entity-staging-batch.test.ts
```

`behaves exactly as before when no coordinator is supplied` and `runs every chunk inline when the coordinator declines to batch` cover the untouched path; the other seven cover the three verdicts, partial-failure fallback, and gate skipping.

The state machine and every fallback branch:

```bash
npx vitest run tests/services/llm/entity-extraction-batch-service.test.ts \
               tests/services/llm/anthropic-batch-provider.test.ts \
               tests/services/llm/llm-batch-config.test.ts \
               tests/dao/llm-batch-job-dao.test.ts
```

Schema, including the single-flight index:

```bash
npm run migrate:local:full
npx wrangler d1 execute loresmith-db-dev --config wrangler.local.jsonc --local \
  --command "SELECT sql FROM sqlite_master WHERE name LIKE 'llm_batch%'"
```

**What you should see:** 58 batch tests passing; the `llm_batch_jobs` table plus `idx_llm_batch_jobs_owner_active` with its `WHERE status IN ('submitting', 'in_progress')` clause — the partial index that makes submission single-flight.

To actually exercise a batch end-to-end you need a real `ANTHROPIC_API_KEY` and `LLM_BATCH_EXTRACTION_ENABLED=true`, then upload a library file large enough to chunk (>12KB of text) and watch `[EntityExtractionBatch]` logs for `batch_submitted` → `batch_collected`. **I did not run that** — it needs a live key and a deployed environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

