### PR TITLE
fix(chat): read tool results from the SDK envelope so answer sources appear

### DIFF
--- a/src/lib/explainability-builder.ts
+++ b/src/lib/explainability-builder.ts
@@ -9,12 +9,23 @@ import {
 	WEAK_GROUNDING_SCORE_THRESHOLD,
 } from "@/types/explainability";
 
-/** Step shape from AI SDK streamText onFinish args */
+/**
+ * Step shape from AI SDK streamText onFinish args.
+ *
+ * `output` is deliberately `unknown`: the SDK stores whatever `execute`
+ * returned and types it as such, so its shape is narrowed at runtime in
+ * `unwrapToolData` rather than asserted here. Declaring a concrete shape is
+ * what let the original bug compile — it read a `result` property the SDK
+ * never sets, which TypeScript accepted as a merely-absent optional field.
+ */
 interface StreamStep {
-	toolCalls?: Array<{ toolName: string; args?: unknown }>;
+	toolCalls?: Array<{ toolCallId?: string; toolName: string; args?: unknown }>;
 	toolResults?: Array<{
+		toolCallId?: string;
 		toolName?: string;
-		result?: { success?: boolean; data?: Record<string, unknown> };
+		output?: unknown;
+		/** Only set by callers that already unwrapped the SDK envelope. */
+		result?: unknown;
 	}>;
 }
 
@@ -25,6 +36,7 @@ interface StreamStep {
  */
 const RETRIEVAL_TOOL_NAMES = new Set([
 	"searchCampaignContext",
+	"listAllEntities",
 	"getDocumentContent",
 	"searchRulesTool",
 	"lookupStatBlockTool",
@@ -182,6 +194,35 @@ function extractContextSourcesFromSearchResults(
 	return sources;
 }
 
+/**
+ * listAllEntities returns raw entity rows rather than search hits: `type` is
+ * the entity type ("npc"), there is no `source`, and every row carries a
+ * placeholder score of 1.0. Map them onto entity sources with no semantic
+ * score, so a listing-backed answer reads as weakly grounded rather than as a
+ * wall of perfect matches.
+ */
+function extractContextSourcesFromEntityList(
+	results: unknown[]
+): ContextSource[] {
+	const sources: ContextSource[] = [];
+	for (const r of results) {
+		const item = (r ?? {}) as Record<string, unknown>;
+		const id = asString(item.id);
+		const title = asString(item.title) ?? asString(item.name);
+		if (!id && !title) continue;
+
+		sources.push({
+			type: "entity",
+			source: "entity_graph",
+			id,
+			title,
+			entityType: asString(item.type),
+			snippet: extractSnippet(item.text, "entity"),
+		});
+	}
+	return sources;
+}
+
 /** getDocumentContent returns whole-document chunks for a single file. */
 function extractContextSourcesFromDocumentContent(
 	data: Record<string, unknown>
@@ -316,6 +357,9 @@ function extractSourcesForTool(
 	if (toolName === "searchCampaignContext") {
 		return extractContextSourcesFromSearchResults(results);
 	}
+	if (toolName === "listAllEntities") {
+		return extractContextSourcesFromEntityList(results);
+	}
 	if (toolName === "searchRulesTool" || toolName === "lookupStatBlockTool") {
 		return extractContextSourcesFromRulesResults(results);
 	}
@@ -329,6 +373,57 @@ interface HarvestedSteps {
 	retrievalAttempted: boolean;
 }
 
+type ToolResultEntry = NonNullable<StreamStep["toolResults"]>[number];
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+/**
+ * Dig the tool's `{ success, data }` payload out of an SDK tool result.
+ *
+ * The AI SDK stores whatever `execute` returned under `output`, and our tools
+ * return the `{ toolCallId, result }` envelope from `createToolSuccess` — so
+ * the payload sits at `output.result.data`. The shallower shapes are accepted
+ * too, for tools that return a bare envelope and for callers that hand us an
+ * already-unwrapped result.
+ */
+function unwrapToolData(
+	entry: ToolResultEntry | undefined
+): Record<string, unknown> | undefined {
+	const record = asRecord(entry);
+	if (!record) return undefined;
+
+	const envelope = asRecord(record.output) ?? record;
+	const inner = asRecord(envelope.result) ?? envelope;
+	return asRecord(inner.data);
+}
+
+/**
+ * Pair a call with its result. Ids are authoritative — within a step, a tool
+ * that threw produces a `tool-error` part and no entry in `toolResults`, so a
+ * positional match would silently attribute one tool's results to another.
+ * Positional matching stays as the fallback for results that carry no id.
+ */
+function findResultForCall(
+	toolResults: ToolResultEntry[],
+	toolCallId: string | undefined,
+	toolName: string,
+	index: number
+): ToolResultEntry | undefined {
+	if (toolCallId) {
+		const byId = toolResults.find((r) => r?.toolCallId === toolCallId);
+		if (byId) return byId;
+	}
+	const positional = toolResults[index];
+	if (positional && (positional.toolName ?? toolName) === toolName) {
+		return positional;
+	}
+	return toolResults.find((r) => r?.toolName === toolName);
+}
+
 function harvestSteps(steps: StreamStep[]): HarvestedSteps {
 	const rawSources: ContextSource[] = [];
 	const toolsUsed: string[] = [];
@@ -339,13 +434,16 @@ function harvestSteps(steps: StreamStep[]): HarvestedSteps {
 		const toolResults = step.toolResults ?? [];
 
 		for (let i = 0; i < toolCalls.length; i++) {
-			const toolName = toolCalls[i]?.toolName;
+			const call = toolCalls[i];
+			const toolName = call?.toolName;
 			if (!toolName) continue;
 
 			toolsUsed.push(toolName);
 			if (RETRIEVAL_TOOL_NAMES.has(toolName)) retrievalAttempted = true;
 
-			const data = toolResults[i]?.result?.data;
+			const data = unwrapToolData(
+				findResultForCall(toolResults, call?.toolCallId, toolName, i)
+			);
 			if (data) rawSources.push(...extractSourcesForTool(toolName, data));
 		}
 	}

--- a/tests/lib/explainability-builder.test.ts
+++ b/tests/lib/explainability-builder.test.ts
@@ -1,12 +1,37 @@
 import { describe, expect, it } from "vitest";
 import { buildExplainabilityFromSteps } from "@/lib/explainability-builder";
+import { createToolSuccess } from "@/tools/tool-utils";
 import { MAX_CONTEXT_SOURCES } from "@/types/explainability";
 
-function searchStep(results: unknown[]) {
+let nextCallId = 0;
+
+/**
+ * A step in the shape `streamText` actually produces.
+ *
+ * The envelope comes from the real `createToolSuccess` so the fixture cannot
+ * drift from what tools return, and the AI SDK's own nesting is reproduced
+ * here: the tool's return value lands in `output`, not `result`. Hand-written
+ * fixtures previously flattened that away, which hid a bug where every
+ * retrieval turn reported "no campaign sources".
+ */
+function toolStep(toolName: string, data: Record<string, unknown>) {
+	const toolCallId = `call-${nextCallId++}`;
 	return {
-		toolCalls: [{ toolName: "searchCampaignContext", args: {} }],
-		toolResults: [{ result: { success: true, data: { results } } }],
+		toolCalls: [{ toolCallId, toolName, args: {} }],
+		toolResults: [
+			{
+				type: "tool-result" as const,
+				toolCallId,
+				toolName,
+				input: {},
+				output: createToolSuccess("ok", data, toolCallId),
+			},
+		],
 	};
+}
+
+function searchStep(results: unknown[]) {
+	return toolStep("searchCampaignContext", { results });
 }
 
 /** Mirrors the banner the search tools wrap around entity content. */
@@ -31,13 +56,9 @@ describe("explainability-builder", () => {
 		});
 
 		it("returns null when no retrieval tool ran", () => {
-			const steps = [
-				{
-					toolCalls: [{ toolName: "otherTool", args: {} }],
-					toolResults: [{ result: { success: true } }],
-				},
-			];
-			expect(buildExplainabilityFromSteps(steps)).toBe(null);
+			expect(buildExplainabilityFromSteps([toolStep("otherTool", {})])).toBe(
+				null
+			);
 		});
 
 		it("builds explainability from searchCampaignContext results", () => {
@@ -253,31 +274,21 @@ describe("explainability-builder", () => {
 
 		it("maps rules citations onto context sources", () => {
 			const result = buildExplainabilityFromSteps([
-				{
-					toolCalls: [{ toolName: "searchRulesTool", args: {} }],
-					toolResults: [
+				toolStep("searchRulesTool", {
+					results: [
 						{
-							result: {
-								success: true,
-								data: {
-									results: [
-										{
-											id: "r1",
-											title: "Grappling",
-											excerpt: "You can use the Attack action to grapple.",
-											score: 0.77,
-											citation: {
-												source: "PHB",
-												fileKey: "phb-key",
-												chunkIndex: 12,
-											},
-										},
-									],
-								},
+							id: "r1",
+							title: "Grappling",
+							excerpt: "You can use the Attack action to grapple.",
+							score: 0.77,
+							citation: {
+								source: "PHB",
+								fileKey: "phb-key",
+								chunkIndex: 12,
 							},
 						},
 					],
-				},
+				}),
 			]);
 			const source = result?.contextSources[0];
 			expect(source?.type).toBe("file_content");
@@ -289,24 +300,14 @@ describe("explainability-builder", () => {
 
 		it("maps getDocumentContent chunks onto context sources", () => {
 			const result = buildExplainabilityFromSteps([
-				{
-					toolCalls: [{ toolName: "getDocumentContent", args: {} }],
-					toolResults: [
-						{
-							result: {
-								success: true,
-								data: {
-									fileKey: "f9",
-									displayName: "Session Prep.pdf",
-									chunks: [
-										{ index: 0, text: "Chapter one." },
-										{ index: 1, text: "Chapter two." },
-									],
-								},
-							},
-						},
+				toolStep("getDocumentContent", {
+					fileKey: "f9",
+					displayName: "Session Prep.pdf",
+					chunks: [
+						{ index: 0, text: "Chapter one." },
+						{ index: 1, text: "Chapter two." },
 					],
-				},
+				}),
 			]);
 			expect(result?.contextSources).toHaveLength(2);
 			expect(result?.contextSources[0].fileKey).toBe("f9");
@@ -314,6 +315,121 @@ describe("explainability-builder", () => {
 			expect(result?.contextSources.map((s) => s.chunkIndex).sort()).toEqual([
 				0, 1,
 			]);
+		});
+
+		it("reads the payload from the SDK's `output` envelope, not `result`", () => {
+			// Regression: the builder read `toolResults[i].result.data`, one level
+			// above where the AI SDK puts a tool's return value. Every retrieval
+			// turn therefore harvested nothing and was labelled ungrounded.
+			const step = searchStep([
+				{
+					type: "entity",
+					source: "entity_graph",
+					entityId: "e1",
+					title: "Big Bosta",
+					score: 0.71,
+				},
+			]);
+			expect(step.toolResults[0]).not.toHaveProperty("result");
+			expect(step.toolResults[0].output).toHaveProperty("result.data.results");
+
+			const result = buildExplainabilityFromSteps([step]);
+			expect(result?.grounding).toBe("grounded");
+			expect(result?.contextSources[0].title).toBe("Big Bosta");
+		});
+
+		it("still reads an already-unwrapped result envelope", () => {
+			const result = buildExplainabilityFromSteps([
+				{
+					toolCalls: [{ toolName: "searchCampaignContext", args: {} }],
+					toolResults: [
+						{
+							result: {
+								success: true,
+								data: {
+									results: [
+										{ type: "entity", source: "entity_graph", entityId: "e1" },
+									],
+								},
+							},
+						},
+					],
+				},
+			]);
+			expect(result?.contextSources).toHaveLength(1);
+		});
+
+		it("pairs calls with results by toolCallId, not position", () => {
+			// A tool that threw contributes no entry to `toolResults`, so the
+			// surviving result sits at an index that belongs to another call.
+			const result = buildExplainabilityFromSteps([
+				{
+					toolCalls: [
+						{ toolCallId: "c1", toolName: "recordWorldEventTool", args: {} },
+						{ toolCallId: "c2", toolName: "searchCampaignContext", args: {} },
+					],
+					toolResults: [
+						{
+							toolCallId: "c2",
+							toolName: "searchCampaignContext",
+							output: createToolSuccess(
+								"ok",
+								{
+									results: [
+										{
+											type: "entity",
+											source: "entity_graph",
+											entityId: "e1",
+											title: "Splinter",
+										},
+									],
+								},
+								"c2"
+							),
+						},
+					],
+				},
+			]);
+			expect(result?.contextSources).toHaveLength(1);
+			expect(result?.contextSources[0].title).toBe("Splinter");
+		});
+
+		it("counts listAllEntities rows as entity sources", () => {
+			const result = buildExplainabilityFromSteps([
+				toolStep("listAllEntities", {
+					entityType: "npcs",
+					results: [
+						{
+							id: "e1",
+							type: "npc",
+							name: "Dur the Anchorhorn",
+							title: "Dur the Anchorhorn",
+							text: JSON.stringify({
+								description: "Structural engineer of the Platform.",
+							}),
+							// listAllEntities stamps every row with this placeholder.
+							score: 1.0,
+						},
+						{
+							id: "e2",
+							type: "npc",
+							name: "Mael Firstburn",
+							title: "Mael Firstburn",
+							text: JSON.stringify({ description: "Keeper of the shrine." }),
+							score: 1.0,
+						},
+					],
+				}),
+			]);
+			expect(result?.contextSources).toHaveLength(2);
+			expect(result?.rationale).toContain("2 entities");
+			expect(result?.contextSources[0].entityType).toBe("npc");
+			expect(result?.contextSources[0].snippet).toBe(
+				"Structural engineer of the Platform."
+			);
+			// The placeholder score must not read as a perfect semantic match.
+			expect(result?.topScore).toBeUndefined();
+			expect(result?.grounding).toBe("weak");
 		});
 	});
 });


### PR DESCRIPTION
## What

Every answer that *was* grounded in campaign data still rendered the amber
warning: **"No campaign sources — this answer isn't grounded in your materials."**

`buildExplainabilityFromSteps` read the tool payload from
`step.toolResults[i].result.data`. The AI SDK (v7) stores whatever `execute`
returned under **`output`**, and this repo's tools return the
`{ toolCallId, result: { success, message, data } }` envelope from
`createToolSuccess` — so the payload actually sits at
`output.result.data`. The read resolved to `undefined` on every turn.

Because #741 deliberately emits explainability whenever a retrieval tool ran
(so an unsourced answer is visibly unsourced), `retrievalAttempted` came back
`true` — that flag is derived from `toolCalls`, which was never broken — while
`contextSources` was always empty. Result: `grounding: "ungrounded"` on
literally every retrieval turn.

## Why the tests didn't catch it

`tests/lib/explainability-builder.test.ts` hand-wrote its fixtures as
`toolResults: [{ result: {...} }]` — the same wrong shape the reader assumed. A
fixture that mirrors the buggy reader can never detect a shape mismatch.

Fixtures now build the envelope by calling the real `createToolSuccess` and
reproduce the SDK's `output` nesting, so they cannot drift from production.
**15 of the 19 tests in this file fail against the pre-fix builder.**

## Why TypeScript didn't catch it either

`StreamStep` declared `result?: { data?: ... }` as an *optional* property.
`TypedToolResult` has no `result` property at all — and TypeScript treats
"optional property that is absent" as structurally identical to "property that
can never exist." The wrong read compiled cleanly.

`output` is now typed `unknown` (as the SDK types it) and narrowed at runtime
in `unwrapToolData`. Asserting a concrete shape is what made the original bug
possible; it now fails to compile, which is how the type error in this branch
surfaced.

## Changes

- **`unwrapToolData`** — narrows `output.result.data`, falling back to
  `output.data` and `result.data` for bare-envelope tools and already-unwrapped
  callers.
- **`findResultForCall`** — pairs calls to results by `toolCallId` instead of
  array index. A tool that throws produces a `tool-error` part and *no* entry in
  `toolResults`, so a positional match would attribute one tool's sources to a
  different tool. Positional matching remains as the fallback for results with
  no id.
- **`listAllEntities`** added as a retrieval tool, with its own extractor. It
  returns raw entity rows (`type` is the entity type, no `source` field, `id`
  not `entityId`, and a hardcoded `score: 1.0`), so the search-hit extractor
  skipped every row. Rows now map to entity sources with **no** semantic score,
  so a listing-backed answer reads as *weakly* grounded rather than as a wall of
  perfect matches.

Other campaign tools (`getChecklistStatusTool`, `generateContextRecapTool`,
`showCampaignDetails`) are still outside `RETRIEVAL_TOOL_NAMES`. That is
unchanged behaviour and out of scope here — flagging it as a known gap.

## Verification

- `npm run check` — clean (7 pre-existing warnings in unrelated files, no TS errors)
- `npm run validate` — **182 files, 1675 tests passed**; branch coverage 72.76% (threshold 70%)
- `npx vitest run tests/lib/explainability-builder.test.ts tests/components/ExplainabilitySection.test.tsx` — 29 passed
- Confirmed the new tests fail against the old builder (15/19) by stashing the source change and re-running

No docs under `docs/` or `README.md` changed, so no wiki sync applies.

## How to see this change

```bash
gh pr checkout <PR#>
```

The regression is in a pure function, so the fastest proof is the test that
pins the SDK's actual envelope:

```bash
npx vitest run tests/lib/explainability-builder.test.ts
```

Look at **"reads the payload from the SDK's `output` envelope, not `result`"** —
it asserts the fixture has *no* top-level `result` property, then asserts the
builder still returns `grounding: "grounded"` with the entity title.

To see it in the app, the two-terminal setup from `docs/DEV_SETUP.md`
(`npm run dev:cloudflare`, then `npm run start`), open
`http://localhost:5173` → Campaigns → pick a campaign with entities → ask the
chat something about your world ("what shops are in <a location you have>").

**What you should see:** below the answer, **before** — an amber bar reading
"No campaign sources — this answer isn't grounded in your materials." **After**
— an expandable "sources" panel listing the entities, digest sections and file
excerpts the answer was built from, with snippets and relevance.

I did not run the in-app path myself: it needs a populated campaign and live
Cloudflare bindings that aren't available in this environment. The tests above
cover the fixed code path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)