### PR TITLE
docs: register LLM_BATCH_PROCESSING.md with the wiki sync

### DIFF
--- a/scripts/wiki/sync-docs-to-wiki.js
+++ b/scripts/wiki/sync-docs-to-wiki.js
@@ -90,6 +90,11 @@ const FILE_MAPPINGS = [
 		process: true,
 	},
 	{
+		src: "docs/LLM_BATCH_PROCESSING.md",
+		dest: "Technical/LLM-Batch-Processing.md",
+		process: true,
+	},
+	{
 		src: "docs/FILE_UPLOAD_SYSTEM.md",
 		dest: "Technical/File-Upload-System.md",
 		process: true,
@@ -329,6 +334,7 @@ function createSidebar() {
 ## Content Pipeline
 - [[Technical/GraphRAG-Integration|GraphRAG Integration]]
 - [[Technical/Library-Entity-Pipeline|Library entity pipeline]]
+- [[Technical/LLM-Batch-Processing|LLM batch processing]]
 - [[Technical/File-Upload-System|File upload system]]
 - [[Technical/File-Analysis-System|File analysis system]]
 - [[Technical/Large-File-Support|Large file support]]


### PR DESCRIPTION
Follow-up to #762.

## What

Adds `docs/LLM_BATCH_PROCESSING.md` to `FILE_MAPPINGS` in
`scripts/wiki/sync-docs-to-wiki.js`, plus its sidebar link.

## Why

#762 added the doc but not a mapping entry. The sync is an explicit allowlist,
not a directory glob — an unlisted file is skipped with no error and no warning,
so the page is simply absent from the public wiki and the sync still reports
success. I hit exactly that running the post-merge sync for #762: the doc exists
on `main`, and the wiki has no page for it.

## How to see this change

```bash
gh pr checkout <PR#>
npm run wiki:sync:dry-run
```

**What you should see:** the diff now lists `?? Technical/LLM-Batch-Processing.md`
and `M _Sidebar.md`, neither of which appears on `main`. No wiki push happens —
dry-run only, and publishing is done from `main` after merge.

## Verification

- `npm run wiki:sync:dry-run` — new page and sidebar entry appear in the diff
- `npm run check` — passes
- `npx vitest run` — 1736 tests / 187 files pass (pre-commit hook)

Wiki is currently one merge behind: `Technical/LLM-Batch-Processing` is pending
and will publish on the sync after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)