### PR TITLE
fix(library): batch the chunk-stats IN list under D1's parameter cap

### DIFF
--- a/src/dao/file/file-processing-chunks-dao.ts
+++ b/src/dao/file/file-processing-chunks-dao.ts
@@ -1,4 +1,5 @@
 import { BaseDAOClass } from "@/dao/base-dao";
+import { D1_IN_LIST_CHUNK_SIZE } from "@/dao/d1-limits";
 import type { SqlParams } from "@/types/utils";
 
 /**
@@ -177,7 +178,12 @@ export class FileProcessingChunksDAO extends BaseDAOClass {
 	}
 
 	/**
-	 * Per-file aggregate chunk stats for many files in one query (GET /library/files).
+	 * Per-file aggregate chunk stats for many files (GET /library/files).
+	 *
+	 * The key list is the caller's entire library, which grows without bound, so
+	 * the `IN (…)` list is batched at {@link D1_IN_LIST_CHUNK_SIZE}. Binding one
+	 * placeholder per file exceeds D1's 100-bound-parameter ceiling and fails the
+	 * whole statement with `too many SQL variables` once a user passes ~100 files.
 	 */
 	async getFileChunkStatsForFileKeys(fileKeys: string[]): Promise<
 		Map<
@@ -204,8 +210,10 @@ export class FileProcessingChunksDAO extends BaseDAOClass {
 		if (fileKeys.length === 0) {
 			return out;
 		}
-		const ph = fileKeys.map(() => "?").join(", ");
-		const sql = `
+		for (let i = 0; i < fileKeys.length; i += D1_IN_LIST_CHUNK_SIZE) {
+			const chunk = fileKeys.slice(i, i + D1_IN_LIST_CHUNK_SIZE);
+			const ph = chunk.map(() => "?").join(", ");
+			const sql = `
       SELECT
         file_key,
         COUNT(*) as total,
@@ -217,22 +225,23 @@ export class FileProcessingChunksDAO extends BaseDAOClass {
       WHERE file_key IN (${ph})
       GROUP BY file_key
     `;
-		const rows = await this.queryAll<{
-			file_key: string;
-			total?: number;
-			completed?: number;
-			failed?: number;
-			pending?: number;
-			processing?: number;
-		}>(sql, fileKeys);
-		for (const row of rows) {
-			out.set(row.file_key, {
-				total: row.total ?? 0,
-				completed: row.completed ?? 0,
-				failed: row.failed ?? 0,
-				pending: row.pending ?? 0,
-				processing: row.processing ?? 0,
-			});
+			const rows = await this.queryAll<{
+				file_key: string;
+				total?: number;
+				completed?: number;
+				failed?: number;
+				pending?: number;
+				processing?: number;
+			}>(sql, chunk);
+			for (const row of rows) {
+				out.set(row.file_key, {
+					total: row.total ?? 0,
+					completed: row.completed ?? 0,
+					failed: row.failed ?? 0,
+					pending: row.pending ?? 0,
+					processing: row.processing ?? 0,
+				});
+			}
 		}
 		return out;
 	}

--- a/src/dao/llm-cost-event-dao.ts
+++ b/src/dao/llm-cost-event-dao.ts
@@ -70,7 +70,7 @@ function n(value: number | null | undefined): number {
 
 export class LLMCostEventDAO extends BaseDAOClass {
 	/**
-	 * False until migration 0030 has been applied. Read paths check this so the
+	 * False until migration 0031 has been applied. Read paths check this so the
 	 * admin dashboard degrades to "no data" instead of erroring on an environment
 	 * that has not migrated yet.
 	 */
@@ -308,9 +308,18 @@ export class LLMCostEventDAO extends BaseDAOClass {
 		}));
 	}
 
+	/**
+	 * No-op when the table is absent. This runs from the 5-minute cron, so a
+	 * Worker deployed ahead of its migration would otherwise log a `no such
+	 * table` failure on every tick — and, because it shares a try/catch with the
+	 * rate-limit ledger prune, bury that prune's own errors behind the noise.
+	 */
 	async pruneOldRows(
 		retentionDays: number = COST_EVENT_RETENTION_DAYS
 	): Promise<number> {
+		if (!(await this.isAvailable())) {
+			return 0;
+		}
 		const result = await this.db
 			.prepare(
 				`DELETE FROM llm_cost_events WHERE created_at < datetime('now', ?)`

--- a/tests/dao/file-processing-chunks-dao.test.ts
+++ b/tests/dao/file-processing-chunks-dao.test.ts
@@ -1,0 +1,122 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	D1_IN_LIST_CHUNK_SIZE,
+	D1_MAX_BOUND_PARAMETERS_PER_QUERY,
+} from "@/dao/d1-limits";
+import { FileProcessingChunksDAO } from "@/dao/file/file-processing-chunks-dao";
+
+interface RecordedCall {
+	sql: string;
+	params: unknown[];
+}
+
+/**
+ * D1 mock that records every statement and the parameters bound to it, so a
+ * test can assert on the shape of the batching rather than only its results.
+ */
+function createRecordingDB(rowsFor: (params: unknown[]) => unknown[]) {
+	const calls: RecordedCall[] = [];
+	const db = {
+		prepare: vi.fn((sql: string) => {
+			const call: RecordedCall = { sql, params: [] };
+			const stmt = {
+				bind: vi.fn((...params: unknown[]) => {
+					call.params = params;
+					calls.push(call);
+					return stmt;
+				}),
+				all: vi.fn(async () => ({ results: rowsFor(call.params) })),
+				first: vi.fn(async () => null),
+				run: vi.fn(async () => ({ meta: { changes: 0 } })),
+			};
+			return stmt;
+		}),
+	} as unknown as D1Database;
+	return { db, calls };
+}
+
+const statsRow = (fileKey: unknown) => ({
+	file_key: fileKey,
+	total: 4,
+	completed: 3,
+	failed: 0,
+	pending: 1,
+	processing: 0,
+});
+
+describe("FileProcessingChunksDAO.getFileChunkStatsForFileKeys", () => {
+	let dao: FileProcessingChunksDAO;
+	let calls: RecordedCall[];
+
+	beforeEach(() => {
+		const recording = createRecordingDB((params) => params.map(statsRow));
+		calls = recording.calls;
+		dao = new FileProcessingChunksDAO(recording.db);
+	});
+
+	it("issues no query for an empty key list", async () => {
+		const stats = await dao.getFileChunkStatsForFileKeys([]);
+		expect(stats.size).toBe(0);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("sends a single query when the library fits in one batch", async () => {
+		const keys = ["a", "b", "c"];
+		const stats = await dao.getFileChunkStatsForFileKeys(keys);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].params).toEqual(keys);
+		expect(stats.get("b")).toEqual({
+			total: 4,
+			completed: 3,
+			failed: 0,
+			pending: 1,
+			processing: 0,
+		});
+	});
+
+	it("never exceeds D1's bound-parameter ceiling for a large library", async () => {
+		// Regression: GET /library/files bound one placeholder per file, so a user
+		// with more than ~100 files got `D1_ERROR: too many SQL variables` and the
+		// whole route 500'd.
+		const keys = Array.from({ length: 250 }, (_, i) => `file-${i}`);
+
+		await dao.getFileChunkStatsForFileKeys(keys);
+
+		expect(calls.length).toBeGreaterThan(1);
+		for (const call of calls) {
+			expect(call.params.length).toBeLessThanOrEqual(
+				D1_MAX_BOUND_PARAMETERS_PER_QUERY
+			);
+			// Placeholder count must match the params actually bound.
+			expect(call.sql.match(/\?/g) ?? []).toHaveLength(call.params.length);
+		}
+		expect(calls).toHaveLength(Math.ceil(keys.length / D1_IN_LIST_CHUNK_SIZE));
+	});
+
+	it("returns stats for every file across batch boundaries", async () => {
+		const keys = Array.from({ length: 250 }, (_, i) => `file-${i}`);
+
+		const stats = await dao.getFileChunkStatsForFileKeys(keys);
+
+		expect(stats.size).toBe(keys.length);
+		// Every key is queried exactly once, in order, with none dropped.
+		expect(calls.flatMap((c) => c.params)).toEqual(keys);
+	});
+
+	it("defaults missing aggregate columns to zero", async () => {
+		const recording = createRecordingDB(() => [{ file_key: "a" }]);
+		dao = new FileProcessingChunksDAO(recording.db);
+
+		const stats = await dao.getFileChunkStatsForFileKeys(["a"]);
+
+		expect(stats.get("a")).toEqual({
+			total: 0,
+			completed: 0,
+			failed: 0,
+			pending: 0,
+			processing: 0,
+		});
+	});
+});

--- a/tests/dao/llm-cost-event-dao.test.ts
+++ b/tests/dao/llm-cost-event-dao.test.ts
@@ -206,10 +206,19 @@ describe("LLMCostEventDAO", () => {
 	});
 
 	it("pruneOldRows deletes beyond the retention horizon", async () => {
+		mockStmt.all.mockResolvedValue({ results: [{ name: "llm_cost_events" }] });
 		mockStmt.run.mockResolvedValue({ meta: { changes: 12 } });
 		const deleted = await dao.pruneOldRows(90);
 		expect(deleted).toBe(12);
 		expect(mockStmt.bind).toHaveBeenCalledWith("-90 days");
+	});
+
+	it("pruneOldRows is a no-op before the migration has run", async () => {
+		// The 5-minute cron calls this; on a Worker deployed ahead of its
+		// migration it must not throw `no such table` on every tick.
+		mockStmt.all.mockResolvedValue({ results: [] });
+		await expect(dao.pruneOldRows(90)).resolves.toBe(0);
+		expect(mockStmt.run).not.toHaveBeenCalled();
 	});
 
 	it("isAvailable is false before the migration has run", async () => {


### PR DESCRIPTION
## What

`GET /api/library/files` is returning **500** in production. This batches the offending query under D1's bound-parameter cap, and quiets a secondary cron error found in the same logs.

## Why — from the production logs

Tailing `loresmith-ai` prod caught the failure directly. Across 108 captured events (101×`200`, 5×`500`), **every 500 was this one route, all with the same error** — no other failing route in production:

```
ok  status=500  GET /api/library/files
  ERROR: ['[Upload] Error fetching files',
          'Error: Database query failed: D1_ERROR: too many SQL variables at offset 713: SQLITE_ERROR']
  ERROR: ['[Server] GET /api/library/files -> 500 (356ms)']
```

`handleGetFiles` (`src/routes/upload.ts:266`) calls `getFileChunkStatsForFileKeys(keys)` with **the caller's entire library**. That DAO built `WHERE file_key IN (?,?,…)` with one placeholder per file:

```ts
const ph = fileKeys.map(() => "?").join(", ");   // unbounded
```

D1 caps bound parameters at **100 per statement**. So the route worked fine until an account crossed ~100 files, then failed permanently for that user — a latent bug that surfaces as a sudden outage rather than a bad deploy.

The repo already codified this limit in `src/dao/d1-limits.ts` (`D1_IN_LIST_CHUNK_SIZE = 90`), and five DAOs (`entity-dao`, `community-dao`, `entity-importance-dao`, `world-state-changelog-dao`, `continuity-finding-dao`) loop over it. This call site was written without it. I swept every `map(() => "?")` in `src/` — **this was the only IN list that scales with user data**; the rest are bounded status/type vocabularies.

## Secondary fix: cron log noise

The same tail showed this every 5 minutes:

```
cron:*/5 * * * *
  ERROR: ['[Scheduled] Failed to prune LLM usage log',
          'Error: D1_ERROR: no such table: llm_cost_events: SQLITE_ERROR']
```

`LLMCostEventDAO` exposes `isAvailable()` for exactly this case, but only its *read* callers used it — `pruneOldRows`, a write reached from cron, was unguarded. (Compare `LlmBatchJobDAO`, which guards every method and documents why.) The guard now lives in the DAO, so all callers are safe. It shared a `try/catch` with the rate-limit ledger prune, so the noise could also mask that prune's own failures.

A longer 9-minute tail caught the same missing table on a second path — this one on **every LLM call**, not just the cron:

```
warn ['[LLMRateLimit] Failed to record cost attribution event',
      'Error: Database execute failed: D1_ERROR: no such table: llm_cost_events: SQLITE_ERROR']
```

That one needs no code change: `recordCostEvent` is best-effort by design and correctly try/caught, so it never breaks a user's turn. I deliberately did **not** add a `hasTable()` guard there — it would put an extra D1 round-trip on the hot path of every LLM call, for no benefit once the migration lands.

> [!IMPORTANT]
> The guard silences the symptom, **not the cause**. Migrations `0031_llm_cost_attribution.sql` and `0032_llm_batch_jobs.sql` are **still unapplied on the prod D1** — the Worker is deployed ahead of its schema. The warning above is proof that cost attribution is currently recording **zero rows** in production, not merely sitting idle; LLM batching is inert for the same reason. Applying them is a production write, so I left it to you:
> ```bash
> npx wrangler d1 migrations list loresmith-db --config wrangler.jsonc --remote   # confirms 0031, 0032 pending
> npm run migrate:prod:apply:resilient
> ```

## Verification

- `npm run check` — clean (7 warnings, all pre-existing and unrelated)
- `npx vitest run` — **194 files / 1810 tests pass**
- Pre-commit hooks (biome, `tsc --noEmit`, staged complexity, full suite) all passed
- e2e (Playwright) **not run locally** — leaving that to CI

New `tests/dao/file-processing-chunks-dao.test.ts` asserts against a recording D1 mock that no statement exceeds `D1_MAX_BOUND_PARAMETERS_PER_QUERY`, that placeholder counts match bound params, and that all 250 keys survive the batch boundaries. Updated the existing `pruneOldRows` test (its default mock reports no table, so it would have started failing) and added a no-op-before-migration case.

## How to see this change

```bash
gh pr checkout <PR#>
```

There is no fixture with a 100+ file library, so the honest reproduction is the unit test — it fails on `main` and passes here:

```bash
npx vitest run tests/dao/file-processing-chunks-dao.test.ts tests/dao/llm-cost-event-dao.test.ts
```

To see it end to end against a real database (two terminals, per `docs/DEV_SETUP.md`):

```bash
npm run dev:cloudflare     # terminal 1
npm run start              # terminal 2
```

Then `http://localhost:5173` → Library, with an account holding **more than 100 files**. I did **not** run this path — seeding 100+ files locally was out of scope for a production hotfix, and the prod logs already pin the failure exactly.

**What you should see:** before, `GET /api/library/files` returns `500 {"error":"Internal server error"}` and the Library page renders its error state for any user with 100+ files; after, it returns `200` with the full file list and per-file `ingestion_chunk_stats`. Users under ~100 files are unaffected either way. The `[Scheduled] Failed to prune LLM usage log` error should also stop appearing in `npx wrangler tail --config wrangler.jsonc`.

No docs under `docs/` or `README.md` changed, so no wiki sync is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
