### PR TITLE
fix(chat): drop empty-content turns so Anthropic stops rejecting the thread

### DIFF
--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/agent-role-utils";
 import { getStatusMessageForTool } from "@/lib/agent-status-messages";
 import { anthropicSamplingParams } from "@/lib/anthropic-model-options";
+import { dropEmptyContentMessages } from "@/lib/chat-message-sanitization";
 import {
 	buildSummaryState,
 	CONVERSATION_SUMMARY_STORAGE_KEY,
@@ -803,8 +804,15 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 		// (see buildConversationContext) rather than simply dropped.
 		const MAX_CONTEXT_MESSAGES = 32;
 
-		const userAssistantMessages = this.messages.filter(
-			(msg) => msg.role === "user" || msg.role === "assistant"
+		// Empty-content turns (tool-call-only replies, turns interrupted before any
+		// text streamed) are dropped here rather than at the provider call: they
+		// would otherwise occupy slots in the trailing window and be fed to the
+		// summarizer, and Anthropic rejects the entire request if even one empty
+		// text block reaches it.
+		const userAssistantMessages = dropEmptyContentMessages(
+			this.messages.filter(
+				(msg) => msg.role === "user" || msg.role === "assistant"
+			)
 		);
 		const { messages: recentMessages, summaryBlock } =
 			await this.buildConversationContext(

--- a/src/durable-objects/chat.ts
+++ b/src/durable-objects/chat.ts
@@ -6,6 +6,7 @@ import { resolveClaimedPlayerContext } from "@/lib/agent-role-utils";
 import type { AgentType } from "@/lib/agent-router";
 import { AgentRouter } from "@/lib/agent-router";
 import { extractJwtFromHeader, sanitizeApiKey } from "@/lib/auth-utils";
+import { dropEmptyContentMessages } from "@/lib/chat-message-sanitization";
 import { getCampaignIdFromConversationId } from "@/lib/conversation-id-utils";
 import { getEnvVar } from "@/lib/env-utils";
 import {
@@ -270,6 +271,22 @@ export class Chat extends SimpleChatAgent<Env> {
 							...(data != null && { data }),
 						};
 					});
+					// A turn that only made tool calls — or that was interrupted before
+					// any text streamed — flattens to empty content above. Sending one
+					// of those makes the provider reject the whole request, and since
+					// the client replays the full history every turn, the conversation
+					// would never recover. Drop them at the door.
+					const flattened = this.messages;
+					this.messages = dropEmptyContentMessages(flattened);
+					if (this.messages.length !== flattened.length) {
+						createLogger(this.env as Record<string, unknown>, "[ChatDO]").debug(
+							"Dropped empty-content messages from incoming history",
+							{
+								dropped: flattened.length - this.messages.length,
+								kept: this.messages.length,
+							}
+						);
+					}
 					// Ensure last user message has jwt and campaignId for agent tools.
 					// Merge from body.data (transport sends these) and conversationId fallback.
 					const conversationId =

--- a/src/lib/chat-message-sanitization.ts
+++ b/src/lib/chat-message-sanitization.ts
@@ -1,0 +1,53 @@
+/**
+ * Guards against sending empty text content blocks to the LLM provider.
+ *
+ * Anthropic rejects any request containing a zero-length (or whitespace-only)
+ * text block with `400 messages: text content blocks must be non-empty`. The
+ * AI SDK renders a message whose `content` is a string as exactly one text
+ * block, so a single message with `content: ""` fails the whole call.
+ *
+ * That failure is not transient. The client replays the entire conversation on
+ * every turn, so one empty message makes every subsequent prompt in that
+ * conversation fail forever — the chat simply stops responding.
+ *
+ * Empty messages are normal and expected in the incoming payload: an assistant
+ * turn that only made tool calls, or one interrupted mid-stream before any text
+ * arrived, has no text part to flatten. Those carry nothing this string-based
+ * pipeline can use, so they are dropped rather than repaired.
+ */
+
+/** Minimal shape needed to decide whether a message can be sent. */
+export interface SanitizableMessage {
+	role: string;
+	content?: unknown;
+}
+
+/**
+ * True when the message would produce a non-empty text block.
+ *
+ * Whitespace-only content is treated as empty: the provider trims text blocks
+ * before validating them, so `" "` fails the same way `""` does.
+ */
+export function hasSendableContent(message: SanitizableMessage): boolean {
+	const { content } = message;
+	if (typeof content === "string") {
+		return content.trim().length > 0;
+	}
+	// Non-string content (structured blocks) is passed through untouched — this
+	// guard only knows how to reason about the flattened string form.
+	return content != null;
+}
+
+/**
+ * Drop messages that would serialize to an empty text block.
+ *
+ * Dropping can leave two same-role messages adjacent (e.g. a tool-only
+ * assistant turn removed from between two user turns). That is safe: the
+ * Anthropic provider merges consecutive same-role messages into one message
+ * with multiple content blocks.
+ */
+export function dropEmptyContentMessages<T extends SanitizableMessage>(
+	messages: T[]
+): T[] {
+	return messages.filter(hasSendableContent);
+}

--- a/tests/durable-objects/chat-empty-message-ingestion.test.ts
+++ b/tests/durable-objects/chat-empty-message-ingestion.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Chat } from "../../src/durable-objects/chat";
+
+vi.mock("@/lib/agent-role-utils", () => ({
+	resolveClaimedPlayerContext: vi.fn().mockResolvedValue(null),
+}));
+
+const mockEnv = {
+	DB: undefined as unknown as D1Database,
+	R2: {} as R2Bucket,
+	VECTORIZE: {} as any,
+	AI: {} as any,
+	JWT_SECRET: "test-jwt-secret",
+	CHAT: {} as DurableObjectNamespace,
+	UPLOAD_SESSION: {} as DurableObjectNamespace,
+	NOTIFICATIONS: {} as DurableObjectNamespace,
+	ASSETS: {} as any,
+	FILE_PROCESSING_QUEUE: {} as any,
+	FILE_PROCESSING_DLQ: {} as any,
+} as any;
+
+const mockCtx = {
+	env: mockEnv,
+	id: { toString: () => "ofisk-campaign-1" },
+	storage: {
+		get: vi.fn().mockResolvedValue(undefined),
+		put: vi.fn().mockResolvedValue(undefined),
+		delete: vi.fn().mockResolvedValue(undefined),
+	},
+} as any;
+
+/**
+ * A turn that only made tool calls, or that the user interrupted before any
+ * text streamed, arrives with no `text` part. Flattening it yields empty
+ * content, and Anthropic rejects the whole request with
+ * "messages: text content blocks must be non-empty". Because the client replays
+ * the entire conversation on every turn, one such message would make the
+ * conversation stop responding permanently.
+ */
+describe("Chat durable object empty-message ingestion", () => {
+	let chat: Chat;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		chat = new Chat(mockCtx, mockEnv);
+		// onRequest's job under test is building `this.messages`; the turn itself
+		// is stubbed out so no provider call is attempted.
+		(chat as any).onChatMessage = vi.fn().mockResolvedValue(new Response("ok"));
+	});
+
+	function post(messages: unknown[]): Promise<Response> {
+		return chat.onRequest(
+			new Request("https://test/api/agents/chat/ofisk-campaign-1", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ messages, data: { campaignId: "campaign-1" } }),
+			})
+		);
+	}
+
+	it("drops a tool-call-only assistant turn instead of sending empty content", async () => {
+		await post([
+			{ role: "user", parts: [{ type: "text", text: "list my NPCs" }] },
+			{
+				role: "assistant",
+				parts: [
+					{ type: "step-start" },
+					{ type: "tool-listAllEntities", state: "output-available" },
+				],
+			},
+			{
+				role: "user",
+				parts: [{ type: "text", text: "what's Grik's voice sound like?" }],
+			},
+		]);
+
+		const messages = (chat as any).messages as Array<{
+			role: string;
+			content: string;
+		}>;
+
+		expect(messages).toHaveLength(2);
+		expect(messages.every((m) => m.content.trim().length > 0)).toBe(true);
+		expect(messages[1].content).toBe("what's Grik's voice sound like?");
+	});
+
+	it("drops an interrupted assistant turn that streamed no text", async () => {
+		await post([
+			{ role: "user", parts: [{ type: "text", text: "tell me about Grik" }] },
+			{ role: "assistant", parts: [{ type: "text", text: "" }] },
+			{ role: "user", parts: [{ type: "text", text: "still there?" }] },
+		]);
+
+		const messages = (chat as any).messages as Array<{ content: string }>;
+
+		expect(messages.map((m) => m.content)).toEqual([
+			"tell me about Grik",
+			"still there?",
+		]);
+	});
+
+	it("still attaches jwt and campaignId to the surviving last user message", async () => {
+		await post([
+			{
+				role: "assistant",
+				parts: [{ type: "tool-searchCampaignContext", state: "output-error" }],
+			},
+			{ role: "user", parts: [{ type: "text", text: "who is Grik?" }] },
+		]);
+
+		const messages = (chat as any).messages as Array<{
+			role: string;
+			content: string;
+			data?: { campaignId?: string };
+		}>;
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0].role).toBe("user");
+		expect(messages[0].data?.campaignId).toBe("campaign-1");
+	});
+
+	it("keeps a conversation with no empty turns intact", async () => {
+		await post([
+			{ role: "user", parts: [{ type: "text", text: "hi" }] },
+			{ role: "assistant", parts: [{ type: "text", text: "hello there" }] },
+			{ role: "user", parts: [{ type: "text", text: "who is Grik?" }] },
+		]);
+
+		const messages = (chat as any).messages as Array<{ content: string }>;
+
+		expect(messages.map((m) => m.content)).toEqual([
+			"hi",
+			"hello there",
+			"who is Grik?",
+		]);
+	});
+});

--- a/tests/jsdom-scroll-polyfill.test.ts
+++ b/tests/jsdom-scroll-polyfill.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+/**
+ * jsdom ships no scroll methods, so `element.scrollTo(...)` throws
+ * "scrollTo is not a function". Chat auto-scroll calls it from a 100ms timer
+ * (src/hooks/useChatSession.ts), which can fire after the scheduling test has
+ * finished — the throw then lands as an unhandled error that fails the whole
+ * vitest run even when every test passed. tests/setup.ts installs a no-op so
+ * that cannot happen; this locks the polyfill in place.
+ */
+describe("jsdom scroll polyfill", () => {
+	it("makes scrollTo callable with the options form used by chat auto-scroll", () => {
+		const container = document.createElement("div");
+		document.body.appendChild(container);
+
+		expect(typeof container.scrollTo).toBe("function");
+		expect(() =>
+			container.scrollTo({ top: container.scrollHeight, behavior: "smooth" })
+		).not.toThrow();
+	});
+
+	it("survives a scroll scheduled by a timer that outlives its caller", async () => {
+		const container = document.createElement("div");
+		document.body.appendChild(container);
+
+		let thrown: unknown = null;
+		setTimeout(() => {
+			try {
+				container.scrollTo({ top: 100, behavior: "smooth" });
+			} catch (error) {
+				thrown = error;
+			}
+		}, 1);
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(thrown).toBeNull();
+	});
+});

--- a/tests/lib/chat-message-sanitization.test.ts
+++ b/tests/lib/chat-message-sanitization.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+	dropEmptyContentMessages,
+	hasSendableContent,
+} from "@/lib/chat-message-sanitization";
+
+/**
+ * Anthropic rejects a request outright when any message flattens to an empty
+ * text block, and the client replays the whole conversation every turn — so one
+ * empty message stops a conversation responding permanently, not just once.
+ */
+describe("chat message sanitization", () => {
+	describe("hasSendableContent", () => {
+		it("keeps messages with real text", () => {
+			expect(
+				hasSendableContent({ role: "user", content: "what's Grik's voice?" })
+			).toBe(true);
+		});
+
+		it("rejects empty string content", () => {
+			expect(hasSendableContent({ role: "assistant", content: "" })).toBe(
+				false
+			);
+		});
+
+		it("rejects whitespace-only content, which the provider trims to empty", () => {
+			expect(hasSendableContent({ role: "assistant", content: "  \n\t" })).toBe(
+				false
+			);
+		});
+
+		it("rejects missing content", () => {
+			expect(hasSendableContent({ role: "assistant" })).toBe(false);
+		});
+
+		it("passes through non-string content untouched", () => {
+			expect(
+				hasSendableContent({
+					role: "assistant",
+					content: [{ type: "text", text: "hi" }],
+				})
+			).toBe(true);
+		});
+	});
+
+	describe("dropEmptyContentMessages", () => {
+		it("removes the tool-call-only assistant turn that poisons the thread", () => {
+			const messages = [
+				{ role: "user", content: "list my NPCs" },
+				{ role: "assistant", content: "" },
+				{ role: "user", content: "what's Grik's voice sound like?" },
+			];
+
+			expect(dropEmptyContentMessages(messages)).toEqual([
+				{ role: "user", content: "list my NPCs" },
+				{ role: "user", content: "what's Grik's voice sound like?" },
+			]);
+		});
+
+		it("leaves a clean history untouched", () => {
+			const messages = [
+				{ role: "user", content: "hi" },
+				{ role: "assistant", content: "hello" },
+			];
+
+			expect(dropEmptyContentMessages(messages)).toEqual(messages);
+		});
+
+		it("preserves message properties beyond role and content", () => {
+			const messages = [
+				{ role: "user", content: "hi", data: { jwt: "token" } },
+				{ role: "assistant", content: "" },
+			];
+
+			expect(dropEmptyContentMessages(messages)).toEqual([
+				{ role: "user", content: "hi", data: { jwt: "token" } },
+			]);
+		});
+
+		it("returns an empty list when every message is empty", () => {
+			expect(
+				dropEmptyContentMessages([
+					{ role: "assistant", content: "" },
+					{ role: "assistant", content: " " },
+				])
+			).toEqual([]);
+		});
+	});
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -26,6 +26,19 @@ vi.mock("partyserver", () => ({
 	},
 }));
 
+// jsdom implements no scroll methods at all — `Element.prototype.scrollTo` is
+// simply absent, so any call throws "scrollTo is not a function". Chat auto-scroll
+// runs from a 100ms timer (src/hooks/useChatSession.ts), which on a slow enough
+// machine fires after the test that scheduled it has finished. The throw then
+// surfaces as an unhandled error that fails the whole run even though every test
+// passed — a real CI failure that does not reproduce on a fast local box.
+if (typeof Element !== "undefined" && !Element.prototype.scrollTo) {
+	Element.prototype.scrollTo = function scrollTo() {
+		// No layout in jsdom, so there is nothing to scroll; existing as a callable
+		// no-op is the entire contract these tests need.
+	};
+}
+
 // Custom matchers (since jest-dom may not be available)
 declare module "vitest" {
 	interface Assertion<T = any> {


### PR DESCRIPTION
## What

Production chat had stopped responding to prompts. Every turn failed the same way:

```
[CampaignContextAgent] Error: {"message":"messages: text content blocks must be non-empty",
                               "name":"AI_APICallError","statusCode":400}
```

Anthropic rejects a request outright if **any** message contains a zero-length text
block. `src/durable-objects/chat.ts` flattens each incoming client message to a string
and falls back to `content = ""` when the message has no `text` part — which is exactly
what an assistant turn that only made tool calls looks like, and what a turn interrupted
mid-stream (#757) looks like before any text arrives.

The AI SDK renders string `content` as one text block, so that empty message fails the
call. And because the client replays the entire conversation on every turn, the failure
is **permanent for that conversation**, not transient — which is why chat "stopped
responding" rather than intermittently erroring.

## Why this fix

Those turns carry nothing usable: this pipeline is string-content-only, so a tool-call-only
message contributes no text either way. Dropping them is the correct normalization, not a
lossy workaround. Dropping can leave two same-role messages adjacent, which is safe — the
Anthropic provider merges consecutive same-role messages into one message with multiple
content blocks.

Applied at two points:

- **`src/durable-objects/chat.ts`** — at ingestion, so the durable object's message array
  never holds a message that cannot be sent.
- **`src/agents/base-agent.ts`** — before the trailing-context window is built, so empty
  turns also stop consuming context slots and stop being fed to the conversation
  summarizer. This covers every agent, not just the one that surfaced the bug.

Shared logic lives in the new `src/lib/chat-message-sanitization.ts`. Whitespace-only
content is treated as empty, since the provider trims text blocks before validating them.

## Verification

- `npx vitest run` — 196 files, 1823 tests passing
- `npm run check` — clean (biome, import paths, tsc)
- `npx vitest run --coverage` — branches 73.78%, above the 70% gate
- Regression check: with the `chat.ts` fix stashed, 3 of the 4 new durable-object tests
  fail. They reproduce the actual production failure, they don't just assert the new code.

## How to see this change

```bash
gh pr checkout <PR#>
npx vitest run tests/durable-objects/chat-empty-message-ingestion.test.ts tests/lib/chat-message-sanitization.test.ts
```

**What you should see:** 13 passing tests. The meaningful one is
`drops a tool-call-only assistant turn instead of sending empty content` — it posts a
three-message history whose middle assistant turn has only `step-start` and `tool-*`
parts, and asserts the durable object keeps 2 messages, all with non-empty content.
Before this change that history became 3 messages with one empty, which is the exact
payload Anthropic rejected in production.

To see it end-to-end against the real provider, run the app locally per
`docs/DEV_SETUP.md` (`npm run dev:cloudflare`, then `npm run start`), open a campaign
chat, ask something that triggers a tool call, then send a follow-up prompt.
**Before:** the follow-up fails with the 400 above and the conversation never recovers.
**After:** the follow-up answers normally. I did not run this end-to-end path myself — I
diagnosed it from production `wrangler tail` output and reproduced it in tests.

## Note: unrelated production issue found while triaging

Prod D1 is missing two applied migrations: `0031_llm_cost_attribution.sql` and
`0032_llm_batch_jobs.sql` (`wrangler d1 migrations list loresmith-db --remote`). This is
the known "prod deploys ship the Worker but not the schema" gap. It is **not** the cause
of the chat outage — `LlmCostEventDAO` guards its writes with a `hasTable` check, so it
degrades silently rather than erroring. The effect is that cost-attribution and batch-job
telemetry are being dropped in production. Applying those migrations is a production
change, so it is left for a human to run and is out of scope for this PR.

No docs changed, so no wiki sync is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second commit: an unrelated CI flake this PR tripped

The first CI run failed `validate` with **all 1823 tests passing** but exit code 1:

```
TypeError: chatContainer.scrollTo is not a function
 ❯ Timeout._onTimeout src/hooks/useChatSession.ts:593:19
This error originated in "tests/hooks/useChatSession.test.ts"
```

jsdom implements no scroll methods, so `Element.prototype.scrollTo` is absent.
Chat auto-scroll calls it from a 100ms timer, and when that timer fires after the
test that scheduled it has finished, the throw surfaces as an unhandled error that
fails the run. It is timing-dependent — it does not reproduce locally, which is why
it slipped through. Nothing to do with the chat fix; this PR just ran slow enough
to hit it.

Fixed in `tests/setup.ts` with a no-op stub rather than by changing production code,
since jsdom's missing API is a test-environment gap, not an app bug.
`tests/jsdom-scroll-polyfill.test.ts` locks it in — with the setup change stashed,
both of its cases fail with the exact CI error above.
