### PR TITLE
build(deps): bump pdfjs-serverless to 1.3.0 and adapt the R2 range transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"mammoth": "^1.12.0",
 				"partyserver": "^0.5.5",
 				"pdf-lib": "^1.17.1",
-				"pdfjs-serverless": "^1.1.0",
+				"pdfjs-serverless": "^1.3.0",
 				"react": "19.2.8",
 				"react-dom": "19.2.8",
 				"react-joyride": "^3.1.0",
@@ -10112,10 +10112,13 @@
 			"license": "0BSD"
 		},
 		"node_modules/pdfjs-serverless": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pdfjs-serverless/-/pdfjs-serverless-1.1.0.tgz",
-			"integrity": "sha512-4JNsyupufenSUfFpMxCsrkfzeskWFS5J8ksXPeSnaaEug9h0bbBNuI+WqEpUGHMLGrORakMOvnc9mN9rqF7iqA==",
-			"license": "MIT"
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/pdfjs-serverless/-/pdfjs-serverless-1.3.0.tgz",
+			"integrity": "sha512-htY6ASkelVqb7+wBvxpQ2MzyyYq2s39ZCOFSOXHf5jrXC4UpDEhop+RM/CJ/3s5zkc8hn1P7KoDsvvOhYJfJZw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22"
+			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
 		"mammoth": "^1.12.0",
 		"partyserver": "^0.5.5",
 		"pdf-lib": "^1.17.1",
-		"pdfjs-serverless": "^1.1.0",
+		"pdfjs-serverless": "^1.3.0",
 		"react": "19.2.8",
 		"react-dom": "19.2.8",
 		"react-joyride": "^3.1.0",

--- a/src/lib/file/pdf-r2-range-transport.ts
+++ b/src/lib/file/pdf-r2-range-transport.ts
@@ -31,7 +31,8 @@ class R2PDFDataRangeTransport extends PDFDataRangeTransport {
 		super(length, null);
 		this.r2 = r2;
 		this.fileKey = fileKey;
-		this.transportReady();
+		// pdfjs-serverless >=1.3.0 calls transportReady(listener) itself from
+		// PDFDataTransportStream; subclasses must no longer invoke it.
 	}
 
 	override requestDataRange(begin: number, end: number): void {
@@ -92,8 +93,9 @@ export async function extractPdfPagesRangeFromR2(
 		);
 	}
 	const transport = new R2PDFDataRangeTransport(fileSize, r2, fileKey);
+	// `length` is no longer a DocumentInitParameters field in pdfjs-serverless
+	// >=1.3.0; it is read from the range transport (`transport.length`) instead.
 	const loadingTask = getDocument({
-		length: fileSize,
 		range: transport,
 		useSystemFonts: true,
 	});

--- a/tests/lib/file/pdf-r2-range-transport.test.ts
+++ b/tests/lib/file/pdf-r2-range-transport.test.ts
@@ -1,0 +1,107 @@
+import { PDFDocument, StandardFonts } from "pdf-lib";
+import { describe, expect, it } from "vitest";
+import { PROCESSING_LIMITS } from "@/app-constants";
+import { MemoryLimitError } from "@/lib/errors";
+import { extractPdfPagesRangeFromR2 } from "@/lib/file/pdf-r2-range-transport";
+
+/**
+ * Builds a small real PDF so the range transport is exercised against actual
+ * PDF bytes rather than a stub. Each page carries distinct text so we can tell
+ * which pages were extracted.
+ */
+async function buildPdf(pageTexts: string[]): Promise<Uint8Array> {
+	const doc = await PDFDocument.create();
+	const font = await doc.embedFont(StandardFonts.Helvetica);
+	for (const text of pageTexts) {
+		const page = doc.addPage([300, 200]);
+		page.drawText(text, { x: 20, y: 150, size: 14, font });
+	}
+	return doc.save();
+}
+
+/** Records every range request so we can assert the transport really ranged. */
+function fakeR2(bytes: Uint8Array) {
+	const ranges: Array<{ offset: number; length: number }> = [];
+	return {
+		ranges,
+		bucket: {
+			async get(
+				_key: string,
+				options?: { range?: { offset: number; length: number } }
+			) {
+				const slice = options?.range
+					? bytes.slice(
+							options.range.offset,
+							options.range.offset + options.range.length
+						)
+					: bytes;
+				if (options?.range) ranges.push(options.range);
+				return {
+					async arrayBuffer() {
+						// Copy into a standalone ArrayBuffer; pdf.js takes ownership.
+						return slice.slice().buffer as ArrayBuffer;
+					},
+				};
+			},
+		},
+	};
+}
+
+describe("extractPdfPagesRangeFromR2", () => {
+	it("extracts text over range requests without loading the whole file", async () => {
+		const bytes = await buildPdf([
+			"AlphaPageOne",
+			"BravoPageTwo",
+			"CharliePageThree",
+		]);
+		const { bucket, ranges } = fakeR2(bytes);
+
+		const result = await extractPdfPagesRangeFromR2(
+			bucket,
+			"uploads/sample.pdf",
+			bytes.length,
+			1,
+			2
+		);
+
+		expect(result.totalPages).toBe(3);
+		expect(result.pagesExtracted).toBe(2);
+		expect(result.text).toContain("AlphaPageOne");
+		expect(result.text).toContain("BravoPageTwo");
+		expect(result.text).not.toContain("CharliePageThree");
+		// pdf.js only asks for data once the transportReady handshake settles,
+		// so a non-empty range log proves the transport was actually driven.
+		expect(ranges.length).toBeGreaterThan(0);
+	});
+
+	it("clamps a page range that runs past the end of the document", async () => {
+		const bytes = await buildPdf(["OnlyPageHere"]);
+		const { bucket } = fakeR2(bytes);
+
+		const result = await extractPdfPagesRangeFromR2(
+			bucket,
+			"uploads/one-page.pdf",
+			bytes.length,
+			1,
+			99
+		);
+
+		expect(result.totalPages).toBe(1);
+		expect(result.pagesExtracted).toBe(1);
+		expect(result.text).toContain("OnlyPageHere");
+	});
+
+	it("rejects files above the range-processing size limit", async () => {
+		const { bucket } = fakeR2(new Uint8Array(0));
+
+		await expect(
+			extractPdfPagesRangeFromR2(
+				bucket,
+				"uploads/huge.pdf",
+				PROCESSING_LIMITS.MAX_PDF_SIZE_FOR_RANGE_BYTES + 1,
+				1,
+				1
+			)
+		).rejects.toBeInstanceOf(MemoryLimitError);
+	});
+});


### PR DESCRIPTION
Supersedes #774, which could not be merged: its `package.json` / `package-lock.json` conflicted with `main` after #777 (react bump) landed, and its `validate` job failed because 1.3.0 is a breaking API change. This branch is the same bump rebuilt on current `main` with the code fix included.

## What changed

`pdfjs-serverless` 1.3.0 changes two things `src/lib/file/pdf-r2-range-transport.ts` relied on:

1. **`length` is no longer a `DocumentInitParameters` field.** The document length is now read from the range transport (`transport.length`), which we already pass to the constructor. Passing it to `getDocument()` is a type error.
2. **`transportReady` inverted its handshake.** In 1.1.0 the subclass called `this.transportReady()` to signal readiness. In 1.3.0 `PDFDataTransportStream` calls `transport.transportReady(listener)` itself and hands down the callback it wants notified, so subclasses must no longer invoke it.

Both were the `validate` failures on #774:

```
src/lib/file/pdf-r2-range-transport.ts(34,8): error TS2554: Expected 1 arguments, but got 0.
src/lib/file/pdf-r2-range-transport.ts(96,3): error TS2353: 'length' does not exist in type 'DocumentInitParameters'.
```

**Both breaks are type-level only.** Ordering means our stray `transportReady()` ran before `getDocument`, so the library's later call overwrote the `undefined` we set — no runtime behavior changed, and no bug shipped. Removing the call is still correct: invoking it without a listener resolves the ready-promise before the real listener is attached, which is a latent race.

## Test coverage

`pdf-r2-range-transport.ts` had **no test coverage at all**, so this bump would have been merged on a green `tsc` alone. Added `tests/lib/file/pdf-r2-range-transport.test.ts`, which builds a real PDF with `pdf-lib`, serves it from a fake R2 that records every range request, and asserts text extraction, page-range clamping, and the size-limit rejection.

To be straight about its limits: this test would **not** have caught the `transportReady` change on its own, because that change is benign at runtime. It is coverage for a previously untested module, not a regression guard for this specific bump.

## Verification

- `npm run check` — pass
- `npm run test:coverage` — pass (197 files / 1864 tests; branches 74%+ vs the 70% floor)
- Merges cleanly into `main` as of dd1e04e2

## How to see this change

```bash
gh pr checkout <PR#>
npm install            # dependencies changed
npx vitest run tests/lib/file/pdf-r2-range-transport.test.ts
```

**What you should see:** 3 passing tests exercising the R2 range path against a real PDF. Before this branch, `npx tsc` fails with the two TS errors above; after it, `npm run check` is clean. There is no user-visible difference — large-PDF range extraction behaves exactly as it did on 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)