### PR TITLE
fix(audio): correct ElevenLabs contracts, add sfx kind, route voice to vendor (#756)

### DIFF
--- a/.dev.vars.template
+++ b/.dev.vars.template
@@ -17,14 +17,26 @@ OPENAI_API_KEY=your-openai-api-key-here
 
 # Generated audio (see docs/GENERATED_AUDIO.md).
 # NPC voices and creature sounds need none of these — they run on the Workers AI
-# binding. Scene ambience and theme music need an external sound/music model,
-# because the Workers AI catalog has neither. Leave these unset and those two
+# binding. Ambience, sound effects, and theme music need an external sound/music
+# model, because the Workers AI catalog has neither. Leave these unset and those
 # kinds report as unavailable in the UI with the reason; nothing breaks.
+#
+# All THREE are required together. The key alone does nothing: without a gateway
+# to route through, the provider stays inactive rather than calling the vendor
+# directly. Create a gateway at Cloudflare dashboard -> AI -> AI Gateway; the
+# account id and gateway id are both in that gateway's API endpoint URL.
 # ELEVENLABS_API_KEY=
 # AI_GATEWAY_ACCOUNT_ID=
 # AI_GATEWAY_ID=
 # Overrides the gateway URL entirely. For tests, or to point at another vendor.
 # AUDIO_GATEWAY_BASE_URL=
+# ElevenLabs voice id used for NPC dialogue. Defaults to a premade voice.
+# ELEVENLABS_VOICE_ID=
+# Setting the key above moves NPC voice onto ElevenLabs too, which is better but
+# bills per character on the highest-volume kind. Set this to `workers-ai` to
+# keep voice on the free first-party model while ambience/sfx/music use the
+# vendor.
+# AUDIO_VOICE_PROVIDER=
 
 # JWT signing secret (required for auth - use a random string)
 JWT_SECRET=your-jwt-secret-here

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -24,9 +24,10 @@ There is **no** separate GitHub Actions `deploy.yml` for production—Cloudflare
 **Optional (for username/password auth and email verification):** Set these as **secrets** the same way:
 - `RESEND_API_KEY` – Resend API key for verification emails. Without this, registration succeeds but no verification email is sent; users see a message directing them to use "Resend verification email" or contact support. To set for dev: `wrangler secret put RESEND_API_KEY --config wrangler.dev.jsonc`
 
-**Optional (for generated scene ambience and theme music):** Set these as **secrets** the same way. See [Generated audio](GENERATED_AUDIO.md).
-- `ELEVENLABS_API_KEY` – External sound/music model, reached through AI Gateway. Without it, NPC voices and creature sounds still work (they run on the Workers AI binding), but ambience and music report as unavailable in the UI with the reason. Nothing errors. To set for dev: `wrangler secret put ELEVENLABS_API_KEY --config wrangler.dev.jsonc`
-- `AI_GATEWAY_ACCOUNT_ID`, `AI_GATEWAY_ID` – Identify the AI Gateway the audio calls route through. Required alongside the key; without both, the provider stays inactive so no request can bypass the gateway.
+**Optional (for generated ambience, sound effects, and theme music):** Set these as **secrets** the same way. See [Generated audio](GENERATED_AUDIO.md).
+- `ELEVENLABS_API_KEY` – External sound/music model, reached through AI Gateway. Without it, NPC voices and creature sounds still work (they run on the Workers AI binding), but ambience, sound effects, and music report as unavailable in the UI with the reason. Nothing errors. To set for dev: `wrangler secret put ELEVENLABS_API_KEY --config wrangler.dev.jsonc`
+- `AI_GATEWAY_ACCOUNT_ID`, `AI_GATEWAY_ID` – Identify the AI Gateway the audio calls route through. **Required alongside the key** — the key on its own does nothing, because without both the provider stays inactive so no request can bypass the gateway. Create the gateway at Cloudflare dashboard → AI → AI Gateway; both ids appear in its API endpoint URL.
+- `AUDIO_VOICE_PROVIDER` *(optional)* – Setting the key above also moves NPC voice onto ElevenLabs, which bills per character on the highest-volume kind. Set this to `workers-ai` to keep voice on the free first-party model.
 
 **Dev Worker URL:** `https://loresmith-ai-dev.<account-subdomain>.workers.dev` (e.g. `https://loresmith-ai-dev.oren-t-fisk.workers.dev`). Check the Cloudflare dashboard or deploy logs for your exact URL.
 

--- a/docs/GENERATED_AUDIO.md
+++ b/docs/GENERATED_AUDIO.md
@@ -1,7 +1,8 @@
 # Generated audio
 
-Scene ambience, campaign theme music, and creature/NPC vocalizations, generated
-from campaign context, stored as campaign assets, and played at the table.
+Scene ambience, one-shot sound effects, campaign theme music, and creature/NPC
+vocalizations, generated from campaign context, stored as campaign assets, and
+played at the table.
 
 Issue: [#756](https://github.com/ofisk/loresmith-ai/issues/756).
 
@@ -15,8 +16,17 @@ currently contains.
 |---|---|---|
 | `voice` | A line of NPC dialogue, spoken | **Yes** — Deepgram Aura |
 | `creature` | A roar, a shriek, a whisper | **Approximated** — Aura is a voice model, not a sound-effect model |
-| `ambience` | Rain, a crypt, a tavern | **No** — needs an external sound model |
+| `ambience` | Rain, a crypt, a tavern — a bed that loops under a scene | **No** — needs an external sound model |
+| `sfx` | A door slam, a spell discharge — one shot, fired on a beat | **No** — needs an external sound model |
 | `music` | A campaign or villain theme | **No** — needs an external music model |
+
+`ambience` and `sfx` reach the same vendor endpoint but stay separate kinds
+because everything around them differs: an ambience bed is long, loops, and must
+survive a GM talking over it; an effect is short, transient, and fires once. They
+get different default durations, different loop defaults, and deliberately
+opposite prompts — one asks for "steady, no transitions", the other for "sharp
+transient, silence before and after". Collapsing them into one kind with a flag
+would make every one of those a caller's problem.
 
 So capability, not vendor preference, is what selects a provider. This is the
 one place the audio stack deliberately differs from
@@ -98,15 +108,26 @@ header.
 
 ### Looping is not `<audio loop>`
 
-Models emit short clips (the sound-effects endpoint caps at 22 seconds) but a
+Models emit short clips (the sound-effects endpoint caps at 30 seconds) but a
 scene at the table lasts ten minutes or more, so a clip has to wrap. `<audio
 loop>` leaves an audible gap at the seam because the element re-buffers on wrap;
 over a twenty-second bed that gap lands every twenty seconds and is the first
 thing a player notices.
 
-`LoopPlayer` therefore decodes to an `AudioBuffer` and schedules overlapping
-passes on the Web Audio clock, crossfading the tail of one into the head of the
-next. The crossfade curve is **equal-power** (`sin`/`cos`), not linear: for two
+Looping is therefore solved in two places, and the order matters:
+
+1. **Ask the model first.** The ElevenLabs v2 sound model accepts `loop: true`
+   and renders a clip whose end already matches its start. Any track stored as
+   `loopable` requests it. This is strictly better than fixing the seam at
+   playback, because no amount of fading reconciles a bed whose start and end
+   disagree.
+2. **Crossfade what comes back anyway.** `LoopPlayer` decodes to an
+   `AudioBuffer` and schedules overlapping passes on the Web Audio clock,
+   crossfading the tail of one pass into the head of the next. It still earns
+   its place: the Workers AI path has no loop flag, and a model asked for a
+   seamless wrap does not always deliver one.
+
+The crossfade curve is **equal-power** (`sin`/`cos`), not linear: for two
 uncorrelated signals a linear fade dips about 3 dB at the midpoint, which is
 heard as a dropout exactly at the loop point — the artifact the crossfade exists
 to remove.
@@ -148,18 +169,60 @@ which model made it.
 
 Voice and creature work with no configuration beyond the existing `AI` binding.
 
-Ambience and music require an external provider through Cloudflare AI Gateway,
-and are **inert until configured**. With `ELEVENLABS_API_KEY` unset, the provider
-is never constructed, the factory reports those kinds unavailable, and the UI
-explains why. Merging this feature commits the project to no vendor and no
+Ambience, effects, and music require an external provider through Cloudflare AI
+Gateway, and are **inert until configured**. With `ELEVENLABS_API_KEY` unset, the
+provider is never constructed, the factory reports those kinds unavailable, and
+the UI explains why. Merging this feature commits the project to no vendor and no
 spend; setting the secret is the deliberate act that turns it on.
 
-| Variable | Purpose |
-|---|---|
-| `ELEVENLABS_API_KEY` | Vendor key. Absent → ambience and music stay unavailable. |
-| `AI_GATEWAY_ACCOUNT_ID` | Cloudflare account id for the gateway path. |
-| `AI_GATEWAY_ID` | AI Gateway id. |
-| `AUDIO_GATEWAY_BASE_URL` | Overrides the gateway URL. For tests, or a different vendor. |
+| Variable | Required | Purpose |
+|---|---|---|
+| `ELEVENLABS_API_KEY` | Yes | Vendor key. Absent → ambience, sfx, and music stay unavailable. |
+| `AI_GATEWAY_ACCOUNT_ID` | Yes | Cloudflare account id for the gateway path. |
+| `AI_GATEWAY_ID` | Yes | AI Gateway id. |
+| `ELEVENLABS_VOICE_ID` | No | Voice used for NPC dialogue. Defaults to a premade voice. |
+| `AUDIO_VOICE_PROVIDER` | No | Set to `workers-ai` to keep NPC voice on the free model. |
+| `AUDIO_GATEWAY_BASE_URL` | No | Overrides the gateway URL. For tests, or a different vendor. |
+
+**An API key on its own does nothing.** All three required variables must be set
+together: without a gateway to route through, `createGatewayAudioProvider`
+returns `null` rather than falling back to calling the vendor directly. That is
+deliberate — the gateway is the whole reason the dependency is defensible, so
+there is no configuration in which a request silently bypasses it. Create one at
+**Cloudflare dashboard → AI → AI Gateway**; the account id and gateway id are
+both visible in that gateway's API endpoint URL.
+
+### Which endpoint each kind uses
+
+The vendor's contract is pinned by tests in `tests/services/audio-providers.test.ts`,
+because a wrong `model_id` is a 422 from the live service and a perfectly green
+local suite.
+
+| Kind | Endpoint | Model |
+|---|---|---|
+| `ambience`, `sfx`, `creature` | `/v1/sound-generation` | `eleven_text_to_sound_v2` |
+| `music` | `/v1/music` | `music_v1` |
+| `voice` | `/v1/text-to-speech/{voice_id}` | `eleven_multilingual_v2` |
+
+Two vendor behaviours are overridden on every request. Music is generated with
+`force_instrumental` on, because Eleven Music sings by default and a track with
+an AI vocalist is unusable under a GM who is themselves talking. Output format is
+requested explicitly as `mp3_44100_128` rather than left to the vendor default,
+because the reported track duration is derived by dividing byte length by that
+exact bitrate — a silent default change would silently corrupt every duration and
+every second of metered spend.
+
+### What configuring a vendor changes about voice
+
+Setting the key does not only enable the three unavailable kinds; it also moves
+`voice` and `creature` off Workers AI, because a dedicated speech model is
+audibly better than steering a generic TTS voice.
+
+That is worth a deliberate decision rather than a silent upgrade. Voice is the
+one kind whose volume is unbounded — ambience and music are generated a handful
+of times per campaign, but NPC dialogue is per line, and ElevenLabs bills per
+character. `AUDIO_VOICE_PROVIDER=workers-ai` pins voice back to the free
+first-party model while leaving ambience, effects, and music on the vendor.
 
 Routing through AI Gateway rather than calling the vendor directly is what makes
 the dependency defensible: caching, rate limiting, logging, and cost visibility

--- a/src/components/campaign-audio/AudioTrackRow.tsx
+++ b/src/components/campaign-audio/AudioTrackRow.tsx
@@ -30,6 +30,7 @@ function formatDuration(seconds: number | null): string {
 
 const KIND_LABEL: Record<string, string> = {
 	ambience: "Ambience",
+	sfx: "Effect",
 	music: "Music",
 	creature: "Creature",
 	voice: "Voice",

--- a/src/components/campaign-audio/CampaignAudioPanel.tsx
+++ b/src/components/campaign-audio/CampaignAudioPanel.tsx
@@ -12,6 +12,7 @@ interface CampaignAudioPanelProps {
 
 const KIND_LABEL: Record<AudioKind, string> = {
 	ambience: "Scene ambience",
+	sfx: "Sound effect",
 	music: "Theme music",
 	creature: "Creature sound",
 	voice: "NPC voice",
@@ -19,6 +20,7 @@ const KIND_LABEL: Record<AudioKind, string> = {
 
 const KIND_PLACEHOLDER: Record<AudioKind, string> = {
 	ambience: "a flooded crypt, dripping water and distant chittering",
+	sfx: "a heavy iron portcullis slamming shut",
 	music: "the villain's theme — dread, low strings",
 	creature: "a wet, throaty roar from something very large",
 	voice: "Type the exact line the NPC should say",

--- a/src/lib/llm-usage-intents.ts
+++ b/src/lib/llm-usage-intents.ts
@@ -17,10 +17,11 @@
  * | conversation_summary | Rolling summarization of older chat turns |
  * | agent_routing | Agent selection classifier (per-message routing tax) |
  * | audio_ambience | Generated scene ambience (per second of audio, not tokens) |
+ * | audio_sfx | Generated one-shot sound effects (per second) |
  * | audio_music | Generated campaign/faction theme music (per second) |
  * | audio_voice | NPC voice and creature vocalization TTS (per second) |
  *
- * The three `audio_*` intents share this vocabulary so audio lands in the same
+ * The four `audio_*` intents share this vocabulary so audio lands in the same
  * per-intent cost view as everything else, but they are metered in SECONDS of
  * output rather than tokens — see `logVerboseAudioSpend` in
  * `src/lib/llm-usage-verbose-log.ts`. Do not add them to token-based totals.
@@ -39,6 +40,7 @@ export const LLM_SPEND_INTENT = {
 	conversation_summary: "conversation_summary",
 	agent_routing: "agent_routing",
 	audio_ambience: "audio_ambience",
+	audio_sfx: "audio_sfx",
 	audio_music: "audio_music",
 	audio_voice: "audio_voice",
 } as const;
@@ -55,6 +57,7 @@ export type LlmSpendIntent =
  */
 export const AUDIO_KIND_SPEND_INTENT = {
 	ambience: LLM_SPEND_INTENT.audio_ambience,
+	sfx: LLM_SPEND_INTENT.audio_sfx,
 	music: LLM_SPEND_INTENT.audio_music,
 	voice: LLM_SPEND_INTENT.audio_voice,
 	creature: LLM_SPEND_INTENT.audio_voice,

--- a/src/lib/prompts/audio-prompts.ts
+++ b/src/lib/prompts/audio-prompts.ts
@@ -206,6 +206,30 @@ function buildAmbiencePrompt(input: BuildAudioPromptInput): string {
 }
 
 /**
+ * A one-shot sound effect: a door slam, a spell discharge, a blade on shield.
+ *
+ * The inverse of the ambience prompt in every respect, which is why it is a
+ * separate builder rather than a flag. Ambience asks for something steady with
+ * no transitions, because it plays under a GM talking; an effect is *entirely*
+ * transient, and asking for a loopable bed would produce a five-second wash
+ * where a single sharp hit was wanted. Campaign context is used sparingly here —
+ * a door slam does not need the campaign's tone, and mining the entity graph for
+ * atmosphere would smear the hit into a bed.
+ */
+function buildSfxPrompt(input: BuildAudioPromptInput): string {
+	const subject =
+		input.hint?.trim() || input.entity?.name || input.scene || "sound effect";
+
+	const parts = [
+		`Single isolated sound effect for a tabletop RPG: ${subject}.`,
+		"One discrete event, close and dry, sharp transient, silence before and after.",
+		"No music, no speech, no continuous background ambience.",
+	];
+
+	return clamp(parts.join(" "));
+}
+
+/**
  * Campaign theme music: instrumentation and mood, plus an explicit request for a
  * short recognizable motif.
  *
@@ -272,6 +296,8 @@ export function buildAudioPrompt(input: BuildAudioPromptInput): string {
 	switch (input.kind) {
 		case "ambience":
 			return buildAmbiencePrompt(input);
+		case "sfx":
+			return buildSfxPrompt(input);
 		case "music":
 			return buildMusicPrompt(input);
 		case "creature":
@@ -295,6 +321,7 @@ export function buildAudioTitle(input: BuildAudioPromptInput): string {
 
 	const label: Record<AudioKind, string> = {
 		ambience: "Ambience",
+		sfx: "Effect",
 		music: "Theme",
 		creature: "Sound",
 		voice: "Voice",

--- a/src/routes/campaign-audio.ts
+++ b/src/routes/campaign-audio.ts
@@ -15,7 +15,7 @@ import {
 	prepareAudioGeneration,
 } from "@/services/audio/audio-generation-service";
 import type { AudioKind, CampaignAudioRecord } from "@/types/campaign-audio";
-import { isAudioKind } from "@/types/campaign-audio";
+import { AUDIO_KINDS, isAudioKind } from "@/types/campaign-audio";
 
 /**
  * Generated campaign audio (issue #756).
@@ -139,8 +139,10 @@ function validateGenerateBody(
 	body: GenerateAudioBody
 ): Response | null {
 	if (!isAudioKind(body.kind)) {
+		// Listed from the source of truth rather than spelled out, so adding a kind
+		// cannot leave this message quietly describing the old set.
 		return c.json(
-			{ error: "kind must be one of: ambience, music, creature, voice" },
+			{ error: `kind must be one of: ${AUDIO_KINDS.join(", ")}` },
 			400
 		);
 	}

--- a/src/services/audio/audio-generation-service.ts
+++ b/src/services/audio/audio-generation-service.ts
@@ -61,6 +61,8 @@ export interface GenerateAudioRequest {
 	/** Provider voice/speaker id for the speech kinds. */
 	voice?: string | null;
 	durationSec?: number | null;
+	/** For `music`: allow vocals. Defaults to instrumental, which tables want. */
+	instrumental?: boolean | null;
 	title?: string | null;
 	description?: string | null;
 	loopable?: boolean | null;
@@ -79,6 +81,8 @@ const AUDIO_SECRET_KEYS = [
 	"AI_GATEWAY_ACCOUNT_ID",
 	"AI_GATEWAY_ID",
 	"AUDIO_GATEWAY_BASE_URL",
+	"ELEVENLABS_VOICE_ID",
+	"AUDIO_VOICE_PROVIDER",
 ] as const;
 
 /**
@@ -283,6 +287,11 @@ export async function runAudioGeneration(
 			prompt: record.prompt,
 			durationSec: request.durationSec ?? undefined,
 			voice: request.voice ?? undefined,
+			// Taken from the persisted row, not the request: `loopable` is where the
+			// per-kind default was already resolved, so asking the model to render a
+			// seamless wrap and marking the track as looping can never disagree.
+			loop: record.loopable,
+			instrumental: request.instrumental ?? undefined,
 		});
 
 		const r2Key = buildAudioR2Key(record.campaignId, record.id);

--- a/src/services/audio/audio-provider-factory.ts
+++ b/src/services/audio/audio-provider-factory.ts
@@ -18,14 +18,21 @@ import { WorkersAiTtsProvider } from "./workers-ai-tts-provider";
  * model at all, so the *capability* is what selects the provider, and a kind can
  * legitimately have no provider.
  *
- * Preference order per kind is "first-party if it can do the job, external
- * otherwise". The one nuance is `creature`: Workers AI can approximate a growl by
- * steering a low TTS voice, but a real sound model does it properly, so the
- * gateway provider wins that kind when configured.
+ * Preference order is "external provider if configured, first-party otherwise".
+ * An external key is only ever present because someone deliberately set it, and
+ * a dedicated audio vendor beats a general TTS model on every kind it serves —
+ * including `creature`, where Workers AI can only approximate a growl by
+ * steering a low TTS voice. Workers AI remains the floor, so removing the key
+ * degrades the feature to voice and creature rather than breaking it.
  */
 
 export interface AudioProviderEnv extends GatewayAudioEnv {
 	AI?: WorkersAiBinding;
+	/**
+	 * Pin `voice` to a specific provider. Only `workers-ai` is meaningful; it
+	 * forces NPC dialogue onto the free first-party model. See `preferenceFor`.
+	 */
+	AUDIO_VOICE_PROVIDER?: string;
 }
 
 export interface AudioCapability {
@@ -43,6 +50,7 @@ const UNAVAILABLE_REASON: Record<AudioKind, string> = {
 		"Creature sounds are unavailable because neither the Workers AI binding nor an external audio provider is configured.",
 	ambience:
 		"Scene ambience needs a sound-effect model. Cloudflare Workers AI does not offer one yet, and no external audio provider is configured for this environment.",
+	sfx: "Sound effects need a sound-effect model. Cloudflare Workers AI does not offer one yet, and no external audio provider is configured for this environment.",
 	music:
 		"Theme music needs a music model. Cloudflare Workers AI does not offer one yet, and no external audio provider is configured for this environment.",
 };
@@ -63,15 +71,29 @@ function buildCandidates(env: AudioProviderEnv): AudioProvider[] {
 }
 
 /**
- * Speech kinds should prefer Workers AI (free-tier, first-party, no vendor);
- * sound and music kinds have no first-party option, so they take whatever
- * supports them.
+ * Pick the provider for a kind from the candidates that can serve it.
+ *
+ * `voice` is the only kind with a real choice, and the choice is a cost/quality
+ * tradeoff rather than a capability one. Configuring an external provider is
+ * taken as opting into it — a GM who supplied an ElevenLabs key wants ElevenLabs
+ * voices, and a dedicated speech model is audibly better than steering a generic
+ * TTS voice.
+ *
+ * That default is deliberately reversible, because voice is the one kind whose
+ * volume is unbounded: ambience and music are generated a handful of times per
+ * campaign, but NPC dialogue is per line, and it bills per character. Setting
+ * `AUDIO_VOICE_PROVIDER=workers-ai` pins voice back to the free first-party
+ * model while leaving ambience, effects, and music on the vendor.
  */
-function preferenceFor(kind: AudioKind, providers: AudioProvider[]) {
+function preferenceFor(
+	kind: AudioKind,
+	providers: AudioProvider[],
+	env: AudioProviderEnv
+) {
 	const supporting = providers.filter((p) => p.supports(kind));
 	if (supporting.length === 0) return null;
 
-	if (kind === "voice") {
+	if (kind === "voice" && env.AUDIO_VOICE_PROVIDER === "workers-ai") {
 		return supporting.find((p) => p.name === "workers-ai") ?? supporting[0];
 	}
 	return supporting[0];
@@ -81,7 +103,7 @@ export function resolveAudioProvider(
 	env: AudioProviderEnv,
 	kind: AudioKind
 ): AudioProvider {
-	const provider = preferenceFor(kind, buildCandidates(env));
+	const provider = preferenceFor(kind, buildCandidates(env), env);
 	if (!provider) {
 		throw new AudioKindUnavailableError(kind, UNAVAILABLE_REASON[kind]);
 	}
@@ -101,7 +123,7 @@ export function describeAudioCapabilities(
 	const providers = buildCandidates(env);
 
 	return AUDIO_KINDS.map((kind) => {
-		const provider = preferenceFor(kind, providers);
+		const provider = preferenceFor(kind, providers, env);
 		return {
 			kind,
 			available: provider !== null,

--- a/src/services/audio/audio-provider.ts
+++ b/src/services/audio/audio-provider.ts
@@ -20,6 +20,16 @@ export interface AudioGenerationRequest {
 	durationSec?: number;
 	/** Provider-specific voice/speaker id, for the speech kinds. */
 	voice?: string;
+	/**
+	 * Ask the model to render a bed that wraps seamlessly.
+	 *
+	 * A hint, not a guarantee — providers that cannot do it ignore it, and
+	 * playback still crossfades. Worth asking for anyway: a model that renders the
+	 * loop point itself beats any amount of fading at the seam.
+	 */
+	loop?: boolean;
+	/** For `music`: suppress vocals. Defaults to instrumental for table use. */
+	instrumental?: boolean;
 }
 
 export interface GeneratedAudio {

--- a/src/services/audio/gateway-audio-provider.ts
+++ b/src/services/audio/gateway-audio-provider.ts
@@ -9,41 +9,76 @@ import {
 } from "./audio-provider";
 
 /**
- * Scene ambience and campaign theme music, routed through Cloudflare AI Gateway
- * to an external audio model (issue #756).
+ * Scene ambience, sound effects, creature vocalizations, theme music, and NPC
+ * voices, routed through Cloudflare AI Gateway to ElevenLabs (issue #756).
  *
  * Why this exists at all: the Workers AI catalog has no text-to-music and no
- * text-to-sound-effect model, so these two kinds cannot be served first-party.
+ * text-to-sound-effect model, so those kinds cannot be served first-party.
  * Going through AI Gateway rather than calling the vendor directly keeps caching,
  * rate limiting, logging, and cost visibility on Cloudflare — which matters more
  * for audio than for text, because a single generation costs orders of magnitude
  * more than a completion and identical scene prompts recur constantly across
  * campaigns ("tavern murmur", "rain on stone").
  *
- * This provider is INERT UNLESS CONFIGURED. Merging it commits the project to no
- * vendor and no spend: with `ELEVENLABS_API_KEY` unset, `createGatewayAudioProvider`
- * returns null, the factory reports ambience and music as unavailable, and the UI
- * explains why. Setting the secret is the deliberate act that turns it on.
+ * This provider is INERT UNLESS CONFIGURED. With `ELEVENLABS_API_KEY` unset,
+ * `createGatewayAudioProvider` returns null, the factory reports the sound and
+ * music kinds as unavailable, and the UI explains why. Setting the secret is the
+ * deliberate act that turns it on.
+ *
+ * Three different ElevenLabs endpoints back the five kinds, which is why
+ * `buildRequest` dispatches per kind rather than the request being uniform:
+ *
+ * | Kind                    | Endpoint               | Model                     |
+ * |-------------------------|------------------------|---------------------------|
+ * | ambience, sfx, creature | `/v1/sound-generation` | `eleven_text_to_sound_v2` |
+ * | music                   | `/v1/music`            | `music_v1`                |
+ * | voice                   | `/v1/text-to-speech`   | `eleven_multilingual_v2`  |
  */
 
-const SUPPORTED_KINDS: readonly AudioKind[] = ["ambience", "music", "creature"];
+const SUPPORTED_KINDS: readonly AudioKind[] = [
+	"ambience",
+	"sfx",
+	"music",
+	"creature",
+	"voice",
+];
 
 /**
- * ElevenLabs' sound-effects endpoint caps a single generation at 22 seconds.
- * Table use wants minutes, so the player loops a short bed client-side rather
- * than this provider attempting a long generation it cannot produce.
+ * Sound Effects v2 caps a single generation at 30 seconds. Table use wants
+ * minutes, so a short bed is generated and looped rather than this provider
+ * attempting a long generation the model cannot produce.
  */
-export const MAX_SOUND_EFFECT_SEC = 22;
+export const MAX_SOUND_EFFECT_SEC = 30;
 
 /** Default bed length: long enough that a loop is not obviously repetitive. */
-export const DEFAULT_AMBIENCE_SEC = 20;
+export const DEFAULT_AMBIENCE_SEC = 22;
 
-/** Music generations are longer-form; the endpoint accepts up to 5 minutes. */
+/** A one-shot effect wants to be short; a 20-second door slam is not a door slam. */
+export const DEFAULT_SFX_SEC = 5;
+
+/**
+ * The `/v1/music` endpoint accepts 3s–600s. The ceiling here is deliberately
+ * lower than the API's: music is the most expensive kind per generation, and a
+ * five-minute loop already outlasts any scene a GM plays it under.
+ */
 export const MAX_MUSIC_SEC = 300;
+export const MIN_MUSIC_SEC = 10;
 export const DEFAULT_MUSIC_SEC = 60;
 
-/** ElevenLabs returns 128 kbps MP3 by default. */
+/**
+ * Requested explicitly rather than relying on the vendor default, because the
+ * duration estimate below divides by this exact bitrate — a silent default
+ * change would silently corrupt every reported track length.
+ */
+const OUTPUT_FORMAT = "mp3_44100_128";
 const ELEVENLABS_MP3_BITS_PER_SECOND = 128_000;
+
+/** Default premade ElevenLabs voice, overridable per request via `voice`. */
+export const DEFAULT_ELEVENLABS_VOICE_ID = "JBFqnCBsd6RMkjVDRZzb";
+
+export const DEFAULT_SOUND_MODEL = "eleven_text_to_sound_v2";
+export const DEFAULT_MUSIC_MODEL = "music_v1";
+export const DEFAULT_SPEECH_MODEL = "eleven_multilingual_v2";
 
 export interface GatewayAudioProviderConfig {
 	apiKey: string;
@@ -51,6 +86,8 @@ export interface GatewayAudioProviderConfig {
 	baseUrl: string;
 	soundModel?: string;
 	musicModel?: string;
+	speechModel?: string;
+	voiceId?: string;
 }
 
 /** Env keys this provider reads. All must be present for it to activate. */
@@ -60,6 +97,8 @@ export interface GatewayAudioEnv {
 	AI_GATEWAY_ID?: string;
 	/** Escape hatch for tests and for pointing at a different gateway/vendor. */
 	AUDIO_GATEWAY_BASE_URL?: string;
+	/** Default ElevenLabs voice id for `kind=voice`. */
+	ELEVENLABS_VOICE_ID?: string;
 }
 
 export function buildGatewayBaseUrl(env: GatewayAudioEnv): string | null {
@@ -85,7 +124,17 @@ export function createGatewayAudioProvider(
 	const baseUrl = buildGatewayBaseUrl(env);
 	if (!baseUrl) return null;
 
-	return new GatewayAudioProvider({ apiKey, baseUrl });
+	return new GatewayAudioProvider({
+		apiKey,
+		baseUrl,
+		voiceId: env.ELEVENLABS_VOICE_ID,
+	});
+}
+
+interface VendorRequest {
+	path: string;
+	model: string;
+	body: Record<string, unknown>;
 }
 
 export class GatewayAudioProvider implements AudioProvider {
@@ -93,10 +142,14 @@ export class GatewayAudioProvider implements AudioProvider {
 
 	private readonly soundModel: string;
 	private readonly musicModel: string;
+	private readonly speechModel: string;
+	private readonly voiceId: string;
 
 	constructor(private readonly config: GatewayAudioProviderConfig) {
-		this.soundModel = config.soundModel ?? "eleven_text_to_sound_v2";
-		this.musicModel = config.musicModel ?? "eleven_music_v1";
+		this.soundModel = config.soundModel ?? DEFAULT_SOUND_MODEL;
+		this.musicModel = config.musicModel ?? DEFAULT_MUSIC_MODEL;
+		this.speechModel = config.speechModel ?? DEFAULT_SPEECH_MODEL;
+		this.voiceId = config.voiceId || DEFAULT_ELEVENLABS_VOICE_ID;
 	}
 
 	supports(kind: AudioKind): boolean {
@@ -111,31 +164,7 @@ export class GatewayAudioProvider implements AudioProvider {
 			);
 		}
 
-		const isMusic = request.kind === "music";
-		const durationSec = this.clampDuration(request.kind, request.durationSec);
-		const { path, body, model } = isMusic
-			? {
-					path: "/v1/music",
-					model: this.musicModel,
-					body: {
-						prompt: request.prompt,
-						music_length_ms: Math.round(durationSec * 1000),
-						model_id: this.musicModel,
-					},
-				}
-			: {
-					path: "/v1/sound-generation",
-					model: this.soundModel,
-					body: {
-						text: request.prompt,
-						duration_seconds: durationSec,
-						// Bias toward following the prompt over the model's own aesthetic;
-						// a GM asking for "dripping water" wants dripping water.
-						prompt_influence: 0.6,
-						model_id: this.soundModel,
-					},
-				};
-
+		const { path, body, model } = this.buildRequest(request);
 		const response = await this.post(path, body);
 		const bytes = await toAudioBytes(response);
 
@@ -146,24 +175,83 @@ export class GatewayAudioProvider implements AudioProvider {
 		return {
 			bytes,
 			contentType: "audio/mpeg",
-			// The request duration is authoritative here — the vendor generates to
-			// the requested length — but confirm against the encoded size so a
-			// truncated response is not reported as a full-length track.
+			// Derived from encoded size rather than trusted from the request, so a
+			// truncated response is not reported — or billed — as a full-length track.
 			durationSec:
 				estimateDurationSec(bytes.byteLength, ELEVENLABS_MP3_BITS_PER_SECOND) ??
-				durationSec,
+				null,
 			durationIsEstimate: true,
 			model,
 		};
 	}
 
-	private clampDuration(kind: AudioKind, requested?: number): number {
-		if (kind === "music") {
-			const value = requested ?? DEFAULT_MUSIC_SEC;
-			return Math.min(Math.max(value, 10), MAX_MUSIC_SEC);
+	/** Dispatch to the right ElevenLabs endpoint for the kind. */
+	private buildRequest(request: AudioGenerationRequest): VendorRequest {
+		if (request.kind === "music") return this.buildMusicRequest(request);
+		if (request.kind === "voice") return this.buildSpeechRequest(request);
+		return this.buildSoundRequest(request);
+	}
+
+	private buildMusicRequest(request: AudioGenerationRequest): VendorRequest {
+		const durationSec = clampRange(
+			request.durationSec ?? DEFAULT_MUSIC_SEC,
+			MIN_MUSIC_SEC,
+			MAX_MUSIC_SEC
+		);
+		return {
+			path: "/v1/music",
+			model: this.musicModel,
+			body: {
+				prompt: request.prompt,
+				music_length_ms: Math.round(durationSec * 1000),
+				model_id: this.musicModel,
+				// Eleven Music sings by default. A theme with an AI vocalist over it is
+				// unusable at a table, where the GM is the only voice that should be
+				// heard, so instrumental is forced unless a caller opts out.
+				force_instrumental: request.instrumental ?? true,
+			},
+		};
+	}
+
+	private buildSpeechRequest(request: AudioGenerationRequest): VendorRequest {
+		const voice = request.voice || this.voiceId;
+		return {
+			path: `/v1/text-to-speech/${encodeURIComponent(voice)}`,
+			model: this.speechModel,
+			body: {
+				// For speech the prompt IS the line to speak — see `buildVoicePrompt`.
+				text: request.prompt,
+				model_id: this.speechModel,
+			},
+		};
+	}
+
+	private buildSoundRequest(request: AudioGenerationRequest): VendorRequest {
+		const fallback =
+			request.kind === "ambience" ? DEFAULT_AMBIENCE_SEC : DEFAULT_SFX_SEC;
+		const durationSec = clampRange(
+			request.durationSec ?? fallback,
+			1,
+			MAX_SOUND_EFFECT_SEC
+		);
+
+		const body: Record<string, unknown> = {
+			text: request.prompt,
+			duration_seconds: durationSec,
+			// Bias toward following the prompt over the model's own aesthetic;
+			// a GM asking for "dripping water" wants dripping water.
+			prompt_influence: 0.6,
+			model_id: this.soundModel,
+		};
+
+		// The v2 sound model can render a bed that wraps seamlessly, which is
+		// strictly better than crossfading a non-looping one at playback time. The
+		// flag is rejected by v1, so it is only sent when the model can take it.
+		if (request.loop && this.soundModel === DEFAULT_SOUND_MODEL) {
+			body.loop = true;
 		}
-		const value = requested ?? DEFAULT_AMBIENCE_SEC;
-		return Math.min(Math.max(value, 1), MAX_SOUND_EFFECT_SEC);
+
+		return { path: "/v1/sound-generation", model: this.soundModel, body };
 	}
 
 	private async post(
@@ -172,15 +260,18 @@ export class GatewayAudioProvider implements AudioProvider {
 	): Promise<Response> {
 		let response: Response;
 		try {
-			response = await fetch(`${this.config.baseUrl}${path}`, {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					"xi-api-key": this.config.apiKey,
-					Accept: "audio/mpeg",
-				},
-				body: JSON.stringify(body),
-			});
+			response = await fetch(
+				`${this.config.baseUrl}${path}?output_format=${OUTPUT_FORMAT}`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"xi-api-key": this.config.apiKey,
+						Accept: "audio/mpeg",
+					},
+					body: JSON.stringify(body),
+				}
+			);
 		} catch (error) {
 			throw new AudioGenerationError(
 				this.name,
@@ -200,4 +291,8 @@ export class GatewayAudioProvider implements AudioProvider {
 
 		return response;
 	}
+}
+
+function clampRange(value: number, min: number, max: number): number {
+	return Math.min(Math.max(value, min), max);
 }

--- a/src/tools/campaign-context/audio-tools.ts
+++ b/src/tools/campaign-context/audio-tools.ts
@@ -128,7 +128,7 @@ const generateAudioSchema = z.object({
 	kind: z
 		.enum(AUDIO_KINDS)
 		.describe(
-			"ambience for background scene sound, music for a theme, creature for a monster vocalization, voice for spoken NPC dialogue"
+			"ambience for a continuous background bed under a scene, sfx for a one-shot sound effect fired on a beat (a door slam, a spell discharge), music for a theme, creature for a monster vocalization, voice for spoken NPC dialogue"
 		),
 	hint: z
 		.string()
@@ -140,7 +140,7 @@ const generateAudioSchema = z.object({
 		.string()
 		.optional()
 		.describe(
-			"Entity to draw detail from — a location for ambience, a monster for creature sound, an NPC for voice"
+			"Entity to draw detail from — a location for ambience, a monster for creature sound, an NPC for voice. Effects rarely need one."
 		),
 	scene: z
 		.string()
@@ -193,7 +193,7 @@ function toGenerationRequest(
 
 export const generateCampaignAudioTool = tool({
 	description:
-		"Generate a campaign audio track (scene ambience, theme music, creature sound, or spoken NPC dialogue) from campaign context. Generation is asynchronous — this starts the job and the GM is notified when the track is ready. GM-only.",
+		"Generate a campaign audio track (scene ambience, a one-shot sound effect, theme music, a creature sound, or spoken NPC dialogue) from campaign context. Generation is asynchronous — this starts the job and the GM is notified when the track is ready. GM-only.",
 	inputSchema: generateAudioSchema,
 	execute: async (
 		input: z.infer<typeof generateAudioSchema>,

--- a/src/types/campaign-audio.ts
+++ b/src/types/campaign-audio.ts
@@ -8,15 +8,27 @@
  * transitions to `ready` or `failed` — because audio models take seconds to a
  * minute and must not block a chat turn.
  *
- * The four kinds are NOT interchangeable, and the split is a platform fact
+ * The five kinds are NOT interchangeable, and the split is a platform fact
  * rather than a design preference: Workers AI ships speech models but no
  * text-to-music or text-to-sound-effect model. `voice` and `creature` are
- * therefore servable today; `ambience` and `music` need an external model
- * reached through Cloudflare AI Gateway. See `AUDIO_KIND_CAPABILITY` below and
+ * therefore servable with no vendor; `ambience`, `sfx`, and `music` need an
+ * external model reached through Cloudflare AI Gateway. See
+ * `AUDIO_KIND_CAPABILITY` below and
  * `src/services/audio/audio-provider-factory.ts`.
+ *
+ * `ambience` and `sfx` hit the same vendor endpoint but are separate kinds
+ * because everything around them differs: ambience is a long loopable bed that
+ * plays under a scene, an effect is a short one-shot fired on a beat. They get
+ * different default durations, different loop defaults, and different prompts.
  */
 
-export const AUDIO_KINDS = ["ambience", "music", "creature", "voice"] as const;
+export const AUDIO_KINDS = [
+	"ambience",
+	"sfx",
+	"music",
+	"creature",
+	"voice",
+] as const;
 
 /** What the caller wants to hear, which also selects the provider. */
 export type AudioKind = (typeof AUDIO_KINDS)[number];
@@ -39,6 +51,7 @@ export const AUDIO_KIND_CAPABILITY: Record<
 	voice: "speech",
 	creature: "speech",
 	ambience: "sound",
+	sfx: "sound",
 	music: "music",
 };
 
@@ -129,8 +142,9 @@ export interface UpdateCampaignAudioInput {
 }
 
 /**
- * Ambience and music are looped under a scene for as long as it lasts; voice and
- * creature sounds are fired once. Used as the default when a caller does not say.
+ * Ambience and music are looped under a scene for as long as it lasts; effects,
+ * voice, and creature sounds are fired once on a beat. Used as the default when
+ * a caller does not say.
  */
 export function defaultLoopableForKind(kind: AudioKind): boolean {
 	return kind === "ambience" || kind === "music";

--- a/tests/lib/audio-prompts.test.ts
+++ b/tests/lib/audio-prompts.test.ts
@@ -23,6 +23,41 @@ const CAMPAIGN: AudioCampaignContext = {
 };
 
 describe("buildAudioPrompt", () => {
+	/**
+	 * Effects and ambience share a vendor endpoint, so the only thing keeping a
+	 * door slam from coming back as a five-second wash is that they build
+	 * opposite prompts. That opposition is the behaviour worth pinning.
+	 */
+	describe("sfx", () => {
+		it("asks for a transient one-shot, not a bed", () => {
+			const prompt = buildAudioPrompt({
+				kind: "sfx",
+				campaign: CAMPAIGN,
+				hint: "an iron portcullis slamming shut",
+			});
+
+			expect(prompt).toContain("an iron portcullis slamming shut");
+			expect(prompt).toContain("sharp transient");
+			expect(prompt).toContain("no continuous background ambience");
+		});
+
+		it("does not ask for the loopable steadiness ambience wants", () => {
+			const sfx = buildAudioPrompt({
+				kind: "sfx",
+				campaign: CAMPAIGN,
+				hint: "a sword striking a shield",
+			});
+			const ambience = buildAudioPrompt({
+				kind: "ambience",
+				campaign: CAMPAIGN,
+				hint: "a battlefield",
+			});
+
+			expect(ambience).toContain("loopable");
+			expect(sfx).not.toContain("loopable");
+		});
+	});
+
 	describe("ambience", () => {
 		it("mines audible detail out of campaign and entity prose", () => {
 			const prompt = buildAudioPrompt({

--- a/tests/services/audio-providers.test.ts
+++ b/tests/services/audio-providers.test.ts
@@ -12,6 +12,10 @@ import {
 import {
 	buildGatewayBaseUrl,
 	createGatewayAudioProvider,
+	DEFAULT_ELEVENLABS_VOICE_ID,
+	DEFAULT_MUSIC_MODEL,
+	DEFAULT_SOUND_MODEL,
+	DEFAULT_SPEECH_MODEL,
 	GatewayAudioProvider,
 	MAX_SOUND_EFFECT_SEC,
 } from "@/services/audio/gateway-audio-provider";
@@ -218,6 +222,196 @@ describe("GatewayAudioProvider", () => {
 		vi.unstubAllGlobals();
 	});
 
+	/**
+	 * These pin the vendor's wire contract, which is the one thing unit tests
+	 * cannot otherwise catch: a wrong `model_id` is a 422 from the live service
+	 * and a perfectly green test suite. Each value here is taken from the
+	 * ElevenLabs API reference, not inferred.
+	 */
+	describe("vendor request contract", () => {
+		function bodyOf(fetchMock: ReturnType<typeof vi.fn>) {
+			return JSON.parse(fetchMock.mock.calls[0][1].body as string);
+		}
+
+		it("sends the music model id the endpoint actually accepts", async () => {
+			const fetchMock = stubFetch(MP3_BYTES);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const provider = new GatewayAudioProvider({
+				apiKey: "key",
+				baseUrl: "https://example.test/eleven",
+			});
+
+			await provider.generate({
+				kind: "music",
+				prompt: "villain theme",
+				durationSec: 45,
+			});
+
+			const body = bodyOf(fetchMock);
+			expect(body.model_id).toBe(DEFAULT_MUSIC_MODEL);
+			expect(body.music_length_ms).toBe(45_000);
+			// Eleven Music sings unless told not to, and a vocal track is unusable
+			// under a GM who is themselves talking.
+			expect(body.force_instrumental).toBe(true);
+
+			vi.unstubAllGlobals();
+		});
+
+		it("lets a caller opt back into vocals", async () => {
+			const fetchMock = stubFetch(MP3_BYTES);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const provider = new GatewayAudioProvider({
+				apiKey: "key",
+				baseUrl: "https://example.test/eleven",
+			});
+
+			await provider.generate({
+				kind: "music",
+				prompt: "a bard's drinking song",
+				instrumental: false,
+			});
+
+			expect(bodyOf(fetchMock).force_instrumental).toBe(false);
+
+			vi.unstubAllGlobals();
+		});
+
+		it("asks the model to render a seamless wrap for looping beds", async () => {
+			const fetchMock = stubFetch(MP3_BYTES);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const provider = new GatewayAudioProvider({
+				apiKey: "key",
+				baseUrl: "https://example.test/eleven",
+			});
+
+			await provider.generate({
+				kind: "ambience",
+				prompt: "rain on stone",
+				loop: true,
+			});
+
+			const body = bodyOf(fetchMock);
+			expect(body.loop).toBe(true);
+			expect(body.model_id).toBe(DEFAULT_SOUND_MODEL);
+
+			vi.unstubAllGlobals();
+		});
+
+		it("omits loop for one-shot effects", async () => {
+			const fetchMock = stubFetch(MP3_BYTES);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const provider = new GatewayAudioProvider({
+				apiKey: "key",
+				baseUrl: "https://example.test/eleven",
+			});
+
+			await provider.generate({ kind: "sfx", prompt: "a door slamming" });
+
+			const body = bodyOf(fetchMock);
+			expect(body.loop).toBeUndefined();
+			expect(fetchMock.mock.calls[0][0]).toContain("/v1/sound-generation");
+
+			vi.unstubAllGlobals();
+		});
+
+		// `loop` is only valid on the v2 sound model; sending it to v1 is a 422.
+		it("withholds loop from a sound model that cannot take it", async () => {
+			const fetchMock = stubFetch(MP3_BYTES);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const provider = new GatewayAudioProvider({
+				apiKey: "key",
+				baseUrl: "https://example.test/eleven",
+				soundModel: "eleven_text_to_sound_v1",
+			});
+
+			await provider.generate({
+				kind: "ambience",
+				prompt: "rain",
+				loop: true,
+			});
+
+			expect(bodyOf(fetchMock).loop).toBeUndefined();
+
+			vi.unstubAllGlobals();
+		});
+
+		it("routes voice to text-to-speech under the configured voice id", async () => {
+			const fetchMock = stubFetch(MP3_BYTES);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const provider = new GatewayAudioProvider({
+				apiKey: "key",
+				baseUrl: "https://example.test/eleven",
+			});
+
+			await provider.generate({
+				kind: "voice",
+				prompt: "You should not have come here.",
+			});
+
+			const url = fetchMock.mock.calls[0][0] as string;
+			expect(url).toContain(
+				`/v1/text-to-speech/${DEFAULT_ELEVENLABS_VOICE_ID}`
+			);
+
+			const body = bodyOf(fetchMock);
+			expect(body.model_id).toBe(DEFAULT_SPEECH_MODEL);
+			// The prompt is the literal line; nothing may be appended to it or the
+			// NPC reads the stage direction aloud.
+			expect(body.text).toBe("You should not have come here.");
+
+			vi.unstubAllGlobals();
+		});
+
+		it("uses a per-request voice over the configured default", async () => {
+			const fetchMock = stubFetch(MP3_BYTES);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const provider = new GatewayAudioProvider({
+				apiKey: "key",
+				baseUrl: "https://example.test/eleven",
+				voiceId: "configured-default",
+			});
+
+			await provider.generate({
+				kind: "voice",
+				prompt: "Hold the line.",
+				voice: "per-request-voice",
+			});
+
+			expect(fetchMock.mock.calls[0][0]).toContain(
+				"/v1/text-to-speech/per-request-voice"
+			);
+
+			vi.unstubAllGlobals();
+		});
+
+		// The reported duration divides byte length by an assumed bitrate, so the
+		// format has to be requested rather than left to a vendor default.
+		it("pins the output format the duration estimate assumes", async () => {
+			const fetchMock = stubFetch(MP3_BYTES);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const provider = new GatewayAudioProvider({
+				apiKey: "key",
+				baseUrl: "https://example.test/eleven",
+			});
+
+			await provider.generate({ kind: "ambience", prompt: "wind" });
+
+			expect(fetchMock.mock.calls[0][0]).toContain(
+				"output_format=mp3_44100_128"
+			);
+
+			vi.unstubAllGlobals();
+		});
+	});
+
 	it("does not leak the vendor's quota detail verbatim in the thrown type", async () => {
 		vi.stubGlobal("fetch", stubFetch(MP3_BYTES, false));
 
@@ -263,7 +457,7 @@ describe("audio capability matrix", () => {
 		expect(capabilities.every((c) => c.available)).toBe(true);
 	});
 
-	it("keeps voice on first-party Workers AI even when a vendor is configured", () => {
+	it("moves voice onto the vendor once one is configured", () => {
 		const provider = resolveAudioProvider(
 			{
 				AI: fakeAi(MP3_BYTES),
@@ -273,7 +467,36 @@ describe("audio capability matrix", () => {
 			"voice"
 		);
 
-		expect(provider.name).toBe("workers-ai");
+		expect(provider.name).toBe("ai-gateway:elevenlabs");
+	});
+
+	// Voice is the one kind whose volume is unbounded — it bills per line of NPC
+	// dialogue — so the vendor default has to be reversible without giving up
+	// ambience, effects, and music.
+	it("pins voice back to Workers AI when AUDIO_VOICE_PROVIDER says so", () => {
+		const env = {
+			AI: fakeAi(MP3_BYTES),
+			ELEVENLABS_API_KEY: "key",
+			AUDIO_GATEWAY_BASE_URL: "https://example.test/eleven",
+			AUDIO_VOICE_PROVIDER: "workers-ai",
+		};
+
+		expect(resolveAudioProvider(env, "voice").name).toBe("workers-ai");
+		// Only voice is pinned; the kinds Workers AI cannot serve are untouched.
+		expect(resolveAudioProvider(env, "music").name).toBe(
+			"ai-gateway:elevenlabs"
+		);
+		expect(resolveAudioProvider(env, "ambience").name).toBe(
+			"ai-gateway:elevenlabs"
+		);
+	});
+
+	it("reports sfx unavailable with a reason when no vendor is configured", () => {
+		const capabilities = describeAudioCapabilities({ AI: fakeAi(MP3_BYTES) });
+		const sfx = capabilities.find((c) => c.kind === "sfx");
+
+		expect(sfx?.available).toBe(false);
+		expect(sfx?.reason).toMatch(/sound-effect model/i);
 	});
 
 	it("prefers a real sound model over coerced TTS for creature", () => {


### PR DESCRIPTION
Stacked on **#767** — base is `feat/756-generated-audio`, not `main`, so merging this updates that PR rather than shipping independently.

#767 shipped the ambience/music path "wired but inert", and said plainly that the ElevenLabs request bodies were written against documented contracts and **unverified against the live service**. I checked them against the API reference. Three would have failed, one silently, and the feature was missing two of the four things a GM would ask for.

## Bugs that would have hit on the first real API key

| | Was | Is | Effect |
|---|---|---|---|
| Music model id | `eleven_music_v1` | `music_v1` | **No such model.** Every music generation 422s. |
| Sound cap | 22s | 30s | v2 raised it; 8s of every bed was being left unused. |
| Seamless loop | not sent | `loop: true` | v2 renders a wrap that actually matches. |
| Vocals | vendor default | `force_instrumental: true` | Eleven Music **sings** by default. |
| Output format | vendor default | `mp3_44100_128` | The duration estimate divides by this exact bitrate. |

The music model id is the one that matters: it is a 422 from the live service and a perfectly green local suite, because nothing local ever sends the request. `tests/services/audio-providers.test.ts` now pins each of these values so the next edit cannot quietly drift off-contract.

The looping one is a design correction, not just a constant. #767 built the equal-power crossfade `LoopPlayer` on the premise that models cannot produce loopable audio. v2 can. Asking the model first is strictly better — no crossfade reconciles a bed whose start and end disagree harmonically — so `loopable` tracks now request it. `LoopPlayer` stays and still earns its place: the Workers AI path has no loop flag, and a model asked for a seamless wrap does not always deliver one.

## New `sfx` kind

`ambience` covered continuous beds and `creature` covered monster vocalizations, which left no way to ask for a door slam, a spell discharge, or a blade on a shield.

`sfx` is a separate kind rather than a flag on `ambience` even though both hit `/v1/sound-generation`, because everything around them is opposite: a bed is long, loops, and must survive a GM talking over it; an effect is short, transient, and fires once. They get different default durations (22s vs 5s), different loop defaults, and deliberately opposite prompts — one asks for *"steady, no transitions"*, the other for *"sharp transient, silence before and after"*. A test pins that opposition. Collapsing them would make all of it the caller's problem.

**No migration.** `kind` is a bare `TEXT NOT NULL` in `0033_campaign_audio.sql` with no CHECK constraint, and everything downstream derives from `AUDIO_KINDS`. Adding a kind is a types-and-labels change. I also replaced a hand-written `"kind must be one of: ambience, music, creature, voice"` in the route with `AUDIO_KINDS.join(", ")`, since it had already drifted.

## Voice now prefers the vendor when one is configured

`preferenceFor` hardcoded `workers-ai` for `voice`, and `GatewayAudioProvider.supports()` never listed `voice` at all — so with an ElevenLabs key set, NPC dialogue still went to Deepgram Aura. A configured key is only ever present deliberately, and a dedicated speech model is audibly better, so the vendor now wins voice and creature.

**Made reversible on purpose.** Voice is the one kind whose volume is unbounded — ambience and music are generated a handful of times per campaign, but NPC dialogue is per line, and ElevenLabs bills per character. `AUDIO_VOICE_PROVIDER=workers-ai` pins voice back to the free first-party model while leaving ambience, sfx, and music on the vendor. Silently moving the highest-volume kind onto a metered vendor is how people get surprised by a bill.

## Config: the key alone does nothing

Documented explicitly in `docs/GENERATED_AUDIO.md` and `docs/DEPLOYMENT.md`, because it is the most likely way to configure this wrong. `ELEVENLABS_API_KEY`, `AI_GATEWAY_ACCOUNT_ID`, and `AI_GATEWAY_ID` are required **together** — `createGatewayAudioProvider` returns `null` without all three rather than falling back to calling the vendor directly, so there is no configuration in which a request bypasses the gateway. Confirmed ElevenLabs is a supported AI Gateway provider and that the URL #767 builds is exactly the documented one.

## Verification

Everything below was actually run:

- `npm run check` — passes (exit 0; remaining warnings are pre-existing, on untouched files)
- `npx vitest run` — **200 files, 1920 tests passing** (12 new)
- `npm run test:coverage` — branches 73.73% vs the 70% gate
- `npm run build` + `check-bundle-size.mjs` — 338.2 kB gzip, within budget (-0.0%)
- `check-complexity.mjs` — passes
- `npm run wiki:sync:dry-run` — `Technical/Generated-Audio.md` in the diff, already registered by #767

**Not run:** still no live ElevenLabs or Workers AI call — I have no credentials here. The contracts are now checked against the published API reference rather than inferred, which is a real step up from #767, but a live call is still the only thing that settles them. That is the one thing local review cannot do.

## How to see this change

```bash
gh pr checkout <PR#>
npm install
```

**The contract fixes, no credentials needed** — this is the fastest path and covers the actual bugs:

```bash
npx vitest run tests/services/audio-providers.test.ts tests/lib/audio-prompts.test.ts
```

The `vendor request contract` block asserts the exact `model_id`, `loop`, `force_instrumental`, and `output_format` values on the wire. Revert `DEFAULT_MUSIC_MODEL` to `eleven_music_v1` and watch it fail — that is the bug that would otherwise have surfaced only against your real key.

**In the app, with your key:** put all three in `.dev.vars`:

```
ELEVENLABS_API_KEY=<your key>
AI_GATEWAY_ACCOUNT_ID=<from the gateway's API endpoint URL>
AI_GATEWAY_ID=<same>
```

Then two terminals per `docs/DEV_SETUP.md` (`npm run dev:cloudflare`, then `npm run start`), and `http://localhost:5173` → Campaigns → pick one → **Audio**. All five kinds enable, including **Sound effect**. Generate one of each; ambience should now loop without a seam, and music should come back instrumental instead of sung. **I could not run this path.**

**Conversationally:** *"generate a sound effect of a portcullis slamming shut"* → `generateCampaignAudioTool` with `kind: "sfx"`.

**What you should see:** before this, an ElevenLabs key got you ambience and creature sounds, silently-failing music, no sound effects, and NPC voices still on the weaker free model. After, all five kinds work against a real key, music comes back instrumental, ambience loops seamlessly, and you can put voice back on the free model with one env var if the per-character billing is not worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
