### PR TITLE
fix(ui): stop Button rendering `title` as content, colliding with its label

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -27,8 +27,11 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 	loading?: boolean;
 	shape?: "base" | "square" | "circular";
 	size?: "sm" | "md" | "lg" | "base";
-	title?: string | ReactNode;
 	toggled?: boolean;
+	/**
+	 * Hover text rendered through `Tooltip`. Prefer this over the native `title`
+	 * attribute, which browsers style inconsistently and screen readers may skip.
+	 */
 	tooltip?: string;
 	variant?: SolidVariant | FormVariant;
 	/** When `appearance="form"`, shown before children; replaced by the loader while `loading`. */
@@ -69,7 +72,6 @@ const ButtonComponent = ({
 	loading,
 	shape = "base",
 	size = "base",
-	title,
 	toggled,
 	tooltip: _tooltip,
 	variant,
@@ -138,8 +140,6 @@ const ButtonComponent = ({
 			target={external ? "_blank" : undefined}
 			{...props}
 		>
-			{title}
-
 			{loading ? (
 				<span
 					className={cn("inline-flex shrink-0 items-center justify-center", {

--- a/src/components/upload/ResourceFileDetails.tsx
+++ b/src/components/upload/ResourceFileDetails.tsx
@@ -319,11 +319,6 @@ export function ResourceFileDetails({
 							size="sm"
 							className="w-full !text-purple-600 dark:!text-purple-400 hover:!text-purple-700 dark:hover:!text-purple-300 border-purple-200 dark:border-purple-700 hover:border-purple-300 dark:hover:border-purple-600"
 							disabled={!canAddToCampaign}
-							title={
-								addWillBeQueued
-									? "This file is still processing. The add is queued and completes automatically."
-									: undefined
-							}
 						>
 							{canAddToCampaign ? "Add to campaign" : "File not ready"}
 						</Button>

--- a/tests/components/Button.test.tsx
+++ b/tests/components/Button.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Button } from "@/components/button/Button";
+import { TooltipProvider } from "@/providers/TooltipProvider";
+
+// Mock window.matchMedia for Tooltip component
+beforeEach(() => {
+	Object.defineProperty(window, "matchMedia", {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+});
+
+describe("Button", () => {
+	it("renders its children as the label", () => {
+		render(<Button>Add to campaign</Button>);
+
+		expect(
+			screen.getByRole("button", { name: "Add to campaign" })
+		).toBeDefined();
+	});
+
+	// Regression: `title` used to be a content slot on ButtonProps, so passing it
+	// painted the hover text inside the button on top of the label.
+	it("passes `title` through as the native attribute, not as button content", () => {
+		const hint = "This file is still processing.";
+		render(<Button title={hint}>Add to campaign</Button>);
+
+		const button = screen.getByRole("button", { name: "Add to campaign" });
+		expect(button.getAttribute("title")).toBe(hint);
+		expect(button.textContent).toBe("Add to campaign");
+	});
+
+	it("renders hover text supplied via `tooltip` outside the button element", () => {
+		render(
+			<TooltipProvider>
+				<Button tooltip="Queued until processing finishes">
+					Add to campaign
+				</Button>
+			</TooltipProvider>
+		);
+
+		const button = screen.getByRole("button", { name: "Add to campaign" });
+		expect(button.textContent).toBe("Add to campaign");
+	});
+});


### PR DESCRIPTION
## What

`Button` shadowed the native HTML `title` attribute with a **content slot**. `ButtonProps` declared `title?: string | ReactNode` and `ButtonComponent` rendered `{title}` as the button's first child, directly before `{children}`.

So in `ResourceFileDetails`, this:

```jsx
<Button className="w-full …" title="This file is still processing. The add is queued and completes automatically.">
  Add to campaign
</Button>
```

put **two** strings inside one button. Because `.btn` is `white-space: nowrap` with a fixed height (`add-size-sm`) and `justify-content: center`, neither run can wrap or grow — they overflow the centered flex line in both directions and paint on top of each other:

> `…file is still processing. The add is queued and completes automatically.Add to camp…`

This is live on production (`loresmith.ai` → Resources → expand a still-processing file).

## Why it wasn't caught

`ButtonProps` is `ButtonHTMLAttributes<HTMLButtonElement> & { title?: string | ReactNode }`. In an **intersection**, the DOM `title` (`string`) and the custom one merge rather than conflict, so `title="…"` typechecks perfectly while silently meaning something completely different from the DOM attribute. There is no type error to catch it.

## Fix

1. **`Button.tsx`** — drop the `title` content slot. `title` now falls through `...props` → `Slot` → the real DOM attribute, as every caller would reasonably expect. Documented `tooltip` as the preferred prop for hover text.
2. **`ResourceFileDetails.tsx`** — remove the `title` entirely. The identical sentence is already rendered as visible helper text in the `<p>` immediately below the button, so the hover copy was pure duplication.

A repo-wide brace-aware scan for `<Button … title=…>` found **exactly one** call site — this bug. Nothing else depended on the slot (the `title` hits in `*.stories.tsx` are Storybook meta titles).

Regression from #783.

## Verification

- `npm run check` — exit 0 (only pre-existing warnings, in files this PR doesn't touch)
- `npx tsc --noEmit` — clean
- Pre-commit hook ran the **full suite: 211 files, 2024 tests, all passing**
- New `tests/components/Button.test.tsx` — **confirmed a real regression test**: I checked out `origin/main`'s `Button.tsx`, re-ran it, and the `title` case fails (`textContent` is `"This file is still processing.Add to campaign"`); it passes on the fix.

## How to see this change

```bash
gh pr checkout <PR#>
npx vitest run tests/components/Button.test.tsx
```

**What you should see:** 3 passing tests. The middle one asserts the button's `title` lands as an *attribute* and its `textContent` is exactly `"Add to campaign"`. To watch it catch the bug, restore the old component and re-run — it fails:

```bash
git show origin/main:src/components/button/Button.tsx > src/components/button/Button.tsx
npx vitest run tests/components/Button.test.tsx   # ✗ title case fails
git checkout src/components/button/Button.tsx
```

For the visual before/after, the affected screen is Resources → expand a file that is still processing → the "Add to campaign" action.

**Before:** the queued-add sentence and the label overlap inside the button, spilling past both edges (see the production screenshot on the linked issue/thread).
**After:** a clean full-width `Add to campaign` button, with the explanatory sentence in the helper text below it — unchanged.

I verified this visually by rendering the pre-fix and post-fix DOM side by side through the throwaway-Vite + headless-Chrome harness in `docs`-adjacent practice (`vite.storybook.config.ts`, since `npm run storybook` does not build on `main`), and the before pane reproduces the production screenshot exactly. Those preview files were deleted before committing and the screenshot is not attached here — this PR was prepared in a non-interactive session that can't upload images to GitHub. The vitest case above is the durable, reviewable form of the same evidence.
