### PR TITLE
fix: stop the assistant explaining how LoreSmith is built

### DIFF
--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -178,7 +178,7 @@ function getUserFacingErrorMessage(error: unknown): string {
 		errorMessage.includes("too many tokens") ||
 		errorMessage.includes("reduce the length");
 	if (isContextLengthError) {
-		return "I encountered an issue: the context retrieved from your campaign is too large for me to process. I've automatically trimmed the least relevant information, but the request still exceeds my capacity. Please try a more specific query to narrow down the results.";
+		return "That pulled in more of your campaign than I can read at once. Could you narrow it down a bit, maybe to a single character, place, or session, and ask again?";
 	}
 	return "I apologize, but I encountered an error while processing your request. Please try again.";
 }

--- a/src/agents/system-prompts.ts
+++ b/src/agents/system-prompts.ts
@@ -1,4 +1,4 @@
-/** Conversation rule preset: minimal = core only; dataRetrieval = core + NO IMPROVISATION + PLAIN LANGUAGE */
+/** Conversation rule preset: minimal = core only; dataRetrieval = core + NO IMPROVISATION */
 export type ConversationRulesPreset = "minimal" | "dataRetrieval";
 
 export interface SystemPromptConfig {
@@ -8,7 +8,7 @@ export interface SystemPromptConfig {
 	workflowGuidelines: string[];
 	importantNotes?: string[];
 	specialization?: string;
-	/** Rule preset. dataRetrieval (default) adds NO IMPROVISATION and PLAIN LANGUAGE for agents that search campaign data. minimal for creative/suggestion agents. */
+	/** Rule preset. dataRetrieval (default) adds NO IMPROVISATION for agents that search campaign data. minimal for creative/suggestion agents. */
 	conversationRules?: ConversationRulesPreset;
 }
 
@@ -48,6 +48,24 @@ export function createToolMappingFromObjects(
 }
 
 /**
+ * Always-on. LoreSmith users are storytellers, not engineers: they should never
+ * learn what the product runs on. Applies to every agent regardless of preset,
+ * because any agent can hit a failure and try to explain it.
+ */
+export const NO_IMPLEMENTATION_DETAILS_RULE = `**CRITICAL - NEVER REVEAL HOW LORESMITH IS BUILT: You are LoreSmith, one assistant. The user is a storyteller, not an engineer, and must never learn anything about the technology behind the product.
+- NEVER name or allude to hosting platforms, cloud services, AI vendors, models, model names or versions, providers, APIs, API keys, databases, vector or search indexes, queues, storage, environments, deployments, configuration, or settings files. Not even to explain why something failed.
+- NEVER describe LoreSmith's internals: no agents, routing, tools, tool names, pipelines, indexing, chunks, embeddings, prompts, tokens, IDs, error codes, or stack traces. Say "I" and "LoreSmith", never "this agent", "my tools", or "the system".
+- NEVER relay raw error text from a failed action. Translate it into what it means for the user's campaign.
+- When you cannot do something, say plainly WHAT you cannot do and offer what you CAN do. Never say why in terms of setup, configuration, availability of a provider, or what is "hooked up" or "enabled here". Say "I'm not able to create audio" or "That's not something I can do yet", never "an audio provider isn't configured" or "the built-in AI doesn't offer that model".
+- NEVER offer to notify, flag, escalate to, or file anything with a support, engineering, or admin team. You have no way to contact anyone. Do not invent that path.
+- Do not speculate about whether a capability might be added, enabled, or fixed later, and never promise a fix or a timeline.**`;
+
+/**
+ * Always-on. Everyday words for everything the user did not say first.
+ */
+export const PLAIN_LANGUAGE_RULE = `**CRITICAL - PLAIN LANGUAGE: Users are not technical. Use simple, everyday language for everything, including how you describe what you looked at and what you found. NEVER use jargon like "semantic search", "entity graph", "campaign context/entities", "query" (as a technical term), "graph traversal", "metadata", "index", or "embedding". Say instead: "I looked through your campaign for...", "I checked your notes and characters...", "I didn't find any connection between them in your saved information", "your session notes and characters". Keep explanations clear and accessible.**`;
+
+/**
  * Builds a standardized system prompt for agents
  */
 export function buildSystemPrompt(config: SystemPromptConfig): string {
@@ -75,9 +93,7 @@ export function buildSystemPrompt(config: SystemPromptConfig): string {
 
 	const dataRetrievalRules = useDataRetrievalRules
 		? `
-
-- **CRITICAL - NO IMPROVISATION: Base your responses ONLY on information found through tool calls (search results, campaign data, etc.). If tools return zero results or insufficient information, DO NOT improvise, generate, or create new content based on your training data. Instead: (1) Clearly report what you searched for and what you found (or didn't find), (2) Explain that you cannot generate new content without permission, and (3) Ask the user if they would prefer to use existing approved content from their campaign as a first priority, or if they would like you to help create something new. Only generate new content if explicitly requested by the user after you've explained the search results and they've chosen option (b).**
-- **CRITICAL - PLAIN LANGUAGE: Users are not expected to be technical. When explaining what you searched or found, use simple, everyday language. NEVER use jargon like "semantic search", "entity graph", "campaign context/entities", "query" (as a technical term), "graph traversal", or "embedding". Say instead: "I looked through your campaign for...", "I checked your notes and characters...", "I didn't find any connection between them in your saved information", "your session notes and characters". Keep explanations clear and accessible.**`
+- **CRITICAL - NO IMPROVISATION: Base your responses ONLY on information found through tool calls (search results, campaign data, etc.). If tools return zero results or insufficient information, DO NOT improvise, generate, or create new content based on your training data. Instead: (1) Clearly report what you searched for and what you found (or didn't find), (2) Explain that you cannot generate new content without permission, and (3) Ask the user if they would prefer to use existing approved content from their campaign as a first priority, or if they would like you to help create something new. Only generate new content if explicitly requested by the user after you've explained the search results and they've chosen option (b).**`
 		: "";
 
 	return `You are a specialized ${config.agentName} for LoreSmith AI.
@@ -95,7 +111,9 @@ ${workflowGuidelines}${importantNotes}${specialization}
 - **Be conversational, natural, and engaging. Never use canned responses or templates.**
 - **Avoid formal structures like "Campaign Name:" or "Campaign Theme:". Use tools directly when you have enough information.**
 - **Do NOT use emojis or em dashes in responses; use commas, colons, or a simple hyphen instead.**
-- **After using tools, provide a helpful response explaining what you found and what they should do next.**${dataRetrievalRules}
+- **After using tools, provide a helpful response explaining what you found and what they should do next.**
+- ${NO_IMPLEMENTATION_DETAILS_RULE}
+- ${PLAIN_LANGUAGE_RULE}${dataRetrievalRules}
 
 You are focused, efficient, conversational, and always prioritize helping users effectively through natural dialogue.`;
 }

--- a/src/lib/user-facing-language.ts
+++ b/src/lib/user-facing-language.ts
@@ -1,0 +1,120 @@
+/**
+ * Keeps implementation detail out of anything the chat model can see.
+ *
+ * Telling the agent "never mention Cloudflare" is not enough on its own: tool
+ * failures hand it strings like "OpenAI API key not configured" and then ask it
+ * not to repeat them. This redacts that vocabulary before the tool result is
+ * returned, so the model has nothing to leak. The raw text is logged instead,
+ * where developers can still read it.
+ *
+ * Only messages that actually contain infrastructure vocabulary are replaced.
+ * Ordinary failures ("Campaign not found") pass through untouched, because the
+ * user and the model both need those.
+ */
+
+/** Shown when a capability is missing or switched off. */
+export const UNAVAILABLE_MESSAGE = "That's not something I can do right now.";
+
+/** Shown when something broke unexpectedly. */
+export const GENERIC_FAILURE_MESSAGE =
+	"Something went wrong on my end, so I couldn't finish that. Please try again in a moment.";
+
+/**
+ * Vocabulary that reveals how LoreSmith is built.
+ *
+ * Patterns are deliberately narrow. Bare "environment", "worker", "binding" and
+ * "model" are all legitimate tabletop words, so each is matched only in a phrase
+ * that can only be infrastructure.
+ */
+const IMPLEMENTATION_DETAIL_PATTERNS: RegExp[] = [
+	// Platform and vendors
+	/\bcloudflare\b/i,
+	/\bworkers?\s+ai\b/i,
+	/\bautorag\b/i,
+	/\bvectorize\b/i,
+	/\bwrangler\b/i,
+	/\bdurable objects?\b/i,
+	/\bR2\b/,
+	/\bD1\b/,
+	/\bKV (namespace|store)\b/i,
+	/\bopenai\b/i,
+	/\banthropic\b/i,
+	/\bgpt-?\d/i,
+	/\bclaude\b/i,
+	/\bllama\b/i,
+	// Credentials and configuration
+	/\bapi[_\s-]?keys?\b/i,
+	/\baccess tokens?\b/i,
+	/\benvironment variables?\b/i,
+	/\benv(ironment)? vars?\b/i,
+	/\bnot configured\b/i,
+	/\bmisconfigured\b/i,
+	/\bthis environment\b/i,
+	/\benvironment (is |was )?(not available|unavailable)\b/i,
+	// Storage and retrieval internals
+	/\bvector (index|store|database|db|search)\b/i,
+	/\bembeddings?\b/i,
+	/\bdirect database access\b/i,
+	/\bdatabase (is |was )?(not available|unavailable)\b/i,
+	/\b(the |a )?database connection\b/i,
+	/\bqueue consumer\b/i,
+	// Model plumbing. "provider" is matched only where it is qualified by a
+	// service word, or where it is talked about as something you switch on --
+	// never in the bare sense ("the provider of the quest").
+	/\bai model\b/i,
+	/\bbuilt-in ai\b/i,
+	/\bmodel (path|name|id|version)\b/i,
+	/\b(ai|model|llm|audio|voice|speech|image|video|search|storage|email|auth|payment|external|third[-\s]party|service|api)\s+providers?\b/i,
+	/\bproviders?\s+(is |are |was |were )?(not )?(configured|enabled|available|set up|hooked up)\b/i,
+	/\bhooked up\b/i,
+	/\bllm\b/i,
+	// Raw diagnostics
+	/\bstack trace\b/i,
+	// Deliberately NOT redacted: bare HTTP status codes. They reveal nothing
+	// about how LoreSmith is built, and the model needs "not found" vs "broke"
+	// to answer sensibly. The prompt rule keeps codes out of what the user reads.
+];
+
+/** Phrasing that means "this capability is off or absent" rather than "it broke". */
+const UNAVAILABILITY_PATTERNS: RegExp[] = [
+	// Only consulted for text already flagged as implementation detail, so these
+	// can be broader than the patterns above.
+	/\bconfigured\b/i,
+	/\bmisconfigured\b/i,
+	/\bhooked up\b/i,
+	/\bdoesn'?t (have|offer|support)\b/i,
+	/\bnot (available|enabled|supported|set up)\b/i,
+	/\bunavailable\b/i,
+	/\bunsupported\b/i,
+	/\bis disabled\b/i,
+	/\bmissing\b/i,
+	/\brequires\b/i,
+];
+
+/** True when `text` names any part of how LoreSmith is built. */
+export function containsImplementationDetail(
+	text: string | null | undefined
+): boolean {
+	if (!text) return false;
+	return IMPLEMENTATION_DETAIL_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+/**
+ * Returns `text` unchanged unless it exposes implementation detail, in which
+ * case it becomes a plain-language stand-in.
+ *
+ * Redaction replaces the whole message rather than swapping words, because
+ * word-level substitution produces sentences that are still recognisably
+ * technical ("the audio thing isn't configured").
+ */
+export function sanitizeUserFacingText(
+	text: string | null | undefined
+): string {
+	if (!text) return GENERIC_FAILURE_MESSAGE;
+	if (!containsImplementationDetail(text)) return text;
+
+	const isUnavailability = UNAVAILABILITY_PATTERNS.some((pattern) =>
+		pattern.test(text)
+	);
+	return isUnavailability ? UNAVAILABLE_MESSAGE : GENERIC_FAILURE_MESSAGE;
+}

--- a/src/tools/tool-utils.ts
+++ b/src/tools/tool-utils.ts
@@ -3,6 +3,10 @@
  */
 
 import type { ToolResult } from "@/app-constants";
+import {
+	containsImplementationDetail,
+	sanitizeUserFacingText,
+} from "@/lib/user-facing-language";
 
 /** Format message with campaign context. */
 export function formatMessageWithCampaign(
@@ -42,7 +46,13 @@ export function createAuthHeaders(jwt?: string | null): Record<string, string> {
 	};
 }
 
-/** Standard error response for tool execution. */
+/**
+ * Standard error response for tool execution.
+ *
+ * The whole `result` is handed to the chat model, so both the message and the
+ * error detail are redacted when they name infrastructure (see
+ * {@link sanitizeUserFacingText}). The originals go to the log, not the model.
+ */
 export function createToolError(
 	message: string,
 	error: unknown,
@@ -51,9 +61,28 @@ export function createToolError(
 	_campaignId?: string | null,
 	campaignName?: string | null
 ): ToolResult {
-	const formattedMessage = campaignName
-		? formatMessageWithCampaign(message, campaignName)
-		: message;
+	const rawDetail = error instanceof Error ? error.message : String(error);
+
+	if (
+		containsImplementationDetail(message) ||
+		containsImplementationDetail(rawDetail)
+	) {
+		console.error("[tool-error] redacted from chat:", {
+			toolCallId,
+			code,
+			message,
+			detail: rawDetail,
+		});
+	}
+
+	// A redacted message is a complete sentence; appending `for campaign "X"` to
+	// it reads as a fragment, so the suffix is only added to messages we kept.
+	const safeMessage = sanitizeUserFacingText(message);
+	const wasRedacted = safeMessage !== message;
+	const formattedMessage =
+		campaignName && !wasRedacted
+			? formatMessageWithCampaign(safeMessage, campaignName)
+			: safeMessage;
 
 	return {
 		toolCallId,
@@ -61,7 +90,7 @@ export function createToolError(
 			success: false,
 			message: formattedMessage,
 			data: {
-				error: error instanceof Error ? error.message : String(error),
+				error: sanitizeUserFacingText(rawDetail),
 				errorCode: code,
 				...(campaignName ? { campaignName } : {}),
 			},

--- a/tests/agents/system-prompts.test.ts
+++ b/tests/agents/system-prompts.test.ts
@@ -29,22 +29,66 @@ describe("buildSystemPrompt", () => {
 		const minimalTokens = estimateTokenCount(minimalPrompt);
 		const dataRetrievalTokens = estimateTokenCount(dataRetrievalPrompt);
 		expect(minimalTokens).toBeLessThan(dataRetrievalTokens);
-		// Document expected savings: dataRetrieval adds NO IMPROVISATION + PLAIN LANGUAGE (~220 tokens)
+		// Document expected savings: dataRetrieval adds NO IMPROVISATION (~150 tokens)
 		expect(dataRetrievalTokens - minimalTokens).toBeGreaterThan(100);
 	});
 
-	it("default (dataRetrieval) includes NO IMPROVISATION and PLAIN LANGUAGE", () => {
+	it("default (dataRetrieval) includes NO IMPROVISATION", () => {
 		const defaultPrompt = buildSystemPrompt(MINIMAL_CONFIG);
 		expect(defaultPrompt).toContain("NO IMPROVISATION");
-		expect(defaultPrompt).toContain("PLAIN LANGUAGE");
 	});
 
-	it("minimal excludes NO IMPROVISATION and PLAIN LANGUAGE", () => {
+	it("minimal excludes NO IMPROVISATION", () => {
 		const minimalPrompt = buildSystemPrompt({
 			...MINIMAL_CONFIG,
 			conversationRules: "minimal",
 		});
 		expect(minimalPrompt).not.toContain("NO IMPROVISATION");
-		expect(minimalPrompt).not.toContain("PLAIN LANGUAGE");
+	});
+
+	// The user is a storyteller, not an engineer. These rules are not optional
+	// per-agent, because any agent can hit a failure and try to explain it.
+	describe("user-facing voice rules apply to every preset", () => {
+		it.each(["minimal", "dataRetrieval"] as const)(
+			"%s includes PLAIN LANGUAGE",
+			(preset) => {
+				const prompt = buildSystemPrompt({
+					...MINIMAL_CONFIG,
+					conversationRules: preset,
+				});
+				expect(prompt).toContain("PLAIN LANGUAGE");
+			}
+		);
+
+		it.each(["minimal", "dataRetrieval"] as const)(
+			"%s forbids revealing how LoreSmith is built",
+			(preset) => {
+				const prompt = buildSystemPrompt({
+					...MINIMAL_CONFIG,
+					conversationRules: preset,
+				});
+				expect(prompt).toContain("NEVER REVEAL HOW LORESMITH IS BUILT");
+			}
+		);
+
+		it("names the specific things that must not be mentioned", () => {
+			const prompt = buildSystemPrompt(MINIMAL_CONFIG);
+			for (const forbidden of [
+				"hosting platforms",
+				"AI vendors",
+				"API keys",
+				"databases",
+				"tool names",
+				"stack traces",
+			]) {
+				expect(prompt).toContain(forbidden);
+			}
+		});
+
+		it("forbids inventing a support escalation path", () => {
+			const prompt = buildSystemPrompt(MINIMAL_CONFIG);
+			expect(prompt).toContain("escalate to");
+			expect(prompt).toContain("You have no way to contact anyone");
+		});
 	});
 });

--- a/tests/agents/system-prompts.test.ts
+++ b/tests/agents/system-prompts.test.ts
@@ -9,6 +9,8 @@ const MINIMAL_CONFIG = {
 	workflowGuidelines: ["Test guideline"],
 };
 
+const ALL_PRESETS = ["minimal", "dataRetrieval"] as const;
+
 describe("buildSystemPrompt", () => {
 	it("produces valid prompt with minimal config", () => {
 		const prompt = buildSystemPrompt(MINIMAL_CONFIG);
@@ -49,27 +51,21 @@ describe("buildSystemPrompt", () => {
 	// The user is a storyteller, not an engineer. These rules are not optional
 	// per-agent, because any agent can hit a failure and try to explain it.
 	describe("user-facing voice rules apply to every preset", () => {
-		it.each(["minimal", "dataRetrieval"] as const)(
-			"%s includes PLAIN LANGUAGE",
-			(preset) => {
-				const prompt = buildSystemPrompt({
-					...MINIMAL_CONFIG,
-					conversationRules: preset,
-				});
-				expect(prompt).toContain("PLAIN LANGUAGE");
-			}
-		);
+		it.each(ALL_PRESETS)("%s includes PLAIN LANGUAGE", (preset) => {
+			const prompt = buildSystemPrompt({
+				...MINIMAL_CONFIG,
+				conversationRules: preset,
+			});
+			expect(prompt).toContain("PLAIN LANGUAGE");
+		});
 
-		it.each(["minimal", "dataRetrieval"] as const)(
-			"%s forbids revealing how LoreSmith is built",
-			(preset) => {
-				const prompt = buildSystemPrompt({
-					...MINIMAL_CONFIG,
-					conversationRules: preset,
-				});
-				expect(prompt).toContain("NEVER REVEAL HOW LORESMITH IS BUILT");
-			}
-		);
+		it.each(ALL_PRESETS)("%s hides how LoreSmith is built", (preset) => {
+			const prompt = buildSystemPrompt({
+				...MINIMAL_CONFIG,
+				conversationRules: preset,
+			});
+			expect(prompt).toContain("NEVER REVEAL HOW LORESMITH IS BUILT");
+		});
 
 		it("names the specific things that must not be mentioned", () => {
 			const prompt = buildSystemPrompt(MINIMAL_CONFIG);

--- a/tests/lib/user-facing-language.test.ts
+++ b/tests/lib/user-facing-language.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+	containsImplementationDetail,
+	GENERIC_FAILURE_MESSAGE,
+	sanitizeUserFacingText,
+	UNAVAILABLE_MESSAGE,
+} from "../../src/lib/user-facing-language";
+
+describe("containsImplementationDetail", () => {
+	it.each([
+		"Cloudflare's built-in AI doesn't offer that model yet",
+		"this campaign's setup doesn't have an audio provider configured",
+		"OpenAI API key not configured",
+		"AI is not configured for this environment.",
+		"Session digest indexing requires database, vector index, and OpenAI API key.",
+		"Direct database access is required for house rule creation.",
+		"Environment not available",
+		"Anthropic returned an error",
+		"Workers AI request failed",
+		"AutoRAG returned no chunks",
+		"Failed to write to R2",
+		"D1 query failed",
+		"Could not generate embeddings",
+		"The LLM timed out",
+	])("flags %j", (text) => {
+		expect(containsImplementationDetail(text)).toBe(true);
+	});
+
+	it.each([
+		"Campaign not found",
+		"No characters matched that name",
+		"That file is still being processed",
+		// Tabletop words that must not be mistaken for infrastructure.
+		"No creatures found for that environment",
+		"The ritual for binding the demon is incomplete",
+		"That worker NPC has no stat block",
+		"This miniature model has no image",
+		"The provider of the quest is unknown",
+		// Status codes stay: they aid the model's reasoning and reveal no architecture.
+		"HTTP 500",
+		"HTTP 404",
+	])("leaves %j alone", (text) => {
+		expect(containsImplementationDetail(text)).toBe(false);
+	});
+
+	it("treats empty input as clean", () => {
+		expect(containsImplementationDetail("")).toBe(false);
+		expect(containsImplementationDetail(null)).toBe(false);
+		expect(containsImplementationDetail(undefined)).toBe(false);
+	});
+});
+
+describe("sanitizeUserFacingText", () => {
+	it("passes ordinary failures through unchanged", () => {
+		expect(sanitizeUserFacingText("Campaign not found")).toBe(
+			"Campaign not found"
+		);
+	});
+
+	it("replaces missing-capability wording with the unavailable message", () => {
+		expect(sanitizeUserFacingText("OpenAI API key not configured")).toBe(
+			UNAVAILABLE_MESSAGE
+		);
+		expect(
+			sanitizeUserFacingText("AI is not configured for this environment.")
+		).toBe(UNAVAILABLE_MESSAGE);
+		expect(
+			sanitizeUserFacingText(
+				"Session digest indexing requires database, vector index, and OpenAI API key."
+			)
+		).toBe(UNAVAILABLE_MESSAGE);
+	});
+
+	it("replaces unexpected infrastructure failures with the generic message", () => {
+		expect(sanitizeUserFacingText("D1 query failed")).toBe(
+			GENERIC_FAILURE_MESSAGE
+		);
+		expect(sanitizeUserFacingText("Anthropic returned an error")).toBe(
+			GENERIC_FAILURE_MESSAGE
+		);
+	});
+
+	it("never returns text that still leaks implementation detail", () => {
+		const leaky = [
+			"Cloudflare Workers AI is not enabled",
+			"Vectorize index unavailable",
+			"Missing ANTHROPIC_API_KEY environment variable",
+			"Durable Object storage failed",
+		];
+		for (const text of leaky) {
+			expect(containsImplementationDetail(sanitizeUserFacingText(text))).toBe(
+				false
+			);
+		}
+	});
+
+	it("returns the generic message for empty input", () => {
+		expect(sanitizeUserFacingText("")).toBe(GENERIC_FAILURE_MESSAGE);
+		expect(sanitizeUserFacingText(null)).toBe(GENERIC_FAILURE_MESSAGE);
+	});
+});

--- a/tests/tools/tool-utils.test.ts
+++ b/tests/tools/tool-utils.test.ts
@@ -117,6 +117,65 @@ describe("tool-utils", () => {
 			const result = createToolError("Fail", 123, 400, "tc-3");
 			expect(result.result.data.error).toBe("123");
 		});
+
+		// The whole result is handed to the chat model, so nothing in it may name
+		// the technology behind LoreSmith.
+		describe("redacts implementation detail", () => {
+			it("replaces a message naming a vendor or missing config", () => {
+				const result = createToolError(
+					"OpenAI API key not configured",
+					new Error("AI is not configured for this environment."),
+					503,
+					"tc-4"
+				);
+				expect(result.result.message).not.toMatch(/openai/i);
+				expect(result.result.message).not.toMatch(/configured/i);
+				expect(result.result.data.error).not.toMatch(/environment/i);
+			});
+
+			it("redacts the detail even when the message is already clean", () => {
+				const result = createToolError(
+					"Could not build the session digest",
+					new Error("Vectorize index unavailable"),
+					500,
+					"tc-5"
+				);
+				expect(result.result.message).toBe(
+					"Could not build the session digest"
+				);
+				expect(result.result.data.error).not.toMatch(/vectorize/i);
+			});
+
+			it("drops the campaign suffix from a redacted message", () => {
+				const result = createToolError(
+					"Direct database access is required for loot generation.",
+					"err",
+					500,
+					"tc-6",
+					null,
+					"Campaign X"
+				);
+				expect(result.result.message).not.toMatch(/database/i);
+				expect(result.result.message).not.toMatch(/for campaign/i);
+				// Still reported in structured data for the UI.
+				expect(result.result.data.campaignName).toBe("Campaign X");
+			});
+
+			it("leaves ordinary failures and their campaign suffix intact", () => {
+				const result = createToolError(
+					"Campaign not found",
+					new Error("no row"),
+					404,
+					"tc-7",
+					null,
+					"Campaign X"
+				);
+				expect(result.result.message).toBe(
+					'Campaign not found for campaign "Campaign X"'
+				);
+				expect(result.result.data.error).toBe("no row");
+			});
+		});
 	});
 
 	describe("createToolSuccess", () => {


### PR DESCRIPTION
## What

The assistant was explaining LoreSmith's architecture to users. From a real session, asked to generate ambient sound:

> Ambient sound generation isn't available in this environment right now, unfortunately, this campaign's setup doesn't have **an audio provider configured** (**Cloudflare's built-in AI** doesn't offer that **model** yet, and no external one is **hooked up**).
> [...] those may use a different **model path** [...]
> If you want, I can **flag this to support** so they know audio generation for ambience/sfx is unavailable here.

Users are storytellers, not engineers. None of that is theirs to know, and the support escalation does not exist.

## Why it happened, in two places

**1. The prompt never forbade it.** `buildSystemPrompt()` is the single chokepoint for all 13 agents. It had a `PLAIN LANGUAGE` rule, but it was gated behind the `dataRetrieval` preset and only banned *search* jargon ("semantic search", "embedding"). Nothing covered vendors, infrastructure, or internals.

**2. Tool failures hand the model the vocabulary.** `createToolError()`'s whole result goes into the model's context. 94 of ~336 error sites carry strings like `"OpenAI API key not configured"`, `"AI is not configured for this environment."`, `"Direct database access is required."` Telling the model not to say what it was just handed is a losing setup, so both layers are fixed.

## Changes

- **`src/agents/system-prompts.ts`** — new always-on `NO_IMPLEMENTATION_DETAILS_RULE`: no platforms, vendors, models, providers, API keys, databases, indexes, environments or config; no internals (agents, routing, tools, chunks, tokens, IDs, error codes); no relaying raw error text; no inventing a support escalation; no promising a future fix. Says what it *can't* do and what it *can* do instead, never why.
- **`PLAIN_LANGUAGE_RULE` hoisted out of the `dataRetrieval` preset** so it applies to every agent. Any agent can hit a failure and try to explain it, so this was never safe as a per-agent opt-in.
- **`src/lib/user-facing-language.ts`** (new) — `sanitizeUserFacingText()`. Messages naming infrastructure are replaced wholesale with either "That's not something I can do right now." or a generic failure line. Messages without it ("Campaign not found") pass through untouched.
- **`src/tools/tool-utils.ts`** — `createToolError()` sanitizes both `message` and `data.error`, and `console.error`s the originals so developers keep the detail in logs.
- **`src/agents/base-agent.ts`** — the hardcoded context-length message ("the context retrieved from your campaign", "query", "capacity") rewritten in plain language. This one is shown to the user directly, so no prompt rule could reach it.

### Two deliberate non-changes

- **Bare HTTP status codes are not redacted.** They reveal nothing about how the app is built, and the model needs "not found" vs "broke" to answer sensibly. The prompt rule keeps codes out of what the user reads. (My first pass did redact them; it broke 7 existing tests in `campaignTools.test.ts`, which was the right signal.)
- **Regexes are deliberately narrow.** This is a tabletop RPG app, so `environment`, `worker`, `binding`, `model` and `provider` are all legitimate in-world words. Each is matched only in a phrase that can only be infrastructure (`this environment`, `model path`, `audio provider`). Tests pin this: "No creatures found for that environment" and "The ritual for binding the demon is incomplete" must pass through clean.

The 94 leaky call sites are left as-is rather than hand-edited: the central sanitizer covers them and every future one.

## Verification

- `npm run check` — clean
- `npx vitest run` — 204 files, **1945 passed**
- `npm run test:coverage` — branches 74.4%, above the 70% gate
- `npm run complexity` — passed
- Playwright e2e — passed in CI (not run locally)

All four CI gates (`check`, `validate`, `migrations`, `e2e`) are green.

No docs changed, so no wiki sync applies.

## How to see this change

```bash
gh pr checkout <PR#>
```

There is no UI to click for this one; it is prompt text plus a pure function. Two ways to see it:

**1. The rendered prompt and the sanitizer, against the exact phrases from the screenshot:**

```bash
npx vitest run tests/lib/user-facing-language.test.ts tests/agents/system-prompts.test.ts tests/tools/tool-utils.test.ts
```

**What you should see:** 50 passing tests. The interesting ones assert that both presets now carry `NEVER REVEAL HOW LORESMITH IS BUILT`, and that the real strings from the session above get replaced:

```
"this campaign's setup doesn't have an audio provider configured"
  -> "That's not something I can do right now."
"Cloudflare's built-in AI doesn't offer that model yet"
  -> "That's not something I can do right now."
"OpenAI API key not configured"
  -> "That's not something I can do right now."
"Campaign not found"
  -> "Campaign not found"          # unchanged, as it should be
```

(I ran exactly this locally; the mapping above is the actual output.)

**2. In the running app** (two terminals, per `docs/DEV_SETUP.md`):

```bash
npm run dev:cloudflare     # terminal 1
npm run start              # terminal 2
```

Go to `http://localhost:5173`, pick a campaign, and ask the chat for something LoreSmith cannot do, e.g. *"generate ambient sounds for Firstburn"*.

**What you should see:** before, a reply naming Cloudflare, providers, model paths, and offering to escalate to support. After, a reply that says it can't create audio, offers what it *can* do instead, and never explains why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

