### PR TITLE
feat(llm-cost): content-hash result cache and character-sheet pre-screen (#761)

### DIFF
--- a/docs/LLM_RESULT_CACHE.md
+++ b/docs/LLM_RESULT_CACHE.md
@@ -1,0 +1,126 @@
+# LLM Result Cache
+
+A content-addressed cache for expensive model results, so the same document is
+never extracted twice.
+
+`CommunitySummaryService.generateOrGetSummary` has always checked for an existing
+summary before calling a model. That was the only place doing it. Re-uploading the
+same PDF, adding a document to a second campaign, or retrying a failed index
+re-paid full extraction cost on Sonnet 5 every time — nothing keyed a result by
+its content. This closes that gap (issue #761, finding 8).
+
+## What is cached
+
+| Kind | Pipeline | Tier | Why it is worth caching |
+|---|---|---|---|
+| `entity_extraction` | Per-chunk entity extraction | `PIPELINE_STRUCTURED` (Sonnet 5) | The volume path — every chunk of every uploaded document |
+| `character_sheet_detection` | Character-sheet detection | `ANALYSIS` (Haiku 4.5) | Runs on **every** upload, character sheet or not |
+| `character_sheet_parse` | Character-sheet parsing | `SESSION_PLANNING` (Sonnet 5) | A full document in one call |
+
+## The key
+
+`cache_key` is a SHA-256 digest over `(namespace, kind, model, rendered prompt
+prefix, per-call content)`. Three properties follow from that, and each of them
+is the answer to a way this kind of cache usually goes wrong:
+
+**There is no prompt-version constant to forget.** Issue #761 asks for a key over
+`(model, prompt-version, chunk-content)`. A hand-maintained `PROMPT_VERSION = 3`
+is a step someone eventually does not take, and a cache that silently serves
+results from a superseded prompt is worse than no cache. Hashing the *rendered
+prompt* means an instruction edit and a content edit invalidate by the same
+mechanism.
+
+**A tier change cannot serve the old model's output.** The resolved model id is
+in the key, so moving a pipeline from Haiku to Sonnet misses rather than
+returning what Haiku said.
+
+**Components are hashed before being joined**, so no rearrangement of text across
+the prompt/content boundary can collide — a plain `${prefix}|${content}` join
+cannot promise that.
+
+## The payload is campaign-independent
+
+This is the property that makes the cache worth having, and it constrains *where*
+the cache sits in the call.
+
+For entity extraction the stored value is the validated model output, captured
+**before** entity IDs are minted and scoped to a campaign. `mapExtractionPayload`
+then re-mints them per campaign. So adding the same document to a second campaign
+is a cache hit that still produces entities belonging to that campaign — not to
+the one that paid for the extraction.
+
+If the cache sat one layer higher, around the campaign-scoped result, it would
+hit only on a literal re-upload into the same campaign, which is the rarer case.
+
+## Every failure is a miss
+
+Missing table, missing DB binding, a D1 error, a stored payload that no longer
+parses — all of them fall through to the model. A cache that can break the
+extraction pipeline is not worth having.
+
+The table-not-yet-migrated window is real rather than hypothetical: merging to
+`main` deploys the Worker automatically, while D1 migrations are applied
+separately (see [Database Migrations](DATABASE_MIGRATIONS.md)). A Worker running
+ahead of its migration pays full model cost and logs nothing alarming.
+
+Two more deliberate non-behaviours:
+
+- **A model failure is never cached.** When a call returns no usable output, the
+  compute step returns `undefined` and nothing is stored, so the next attempt
+  retries the model rather than inheriting one bad response permanently.
+- **Oversized payloads are not stored.** Above `MAX_CACHEABLE_PAYLOAD_BYTES`
+  (512 KB) the result is returned but not written; such a result is simply always
+  recomputed.
+
+## Storage and eviction
+
+One D1 table, `llm_result_cache` (migration `0035_llm_result_cache.sql`), read
+and written through `LlmResultCacheDAO`.
+
+Age is the whole eviction policy: `pruneOldRows()` runs on the fast cron
+alongside the LLM usage-log prunes and deletes rows older than 90 days. Nothing
+more is needed — a cached value is always re-derivable, and a stale prompt's rows
+are already unreachable because their key can never be derived again. They cost
+storage, not correctness.
+
+## Turning it off
+
+On by default. Unlike the extraction chunk gate, a hit changes no model output —
+it returns a payload an identical call already produced — so the conservative
+default is on.
+
+```
+LLM_RESULT_CACHE_ENABLED=false
+```
+
+Anything other than `false` / `0` / `no` / `off` leaves it enabled. The switch
+exists so the cache can be taken out during an incident without a deploy.
+
+## Measuring what it saved
+
+Set `LORESMITH_VERBOSE_LLM_USAGE=true` and read a `wrangler tail`:
+
+| Event | Meaning |
+|---|---|
+| `llm_result_cache_hit` | A model call that did not happen. Carries `kind`, `model`, `payloadBytes`, `priorHits` |
+| `llm_result_cache_miss` | A key with no stored row |
+| `llm_result_cache_payload_too_large` | Result returned but not stored |
+
+Entity-extraction telemetry also records `servedFromResultCache` on each
+extraction count, so the extraction count and the spend log in
+[Cost Attribution](COST_ATTRIBUTION.md) can be reconciled — without it a drop in
+spend with a flat extraction count looks like a bug.
+
+## Adding another call site
+
+1. Take an `LlmResultCache` in the constructor, defaulting to
+   `NOOP_LLM_RESULT_CACHE` so existing construction sites and unit tests are
+   unchanged.
+2. Add a `kind` to `LlmResultCacheKind`.
+3. Wrap **only the model call** in `getOrCompute`, with `promptPrefix` set to the
+   instruction text the call actually sends (render the prompt with empty content
+   to get it) and `variablePart` set to the per-call content.
+4. Return `undefined` from the compute step for a model failure, so it is not
+   stored.
+
+Pass the real cache at the call site with `await createLlmResultCache(env)`.

--- a/migrations/0035_llm_result_cache.sql
+++ b/migrations/0035_llm_result_cache.sql
@@ -1,0 +1,43 @@
+-- Content-addressed cache for expensive LLM results (issue #761, finding 8)
+--
+-- `CommunitySummaryService.generateOrGetSummary` already checks for an existing
+-- result before calling a model. Nothing else did, so re-uploading the same PDF
+-- or re-running a rebuild over unchanged chunks re-paid full extraction cost on
+-- Sonnet 5 every time.
+--
+-- `cache_key` is a SHA-256 hex digest over (namespace version, kind, model,
+-- rendered prompt prefix, per-call content). Hashing the *rendered prompt*
+-- rather than a hand-maintained version constant means an instruction edit and
+-- a content edit invalidate by the same mechanism — there is no version number
+-- for a future author to forget to bump.
+--
+-- The stored `payload` is deliberately the *validated, campaign-independent*
+-- model output, captured before entity IDs are minted and scoped to a campaign.
+-- That is what makes the same document uploaded to a second campaign a cache
+-- hit rather than a second full extraction.
+--
+-- There is no eviction beyond an age sweep on the fast cron. Rows are small
+-- (a capped JSON payload) and a stale prompt's rows are already unreachable —
+-- their key can never be derived again — so they cost storage, not correctness.
+CREATE TABLE IF NOT EXISTS llm_result_cache (
+  cache_key TEXT PRIMARY KEY,
+  -- Which pipeline produced this, e.g. 'entity_extraction'. Also the unit the
+  -- hit-rate log groups by.
+  kind TEXT NOT NULL,
+  model TEXT NOT NULL,
+  -- JSON. Result of the call, as validated by the caller's schema.
+  payload TEXT NOT NULL,
+  payload_bytes INTEGER NOT NULL,
+  hit_count INTEGER NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_hit_at DATETIME
+);
+
+-- The retention sweep on the fast cron deletes by age.
+CREATE INDEX IF NOT EXISTS idx_llm_result_cache_created
+  ON llm_result_cache(created_at);
+
+-- Reporting what the cache saved, and dropping a superseded model's rows after
+-- a tier change, both scan by these two columns.
+CREATE INDEX IF NOT EXISTS idx_llm_result_cache_kind_model
+  ON llm_result_cache(kind, model);

--- a/scripts/d1/d1-bootstrap.sql
+++ b/scripts/d1/d1-bootstrap.sql
@@ -1179,3 +1179,47 @@ CREATE TABLE IF NOT EXISTS experiments (
 -- resolves the whole map for one user), so the admin listing order is the only
 -- access pattern worth an index beyond the primary key.
 CREATE INDEX IF NOT EXISTS idx_experiments_status ON experiments(status);
+
+-- Content-addressed cache for expensive LLM results (issue #761, finding 8)
+--
+-- `CommunitySummaryService.generateOrGetSummary` already checks for an existing
+-- result before calling a model. Nothing else did, so re-uploading the same PDF
+-- or re-running a rebuild over unchanged chunks re-paid full extraction cost on
+-- Sonnet 5 every time.
+--
+-- `cache_key` is a SHA-256 hex digest over (namespace version, kind, model,
+-- rendered prompt prefix, per-call content). Hashing the *rendered prompt*
+-- rather than a hand-maintained version constant means an instruction edit and
+-- a content edit invalidate by the same mechanism — there is no version number
+-- for a future author to forget to bump.
+--
+-- The stored `payload` is deliberately the *validated, campaign-independent*
+-- model output, captured before entity IDs are minted and scoped to a campaign.
+-- That is what makes the same document uploaded to a second campaign a cache
+-- hit rather than a second full extraction.
+--
+-- There is no eviction beyond an age sweep on the fast cron. Rows are small
+-- (a capped JSON payload) and a stale prompt's rows are already unreachable —
+-- their key can never be derived again — so they cost storage, not correctness.
+CREATE TABLE IF NOT EXISTS llm_result_cache (
+  cache_key TEXT PRIMARY KEY,
+  -- Which pipeline produced this, e.g. 'entity_extraction'. Also the unit the
+  -- hit-rate log groups by.
+  kind TEXT NOT NULL,
+  model TEXT NOT NULL,
+  -- JSON. Result of the call, as validated by the caller's schema.
+  payload TEXT NOT NULL,
+  payload_bytes INTEGER NOT NULL,
+  hit_count INTEGER NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_hit_at DATETIME
+);
+
+-- The retention sweep on the fast cron deletes by age.
+CREATE INDEX IF NOT EXISTS idx_llm_result_cache_created
+  ON llm_result_cache(created_at);
+
+-- Reporting what the cache saved, and dropping a superseded model's rows after
+-- a tier change, both scan by these two columns.
+CREATE INDEX IF NOT EXISTS idx_llm_result_cache_kind_model
+  ON llm_result_cache(kind, model);

--- a/scripts/wiki/sync-docs-to-wiki.js
+++ b/scripts/wiki/sync-docs-to-wiki.js
@@ -95,6 +95,11 @@ const FILE_MAPPINGS = [
 		process: true,
 	},
 	{
+		src: "docs/LLM_RESULT_CACHE.md",
+		dest: "Technical/LLM-Result-Cache.md",
+		process: true,
+	},
+	{
 		src: "docs/FILE_UPLOAD_SYSTEM.md",
 		dest: "Technical/File-Upload-System.md",
 		process: true,
@@ -351,6 +356,7 @@ function createSidebar() {
 - [[Technical/GraphRAG-Integration|GraphRAG Integration]]
 - [[Technical/Library-Entity-Pipeline|Library entity pipeline]]
 - [[Technical/LLM-Batch-Processing|LLM batch processing]]
+- [[Technical/LLM-Result-Cache|LLM result cache]]
 - [[Technical/File-Upload-System|File upload system]]
 - [[Technical/File-Analysis-System|File analysis system]]
 - [[Technical/Large-File-Support|Large file support]]

--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -1272,6 +1272,29 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 			// keeps billing) server-side long after the client stopped listening.
 			...(abortSignal ? { abortSignal } : {}),
 			stopWhen: stepCountIs(MAX_AGENT_STEPS),
+			// This is the *second* truncation strategy in this method, and it is not
+			// redundant with the first: `buildConversationContext` folds older turns
+			// into a summary before the call, while this one bounds the messages a
+			// long tool loop adds during it. They cannot be merged — the summariser
+			// runs once, before any step exists.
+			//
+			// They do interfere, in two ways worth knowing before #734 places a
+			// message-level cache breakpoint (issue #761, finding 9):
+			//
+			// 1. `MAX_CONTEXT_MESSAGES` above keeps up to 32 recent turns. Once that
+			//    window is full this branch fires on step *one*, before any tool
+			//    traffic, and cuts it to 15. The effective history is therefore 15,
+			//    not 32, on exactly the long conversations the summariser is for.
+			//    (The summary block itself survives — it rides in the system prompt.)
+			// 2. Slicing from the front rewrites the message prefix on every later
+			//    step, so any message-level cache entry is discarded precisely when a
+			//    long loop would benefit most. #734's target is the system+tools
+			//    prefix, which renders before messages and is unaffected — but a
+			//    message breakpoint added later must not sit above this slice.
+			//
+			// Left as-is here deliberately: changing the window changes chat
+			// behaviour, and truncating from anywhere but the end risks orphaning a
+			// tool-call/tool-result pair, which Anthropic rejects outright.
 			prepareStep: async ({ messages }) => {
 				if (messages.length > MESSAGE_COMPRESSION_THRESHOLD) {
 					log.debug("Compressing message history for long agent loop", {

--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -27,6 +27,7 @@ import { FileRetryUsageDAO } from "./file-retry-usage-dao";
 import { GraphRebuildDirtyDAO } from "./graph-rebuild-dirty-dao";
 import { LlmBatchJobDAO } from "./llm-batch-job-dao";
 import { LLMCostEventDAO } from "./llm-cost-event-dao";
+import { LlmResultCacheDAO } from "./llm-result-cache-dao";
 import { LLMUsageDAO } from "./llm-usage-dao";
 import { MessageHistoryDAO } from "./message-history-dao";
 import { PlanningTaskDAO } from "./planning-task-dao";
@@ -68,6 +69,7 @@ export interface DAOFactory {
 	llmUsageDAO: LLMUsageDAO;
 	llmCostEventDAO: LLMCostEventDAO;
 	llmBatchJobDAO: LlmBatchJobDAO;
+	llmResultCacheDAO: LlmResultCacheDAO;
 	communityDAO: CommunityDAO;
 	communitySummaryDAO: CommunitySummaryDAO;
 	continuityFindingDAO: ContinuityFindingDAO;
@@ -116,6 +118,7 @@ export class DAOFactoryImpl implements DAOFactory {
 	public readonly llmUsageDAO: LLMUsageDAO;
 	public readonly llmCostEventDAO: LLMCostEventDAO;
 	public readonly llmBatchJobDAO: LlmBatchJobDAO;
+	public readonly llmResultCacheDAO: LlmResultCacheDAO;
 	public readonly communityDAO: CommunityDAO;
 	public readonly communitySummaryDAO: CommunitySummaryDAO;
 	public readonly continuityFindingDAO: ContinuityFindingDAO;
@@ -160,6 +163,7 @@ export class DAOFactoryImpl implements DAOFactory {
 		this.llmUsageDAO = new LLMUsageDAO(db);
 		this.llmCostEventDAO = new LLMCostEventDAO(db);
 		this.llmBatchJobDAO = new LlmBatchJobDAO(db);
+		this.llmResultCacheDAO = new LlmResultCacheDAO(db);
 		this.communityDAO = new CommunityDAO(db);
 		this.communitySummaryDAO = new CommunitySummaryDAO(db);
 		this.continuityFindingDAO = new ContinuityFindingDAO(db);

--- a/src/dao/llm-result-cache-dao.ts
+++ b/src/dao/llm-result-cache-dao.ts
@@ -1,0 +1,100 @@
+import { BaseDAOClass } from "@/dao/base-dao";
+import type { LlmResultCacheKind } from "@/lib/llm-result-cache-key";
+
+export interface LlmResultCacheRow {
+	cache_key: string;
+	kind: string;
+	model: string;
+	payload: string;
+	payload_bytes: number;
+	hit_count: number;
+	created_at: string;
+	last_hit_at: string | null;
+}
+
+export interface PutLlmResultCacheInput {
+	cacheKey: string;
+	kind: LlmResultCacheKind;
+	model: string;
+	/** Already-serialized JSON payload. */
+	payload: string;
+}
+
+/** Rows older than this are swept by the fast cron. */
+export const LLM_RESULT_CACHE_RETENTION_DAYS = 90;
+
+/**
+ * Persistence for the content-addressed LLM result cache (issue #761, finding 8).
+ *
+ * Every method degrades to "cache miss" when the table is absent, so a Worker
+ * deployed ahead of its migration pays full model cost rather than throwing on
+ * every extraction. Merging to `main` deploys the Worker automatically but does
+ * not apply D1 migrations, so that window is real, not hypothetical.
+ */
+export class LlmResultCacheDAO extends BaseDAOClass {
+	async isSchemaReady(): Promise<boolean> {
+		return this.hasTable("llm_result_cache");
+	}
+
+	/**
+	 * Fetch a cached payload. Returns the raw JSON string; deserialization and
+	 * schema validation belong to the caller, which owns the shape.
+	 */
+	async get(cacheKey: string): Promise<LlmResultCacheRow | null> {
+		return this.queryFirst<LlmResultCacheRow>(
+			`SELECT * FROM llm_result_cache WHERE cache_key = ?`,
+			[cacheKey]
+		);
+	}
+
+	/**
+	 * Store a payload, ignoring one that is already there.
+	 *
+	 * `INSERT OR IGNORE` rather than an upsert: two concurrent extractions of the
+	 * same chunk produce interchangeable payloads, so the first to land is as good
+	 * as the second and overwriting would only churn the row.
+	 */
+	async put(input: PutLlmResultCacheInput): Promise<void> {
+		await this.execute(
+			`INSERT OR IGNORE INTO llm_result_cache (
+        cache_key, kind, model, payload, payload_bytes, hit_count, created_at
+      ) VALUES (?, ?, ?, ?, ?, 0, datetime('now'))`,
+			[
+				input.cacheKey,
+				input.kind,
+				input.model,
+				input.payload,
+				input.payload.length,
+			]
+		);
+	}
+
+	/**
+	 * Record that a row was served. Best-effort accounting for the savings
+	 * report — never on the critical path of returning the payload.
+	 */
+	async recordHit(cacheKey: string): Promise<void> {
+		await this.execute(
+			`UPDATE llm_result_cache
+         SET hit_count = hit_count + 1, last_hit_at = datetime('now')
+       WHERE cache_key = ?`,
+			[cacheKey]
+		);
+	}
+
+	/** Age-based eviction, run from the fast cron alongside the usage-log prunes. */
+	async pruneOldRows(
+		retentionDays: number = LLM_RESULT_CACHE_RETENTION_DAYS
+	): Promise<number> {
+		if (!(await this.isSchemaReady())) {
+			return 0;
+		}
+		const result = await this.db
+			.prepare(
+				`DELETE FROM llm_result_cache WHERE created_at < datetime('now', ?)`
+			)
+			.bind(`-${retentionDays} days`)
+			.run();
+		return result.meta?.changes ?? 0;
+	}
+}

--- a/src/lib/english-prose-stats.ts
+++ b/src/lib/english-prose-stats.ts
@@ -1,0 +1,86 @@
+/**
+ * "Is this English prose?" — the one text-shape measure shared by the
+ * deterministic pre-gates added under issue #761.
+ *
+ * Both pre-gates need it for the same reason, and it is the reason worth
+ * spelling out: **the absence of a keyword only means something in a language
+ * whose keywords we know.** A rule like "no character-sheet vocabulary, so not
+ * a character sheet" is safe on an English document and wrong on a French one.
+ * Requiring a minimum connective-word density before acting on an absence is
+ * what closes that hole, so a non-English document falls through to the model
+ * instead of being skipped.
+ */
+
+/**
+ * Words common enough that any real English prose contains several. A run of
+ * page numbers, a heading index, or text in another language contains almost
+ * none.
+ */
+export const COMMON_WORDS = new Set([
+	"the",
+	"a",
+	"an",
+	"and",
+	"or",
+	"but",
+	"if",
+	"of",
+	"to",
+	"in",
+	"on",
+	"at",
+	"for",
+	"with",
+	"from",
+	"by",
+	"as",
+	"is",
+	"are",
+	"was",
+	"were",
+	"be",
+	"been",
+	"has",
+	"have",
+	"had",
+	"can",
+	"may",
+	"will",
+	"would",
+	"this",
+	"that",
+	"they",
+	"their",
+	"you",
+	"your",
+	"it",
+	"its",
+	"not",
+	"when",
+	"which",
+	"who",
+	"all",
+	"any",
+	"each",
+	"more",
+	"than",
+	"then",
+	"into",
+	"out",
+	"up",
+	"do",
+	"does",
+]);
+
+/** Lowercased alphabetic words. Apostrophes are kept so "it's" stays one token. */
+export function tokenizeWords(text: string): string[] {
+	return text.toLowerCase().match(/[a-z']+/g) ?? [];
+}
+
+/** Share of words drawn from {@link COMMON_WORDS}. 0 for text with no words. */
+export function commonWordRatio(words: string[]): number {
+	if (words.length === 0) {
+		return 0;
+	}
+	return words.filter((w) => COMMON_WORDS.has(w)).length / words.length;
+}

--- a/src/lib/llm-result-cache-key.ts
+++ b/src/lib/llm-result-cache-key.ts
@@ -1,0 +1,86 @@
+/**
+ * Cache keys for the content-addressed LLM result cache (issue #761, finding 8).
+ *
+ * Pure and dependency-free so the key derivation can be tested without a D1
+ * binding, and so the queue-driven batch path can derive the same key as the
+ * inline path without importing the whole service.
+ *
+ * The issue asks for a key over `(model, prompt-version, chunk-content)`. This
+ * hashes the **rendered prompt prefix** in place of a `prompt-version` constant:
+ * a hand-maintained version number is a step someone eventually forgets to
+ * bump, and a stale cache that silently serves results from a superseded prompt
+ * is worse than no cache. Deriving the version from the prompt text itself
+ * makes an instruction edit and a content edit invalidate by the same
+ * mechanism, with nothing left to remember.
+ */
+
+/** Which pipeline a cached payload came from. Also the hit-rate grouping key. */
+export type LlmResultCacheKind =
+	| "entity_extraction"
+	| "character_sheet_detection"
+	| "character_sheet_parse";
+
+/**
+ * Bumped by hand only when the *interpretation* of a stored payload changes in
+ * a way the prompt text does not capture — a new post-processing step, a
+ * different validation schema applied to the same model output. Prompt edits do
+ * not need it; they change `promptDigest` on their own.
+ */
+export const LLM_RESULT_CACHE_NAMESPACE = "v1";
+
+const encoder = new TextEncoder();
+
+/** SHA-256 as lowercase hex. `crypto.subtle` is available in Workers and Node 18+. */
+export async function sha256Hex(input: string): Promise<string> {
+	const digest = await crypto.subtle.digest("SHA-256", encoder.encode(input));
+	return Array.from(new Uint8Array(digest))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+export interface LlmResultCacheKeyInput {
+	kind: LlmResultCacheKind;
+	/** Resolved model id, so a tier change does not serve the old model's output. */
+	model: string;
+	/**
+	 * The stable instruction block — everything that is identical across calls of
+	 * this kind. Editing it must invalidate every entry, which is what hashing it
+	 * into the key achieves.
+	 */
+	promptPrefix: string;
+	/** The per-call part: chunk text, document text, a name hint. */
+	variablePart: string;
+}
+
+export interface LlmResultCacheKeyParts {
+	/** Primary key of the cache row. */
+	cacheKey: string;
+	/** Digest of `promptPrefix` alone, so a superseded prompt's rows can be swept. */
+	promptDigest: string;
+}
+
+/**
+ * Derive the cache key and the prompt digest.
+ *
+ * Components are hashed to fixed-length hex before being joined, so no choice of
+ * prompt or content can produce the same joined string as a different choice —
+ * a plain `${a}|${b}` join over variable-length text cannot promise that.
+ */
+export async function buildLlmResultCacheKey(
+	input: LlmResultCacheKeyInput
+): Promise<LlmResultCacheKeyParts> {
+	const [promptDigest, contentDigest] = await Promise.all([
+		sha256Hex(input.promptPrefix),
+		sha256Hex(input.variablePart),
+	]);
+	const cacheKey = await sha256Hex(
+		[
+			LLM_RESULT_CACHE_NAMESPACE,
+			input.kind,
+			input.model,
+			promptDigest,
+			contentDigest,
+		].join("\n")
+	);
+	return { cacheKey, promptDigest };
+}

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -387,6 +387,10 @@ async function runFastScheduledTasks(
 		// Cost attribution keeps a much longer horizon than the rate-limit ledger
 		// (90 days vs 25 hours) so month-over-month comparisons stay possible.
 		await daoFactory.llmCostEventDAO.pruneOldRows();
+		// Cached model results are only ever re-derivable, so age is the whole
+		// eviction policy: a row nothing has asked for in 90 days is storage, not
+		// a saving.
+		await daoFactory.llmResultCacheDAO.pruneOldRows();
 	} catch (error) {
 		log.error("Failed to prune LLM usage log", error);
 	}

--- a/src/services/campaign/entity-staging-service.ts
+++ b/src/services/campaign/entity-staging-service.ts
@@ -36,6 +36,7 @@ import { ProviderEmbeddingService } from "@/services/embedding/provider-embeddin
 import { EntityGraphService } from "@/services/graph/entity-graph-service";
 import { EntityImportanceService } from "@/services/graph/entity-importance-service";
 import { getLLMRateLimitService } from "@/services/llm/llm-rate-limit-service";
+import { createLlmResultCache } from "@/services/llm/llm-result-cache";
 import type { ExtractedEntity } from "@/services/rag/entity-extraction-service";
 import { EntityExtractionService } from "@/services/rag/entity-extraction-service";
 import {
@@ -657,7 +658,12 @@ async function stageEntitiesFromResourceImpl(
 
 		// Check if this is a character sheet before normal entity extraction
 		try {
-			const detectionService = new CharacterSheetDetectionService(llmApiKey);
+			const resultCache = await createLlmResultCache(env);
+			const detectionService = new CharacterSheetDetectionService(
+				llmApiKey,
+				resultCache,
+				env
+			);
 			const rateLimitService = getLLMRateLimitService(env);
 			const detectionResult = await detectionService.detectCharacterSheet(
 				fileContent,
@@ -684,7 +690,10 @@ async function stageEntitiesFromResourceImpl(
 
 			if (detectionService.isConfidentDetection(detectionResult)) {
 				// Parse the character sheet
-				const parserService = new CharacterSheetParserService(llmApiKey);
+				const parserService = new CharacterSheetParserService(
+					llmApiKey,
+					resultCache
+				);
 				const characterData = await parserService.parseCharacterSheet(
 					fileContent,
 					detectionResult.characterName || undefined
@@ -874,8 +883,15 @@ async function stageEntitiesFromResourceImpl(
 			}
 		}
 
-		// Extract entities from each chunk and merge results
-		const extractionService = new EntityExtractionService(llmApiKey);
+		// Extract entities from each chunk and merge results.
+		// The result cache is content-addressed, so re-indexing a file whose chunks
+		// have not changed — or adding the same document to a second campaign —
+		// skips the Sonnet call per unchanged chunk (issue #761, finding 8).
+		const extractionService = new EntityExtractionService(
+			llmApiKey,
+			null,
+			await createLlmResultCache(env)
+		);
 		const allExtractedEntities: Map<string, ExtractedEntity> = new Map();
 		let jsonRepairCount = 0;
 		let batchServedChunks = 0;

--- a/src/services/character-sheet/character-sheet-detection-service.ts
+++ b/src/services/character-sheet/character-sheet-detection-service.ts
@@ -3,12 +3,22 @@
 
 import { z } from "zod";
 import { getGenerationModelForProvider, MODEL_CONFIG } from "@/app-constants";
+import type { EnvWithSecrets } from "@/lib/env-utils";
 import { chunkTextByCharacterCount } from "@/lib/file/text-chunking-utils";
 import type { LlmUsageReport } from "@/lib/llm-usage-breakdown";
 import { isVerboseLlmSpendEnabled } from "@/lib/llm-usage-verbose-log";
 import { formatCharacterSheetDetectionPrompt } from "@/lib/prompts/character-sheet-prompts";
 import { parseOrThrow } from "@/lib/zod-utils";
 import { createLLMProvider } from "@/services/llm/llm-provider-factory";
+import {
+	type LlmResultCache,
+	NOOP_LLM_RESULT_CACHE,
+} from "@/services/llm/llm-result-cache";
+import { logCharacterSheetDetection } from "./character-sheet-detection-telemetry";
+import {
+	classifyCharacterSheetAdvisory,
+	classifyCharacterSheetDecisively,
+} from "./character-sheet-indicators";
 
 const DETECTION_CONFIDENCE_THRESHOLD = 0.7;
 const MAX_CHUNK_SIZE = 10000; // Characters per chunk for detection
@@ -49,9 +59,45 @@ export type CharacterSheetDetectionResult = z.infer<
  * Service to detect if extracted text content is a character sheet.
  * Works on any file type (PDF, DOCX, Markdown, TXT, etc.) as long as text can be extracted.
  * Game-system agnostic - works with D&D, Pathfinder, Call of Cthulhu, etc.
+ *
+ * ## Why detection is still a separate call from parsing
+ *
+ * Issue #761 finding 5b proposes merging this with `CharacterSheetParserService`
+ * into one SESSION_PLANNING call that returns `isCharacterSheet` alongside the
+ * parsed data. Measured against what each pass actually costs, that trade is
+ * negative:
+ *
+ * | Path | Today | Merged |
+ * |---|---|---|
+ * | True positive | ~7.5k tok on ANALYSIS + full doc on SESSION_PLANNING | full doc on SESSION_PLANNING |
+ * | True negative | ~7.5k tok on ANALYSIS | **full doc on SESSION_PLANNING** |
+ *
+ * Detection caps its input at three 10,000-character chunks; parsing sends up to
+ * 200,000 characters. So merging saves the detection pass — a few percent — on a
+ * true positive, and pays roughly twenty times more on a true negative. Most
+ * uploads are true negatives, which is the case the merge is worst for. "Returns
+ * early on false" does not help: the early return saves output tokens, and the
+ * cost here is input.
+ *
+ * The merge only becomes a win behind a pre-screen confident enough to route
+ * *positives* deterministically, and `classifyCharacterSheetDecisively` only ever
+ * short-circuits negatives — deliberately, since a wrong positive would create a
+ * bogus PC entity. Promoting a positive rule needs the agreement data that
+ * `character-sheet-detection-telemetry` now collects. Until then, two calls.
  */
 export class CharacterSheetDetectionService {
-	constructor(private llmApiKey: string) {}
+	constructor(
+		private llmApiKey: string,
+		/**
+		 * Content-addressed result cache (issue #761, finding 8). Detection runs on
+		 * every uploaded file, so a re-upload or a retry of the same document is
+		 * pure repeat spend. Defaults to the no-op cache so existing construction
+		 * sites are unchanged.
+		 */
+		private resultCache: LlmResultCache = NOOP_LLM_RESULT_CACHE,
+		/** Worker env, used only for the advisory-rule agreement log. */
+		private env?: EnvWithSecrets | Record<string, unknown>
+	) {}
 
 	/**
 	 * Detect if the provided text content is a character sheet
@@ -68,15 +114,62 @@ export class CharacterSheetDetectionService {
 		}
 	): Promise<CharacterSheetDetectionResult> {
 		if (!textContent || textContent.trim().length === 0) {
-			return {
-				isCharacterSheet: false,
-				confidence: 0,
-				characterName: undefined,
-				detectedGameSystem: undefined,
-				reasoning: "Empty or no content provided",
-			};
+			return this.notACharacterSheet("Empty or no content provided");
 		}
 
+		// Layer 1: rules that cannot be wrong, evaluated on the whole document
+		// before it is chunked. Detection otherwise runs a model on every upload,
+		// and most uploads are not character sheets (issue #761, finding 5a).
+		const decisive = classifyCharacterSheetDecisively(textContent);
+		if (decisive) {
+			logCharacterSheetDetection(this.env, {
+				source: "deterministic",
+				isCharacterSheet: false,
+				rule: decisive.rule,
+				reason: decisive.reason,
+				groupsMatched: decisive.groupsMatched,
+				documentLength: textContent.length,
+			});
+			return this.notACharacterSheet(decisive.reason);
+		}
+
+		// Layer 2: the full rule set, evaluated but never routed on. Its agreement
+		// with the model below is the measurement that decides what gets promoted.
+		const advisory = classifyCharacterSheetAdvisory(textContent);
+
+		const result = await this.detectViaModel(textContent, options);
+
+		logCharacterSheetDetection(this.env, {
+			source: "llm",
+			isCharacterSheet: result.isCharacterSheet,
+			advisoryVerdict: advisory.verdict,
+			advisoryRule: advisory.rule,
+			// `ambiguous` is a deferral, not a guess — scoring it as a disagreement
+			// would understate how well the rules that do fire are doing.
+			advisoryAgreed:
+				advisory.verdict === "ambiguous"
+					? undefined
+					: (advisory.verdict === "character-sheet") ===
+						result.isCharacterSheet,
+			groupsMatched: advisory.groupsMatched,
+			documentLength: textContent.length,
+			model: getGenerationModelForProvider("ANALYSIS"),
+		});
+
+		return result;
+	}
+
+	/**
+	 * The model-driven detection: one call for a small document, or up to three
+	 * strategically chosen chunks for a large one, combined.
+	 */
+	private async detectViaModel(
+		textContent: string,
+		options?: {
+			username?: string;
+			onUsage?: (usage: LlmUsageReport) => void | Promise<void>;
+		}
+	): Promise<CharacterSheetDetectionResult> {
 		// If content is small enough, analyze it directly
 		if (textContent.length <= MAX_CHUNK_SIZE) {
 			return await this.analyzeChunk(textContent, options);
@@ -130,10 +223,47 @@ export class CharacterSheetDetectionService {
 			onUsage?: (usage: LlmUsageReport) => void | Promise<void>;
 		}
 	): Promise<CharacterSheetDetectionResult> {
+		const includeReasoning = isVerboseLlmSpendEnabled();
 		const prompt = formatCharacterSheetDetectionPrompt(chunkContent, {
-			includeReasoning: isVerboseLlmSpendEnabled(),
+			includeReasoning,
 		});
 
+		// Rendering the prompt with empty content gives the exact instruction text
+		// this call will send, including the reasoning branch, so a prompt edit
+		// invalidates the cache without anyone having to bump a version.
+		const { value } = await this.resultCache.getOrCompute<
+			CharacterSheetDetectionResult | undefined
+		>(
+			{
+				kind: "character_sheet_detection",
+				model: getGenerationModelForProvider("ANALYSIS"),
+				promptPrefix: formatCharacterSheetDetectionPrompt("", {
+					includeReasoning,
+				}),
+				variablePart: chunkContent,
+			},
+			() => this.callDetectionModel(prompt, options)
+		);
+
+		return (
+			value ?? this.notACharacterSheet("Model returned no structured output")
+		);
+	}
+
+	/**
+	 * The model call itself, split out so the cache wraps exactly one thing.
+	 *
+	 * Returns undefined rather than a result when the model produced no output:
+	 * that is a transient failure, and caching it would make one bad response
+	 * permanent for that document.
+	 */
+	private async callDetectionModel(
+		prompt: string,
+		options?: {
+			username?: string;
+			onUsage?: (usage: LlmUsageReport) => void | Promise<void>;
+		}
+	): Promise<CharacterSheetDetectionResult | undefined> {
 		const llmProvider = createLLMProvider({
 			provider: MODEL_CONFIG.PROVIDER.DEFAULT,
 			apiKey: this.llmApiKey,
@@ -170,16 +300,21 @@ export class CharacterSheetDetectionService {
 
 			// No output from model: treat as "not a character sheet", continue with normal extraction
 			if (isNoOutput) {
-				return {
-					isCharacterSheet: false,
-					confidence: 0,
-					characterName: undefined,
-					detectedGameSystem: undefined,
-					reasoning: "Model returned no structured output",
-				};
+				return undefined;
 			}
 			throw error;
 		}
+	}
+
+	/** The conservative answer, used whenever there is nothing to judge. */
+	private notACharacterSheet(reasoning: string): CharacterSheetDetectionResult {
+		return {
+			isCharacterSheet: false,
+			confidence: 0,
+			characterName: undefined,
+			detectedGameSystem: undefined,
+			reasoning,
+		};
 	}
 
 	/**

--- a/src/services/character-sheet/character-sheet-detection-telemetry.ts
+++ b/src/services/character-sheet/character-sheet-detection-telemetry.ts
@@ -1,0 +1,61 @@
+/**
+ * Structured logging for character-sheet detection decisions (issue #761).
+ *
+ * Answers the question that decides how far the deterministic pre-screen should
+ * go: **how often does the model disagree with what a vocabulary match would
+ * have decided?** Filter the drain to `source=llm` and group by `advisoryRule`
+ * + `advisoryAgreed` for a per-rule disagreement rate; a rule that holds up is a
+ * candidate for promotion into `classifyCharacterSheetDecisively`.
+ *
+ * Gated behind `LORESMITH_VERBOSE_LLM_USAGE`, the same switch as token spend and
+ * the chunk gate, rather than adding another knob.
+ */
+
+import type { EnvWithSecrets } from "@/lib/env-utils";
+import { isVerboseLlmSpendEnabled } from "@/lib/llm-usage-verbose-log";
+import { createLogger } from "@/lib/logger";
+import type { CharacterSheetVerdict } from "./character-sheet-indicators";
+
+export type CharacterSheetDetectionLog = {
+	source: "deterministic" | "llm";
+	/** What the pipeline acted on. */
+	isCharacterSheet: boolean;
+	/** Rule that decided, when `source` is `deterministic`. */
+	rule?: string;
+	reason?: string;
+	/** What the advisory rules would have said, when the model branch ran. */
+	advisoryVerdict?: CharacterSheetVerdict;
+	advisoryRule?: string;
+	/** Undefined when the advisory verdict was `ambiguous` (a deferral, not a guess). */
+	advisoryAgreed?: boolean;
+	/** Indicator groups matched, so a threshold can be tuned from the logs. */
+	groupsMatched?: number;
+	documentLength?: number;
+	model?: string;
+};
+
+/**
+ * Emit one structured detection decision line.
+ *
+ * Never throws: an upload must not fail because logging did.
+ */
+export function logCharacterSheetDetection(
+	env: EnvWithSecrets | Record<string, unknown> | undefined,
+	decision: CharacterSheetDetectionLog
+): void {
+	if (!isVerboseLlmSpendEnabled(env)) {
+		return;
+	}
+	try {
+		const log = createLogger(
+			env as Record<string, unknown> | undefined,
+			"[CharacterSheetDetection]"
+		);
+		log.info("character_sheet_detection_decision", {
+			event: "character_sheet_detection_decision",
+			...decision,
+		});
+	} catch {
+		// Logging is best-effort; a drain problem must not break the upload path.
+	}
+}

--- a/src/services/character-sheet/character-sheet-indicators.ts
+++ b/src/services/character-sheet/character-sheet-indicators.ts
@@ -1,0 +1,245 @@
+/**
+ * Deterministic pre-screen for character-sheet detection (issue #761, finding 5a).
+ *
+ * `CharacterSheetDetectionService` runs a model on **every uploaded file**,
+ * across up to three chunks of 10,000 characters each, to answer one boolean.
+ * The prompt asks the model to look for indicators — a character name, a stats
+ * block, class/level, hit points, an equipment list, armour class. Those are
+ * field labels, and field labels are a vocabulary match.
+ *
+ * Structured the way #759 established and #765 reused for the chunk gate:
+ *
+ * - `classifyCharacterSheetDecisively` holds only rules with no failure mode,
+ *   and its answer short-circuits the model call.
+ * - `classifyCharacterSheetAdvisory` holds the full rule set. It is evaluated
+ *   on every detection and logged against what the model said, but never routed
+ *   on. The measured agreement rate is what decides which rules get promoted.
+ *
+ * The one decisive rule is an *absence* rule, and absence is only meaningful in
+ * a language whose vocabulary we know — so it requires English prose density
+ * before it fires. A French character sheet matches no English indicator and
+ * must reach the model, not be skipped. See `lib/english-prose-stats`.
+ */
+
+import { commonWordRatio, tokenizeWords } from "@/lib/english-prose-stats";
+
+export type CharacterSheetVerdict =
+	/** Confidently a character sheet. */
+	| "character-sheet"
+	/** Confidently not one — no model call needed. */
+	| "not-character-sheet"
+	/** Genuinely unclear — defer to the model. */
+	| "ambiguous";
+
+export interface CharacterSheetRuleMatch {
+	verdict: CharacterSheetVerdict;
+	/** Stable identifier so the log drain can group by rule. */
+	rule: string;
+	/** Short justification, safe to log — never contains document text. */
+	reason: string;
+	/** How many distinct indicator groups matched. */
+	groupsMatched: number;
+}
+
+/**
+ * Indicator groups, one per *concept* the detection prompt asks about, with the
+ * vocabulary each concept uses across the systems this app claims to support
+ * (D&D, Pathfinder, Call of Cthulhu, and generic sheets).
+ *
+ * Groups, not raw hits, are what get counted: the prompt's own criterion is
+ * "a character sheet typically has multiple of these indicators present", and a
+ * rulebook page repeating "hit points" forty times is still one concept.
+ */
+const INDICATOR_GROUPS: Array<{ group: string; patterns: RegExp }> = [
+	{
+		group: "identity",
+		patterns: /\b(?:character name|player name|character sheet|investigator)\b/,
+	},
+	{
+		group: "advancement",
+		patterns: /\b(?:level|xp|experience points?|rank|tier|milestones?)\b/,
+	},
+	{
+		group: "role",
+		patterns: /\b(?:class|profession|archetype|occupation|career|calling)\b/,
+	},
+	{
+		group: "ancestry",
+		patterns: /\b(?:race|species|ancestry|heritage|lineage)\b/,
+	},
+	{
+		group: "vitality",
+		patterns: /\b(?:hit points?|hp|health|wounds?|vitality|stamina|sanity)\b/,
+	},
+	{
+		group: "defense",
+		patterns: /\b(?:armou?r class|ac|defen[cs]e|dodge|soak|toughness)\b/,
+	},
+	{
+		group: "attributes",
+		patterns:
+			/\b(?:strength|dexterity|constitution|intelligence|wisdom|charisma|str|dex|con|int|wis|cha|power|appearance|education|willpower|agility)\b/,
+	},
+	{
+		group: "skills",
+		patterns:
+			/\b(?:skills?|proficienc(?:y|ies)|saving throws?|saves|specialit(?:y|ies)|talents?)\b/,
+	},
+	{
+		group: "equipment",
+		patterns:
+			/\b(?:equipment|inventory|gear|possessions|weapons?|armou?r|carried items?)\b/,
+	},
+	{
+		group: "traits",
+		patterns:
+			/\b(?:personality traits?|ideals?|bonds?|flaws?|backstory|background|alignment)\b/,
+	},
+	{
+		group: "magic",
+		patterns: /\b(?:spells?|cantrips?|spell slots?|spellcasting|rituals?)\b/,
+	},
+];
+
+export const INDICATOR_GROUP_COUNT = INDICATOR_GROUPS.length;
+
+/**
+ * Character sheets are short documents. Past this, a high indicator count means
+ * a rulebook — a source that discusses every one of these concepts without
+ * being a sheet for any one character.
+ */
+const RULEBOOK_LENGTH_CHARS = 60_000;
+
+/** Below this word count, an absence of vocabulary proves nothing. */
+const MIN_WORDS_FOR_ABSENCE_RULE = 150;
+
+/** Below this connective-word density the text is not English, so see above. */
+const MIN_ENGLISH_DENSITY = 0.15;
+
+export interface CharacterSheetIndicatorScore {
+	/** Names of the indicator groups that matched. */
+	matchedGroups: string[];
+	groupsMatched: number;
+	wordCount: number;
+	/** Connective-word density; the "is this English" check. */
+	englishDensity: number;
+	length: number;
+}
+
+/** Measure a document against the indicator vocabulary. Pure and allocation-light. */
+export function scoreCharacterSheetIndicators(
+	text: string
+): CharacterSheetIndicatorScore {
+	const lower = text.toLowerCase();
+	const matchedGroups: string[] = [];
+	for (const { group, patterns } of INDICATOR_GROUPS) {
+		if (patterns.test(lower)) {
+			matchedGroups.push(group);
+		}
+	}
+	const words = tokenizeWords(text);
+	return {
+		matchedGroups,
+		groupsMatched: matchedGroups.length,
+		wordCount: words.length,
+		englishDensity: commonWordRatio(words),
+		length: text.length,
+	};
+}
+
+/**
+ * Rules confident enough to skip the detection call today.
+ *
+ * Deliberately just two, both about text that cannot be a character sheet under
+ * any reading. Everything with a plausible failure mode stays advisory until
+ * the logs say otherwise.
+ */
+export function classifyCharacterSheetDecisively(
+	text: string
+): CharacterSheetRuleMatch | null {
+	if (text.trim().length === 0) {
+		return {
+			verdict: "not-character-sheet",
+			rule: "empty-or-whitespace",
+			reason: "Document is empty or whitespace only",
+			groupsMatched: 0,
+		};
+	}
+
+	const score = scoreCharacterSheetIndicators(text);
+
+	// Substantial English prose containing not one of eleven concept groups —
+	// no name label, no stat, no class, no health, no gear, no skills, no
+	// spells. There is no game system whose character sheet reads like that.
+	if (
+		score.groupsMatched === 0 &&
+		score.wordCount >= MIN_WORDS_FOR_ABSENCE_RULE &&
+		score.englishDensity >= MIN_ENGLISH_DENSITY
+	) {
+		return {
+			verdict: "not-character-sheet",
+			rule: "no-indicators-in-english-prose",
+			reason:
+				"Substantial English text matching none of the character-sheet indicator groups",
+			groupsMatched: 0,
+		};
+	}
+
+	return null;
+}
+
+/**
+ * The full rule set, including rules not yet trusted to short-circuit.
+ *
+ * Evaluated on every detection and logged against the model's answer. A rule
+ * whose agreement rate holds up is a candidate for promotion into
+ * {@link classifyCharacterSheetDecisively}.
+ */
+export function classifyCharacterSheetAdvisory(
+	text: string
+): CharacterSheetRuleMatch {
+	const decisive = classifyCharacterSheetDecisively(text);
+	if (decisive) {
+		return decisive;
+	}
+
+	const score = scoreCharacterSheetIndicators(text);
+
+	// A long document that touches every concept is a rulebook, not a sheet.
+	// This is the rule most worth measuring: if it holds, it removes the
+	// detection call from the dominant upload — a sourcebook PDF.
+	if (score.length >= RULEBOOK_LENGTH_CHARS) {
+		return {
+			verdict: "not-character-sheet",
+			rule: "rulebook-length",
+			reason:
+				"Document is far longer than any character sheet, so indicator matches read as reference material",
+			groupsMatched: score.groupsMatched,
+		};
+	}
+
+	if (score.groupsMatched >= 6) {
+		return {
+			verdict: "character-sheet",
+			rule: "dense-indicator-coverage",
+			reason: "Short document covering most character-sheet concept groups",
+			groupsMatched: score.groupsMatched,
+		};
+	}
+
+	if (score.groupsMatched <= 2) {
+		return {
+			verdict: "not-character-sheet",
+			rule: "sparse-indicator-coverage",
+			reason: "Almost none of the character-sheet concept groups are present",
+			groupsMatched: score.groupsMatched,
+		};
+	}
+
+	return {
+		verdict: "ambiguous",
+		rule: "none",
+		reason: "Indicator coverage falls between the confident bands",
+		groupsMatched: score.groupsMatched,
+	};
+}

--- a/src/services/character-sheet/character-sheet-parser-service.ts
+++ b/src/services/character-sheet/character-sheet-parser-service.ts
@@ -7,6 +7,10 @@ import { chunkTextByCharacterCount } from "@/lib/file/text-chunking-utils";
 import { formatCharacterSheetParsingPrompt } from "@/lib/prompts/character-sheet-prompts";
 import { parseOrThrow } from "@/lib/zod-utils";
 import { createLLMProvider } from "@/services/llm/llm-provider-factory";
+import {
+	type LlmResultCache,
+	NOOP_LLM_RESULT_CACHE,
+} from "@/services/llm/llm-result-cache";
 
 /**
  * Schema for parsed character data
@@ -158,7 +162,17 @@ const MAX_CHUNK_SIZE = 200000; // Characters per chunk for parsing (GPT-5 models
  * Game-system agnostic - extracts whatever fields are present without assuming a specific system.
  */
 export class CharacterSheetParserService {
-	constructor(private llmApiKey: string) {}
+	constructor(
+		private llmApiKey: string,
+		/**
+		 * Content-addressed result cache (issue #761, finding 8). This is the
+		 * expensive half of the character-sheet path — a full document on the
+		 * SESSION_PLANNING tier — so a re-upload or a retry is worth not paying
+		 * twice. Defaults to the no-op cache so existing construction sites are
+		 * unchanged.
+		 */
+		private resultCache: LlmResultCache = NOOP_LLM_RESULT_CACHE
+	) {}
 
 	/**
 	 * Parse character sheet text into structured character data
@@ -206,6 +220,26 @@ export class CharacterSheetParserService {
 	 * Parse a single chunk of character sheet text
 	 */
 	private async parseChunk(
+		chunkContent: string,
+		characterName?: string
+	): Promise<CharacterData> {
+		// Rendering the prompt with empty content gives the exact instruction text
+		// this call will send — including the name hint, which changes the prompt —
+		// so an edit to the template invalidates the cache on its own.
+		const { value } = await this.resultCache.getOrCompute<CharacterData>(
+			{
+				kind: "character_sheet_parse",
+				model: getGenerationModelForProvider("SESSION_PLANNING"),
+				promptPrefix: formatCharacterSheetParsingPrompt("", characterName),
+				variablePart: chunkContent,
+			},
+			() => this.callParseModel(chunkContent, characterName)
+		);
+		return value;
+	}
+
+	/** The model call itself, split out so the cache wraps exactly one thing. */
+	private async callParseModel(
 		chunkContent: string,
 		characterName?: string
 	): Promise<CharacterData> {

--- a/src/services/llm/llm-result-cache.ts
+++ b/src/services/llm/llm-result-cache.ts
@@ -1,0 +1,256 @@
+/**
+ * Content-addressed cache for expensive LLM results (issue #761, finding 8).
+ *
+ * `CommunitySummaryService.generateOrGetSummary` already checks for an existing
+ * result before calling a model. That is the pattern; it just was not applied
+ * anywhere else. Re-uploading the same PDF, or re-running a rebuild over
+ * unchanged chunks, re-paid full extraction cost on Sonnet 5 every time.
+ *
+ * Three properties matter more than the storage details:
+ *
+ * 1. **The key covers the rendered prompt, not a version constant.** An
+ *    instruction edit and a content edit invalidate the same way, so there is
+ *    no version number to forget. See `lib/llm-result-cache-key`.
+ * 2. **The payload is campaign-independent.** For extraction the cached value
+ *    is the validated model output, captured *before* entity IDs are minted and
+ *    scoped to a campaign. The same document added to a second campaign is
+ *    therefore a hit, which is where re-index savings actually live.
+ * 3. **Every failure is a miss.** Missing table, missing binding, unparseable
+ *    row, D1 error — all of them fall through to the model. A cache that can
+ *    break a pipeline is not worth having, and `main` deploys the Worker
+ *    automatically while D1 migrations are applied separately, so the
+ *    table-not-yet-there window is real.
+ */
+
+import { getDAOFactory } from "@/dao/dao-factory";
+import type { LlmResultCacheDAO } from "@/dao/llm-result-cache-dao";
+import type { EnvWithSecrets } from "@/lib/env-utils";
+import { getEnvVar } from "@/lib/env-utils";
+import {
+	buildLlmResultCacheKey,
+	type LlmResultCacheKeyInput,
+	type LlmResultCacheKind,
+} from "@/lib/llm-result-cache-key";
+import { isVerboseLlmSpendEnabled } from "@/lib/llm-usage-verbose-log";
+import { createLogger } from "@/lib/logger";
+
+/**
+ * Payloads above this are not stored.
+ *
+ * D1 permits far larger rows, but a payload this size is an extraction that
+ * returned an unusual amount of output, and caching it trades a large write on
+ * every miss for a saving on a repeat that may never come. Skipping is silent
+ * on the read path — an oversized result is simply always recomputed.
+ */
+export const MAX_CACHEABLE_PAYLOAD_BYTES = 512 * 1024;
+
+export interface LlmResultCacheLookup<T> {
+	value: T;
+	/** True when the value came from the cache and no model call happened. */
+	cached: boolean;
+}
+
+/**
+ * The surface call sites depend on. Narrow on purpose: services take this
+ * rather than a DAO or an `Env` so a unit test can pass a stub without a D1
+ * binding, and so a call site cannot reach past it into the table.
+ */
+export interface LlmResultCache {
+	getOrCompute<T>(
+		input: LlmResultCacheKeyInput,
+		compute: () => Promise<T>
+	): Promise<LlmResultCacheLookup<T>>;
+}
+
+/** A cache that never hits. Used when the flag is off or there is no DB binding. */
+export const NOOP_LLM_RESULT_CACHE: LlmResultCache = {
+	async getOrCompute(_input, compute) {
+		return { value: await compute(), cached: false };
+	},
+};
+
+interface D1LlmResultCacheOptions {
+	dao: LlmResultCacheDAO;
+	env?: EnvWithSecrets | Record<string, unknown>;
+}
+
+class D1LlmResultCache implements LlmResultCache {
+	private readonly dao: LlmResultCacheDAO;
+	private readonly env?: EnvWithSecrets | Record<string, unknown>;
+	/** Resolved once per instance: `sqlite_master` should not be queried per chunk. */
+	private schemaReady: Promise<boolean> | null = null;
+
+	constructor(options: D1LlmResultCacheOptions) {
+		this.dao = options.dao;
+		this.env = options.env;
+	}
+
+	async getOrCompute<T>(
+		input: LlmResultCacheKeyInput,
+		compute: () => Promise<T>
+	): Promise<LlmResultCacheLookup<T>> {
+		if (!(await this.isReady())) {
+			return { value: await compute(), cached: false };
+		}
+
+		let cacheKey: string;
+		try {
+			({ cacheKey } = await buildLlmResultCacheKey(input));
+		} catch {
+			return { value: await compute(), cached: false };
+		}
+
+		const hit = await this.read<T>(cacheKey, input.kind);
+		if (hit !== undefined) {
+			return { value: hit, cached: true };
+		}
+
+		const value = await compute();
+		await this.write(cacheKey, input, value);
+		return { value, cached: false };
+	}
+
+	private async isReady(): Promise<boolean> {
+		if (!this.schemaReady) {
+			this.schemaReady = this.dao.isSchemaReady().catch(() => false);
+		}
+		return this.schemaReady;
+	}
+
+	/** `undefined` means miss; a stored `null` payload is a legitimate hit. */
+	private async read<T>(
+		cacheKey: string,
+		kind: LlmResultCacheKind
+	): Promise<T | undefined> {
+		try {
+			const row = await this.dao.get(cacheKey);
+			if (!row) {
+				this.log("llm_result_cache_miss", { kind, cacheKey });
+				return undefined;
+			}
+			const value = JSON.parse(row.payload) as T;
+			// Accounting only; a failed increment must not turn a hit into a miss.
+			this.dao.recordHit(cacheKey).catch(() => {});
+			this.log("llm_result_cache_hit", {
+				kind,
+				cacheKey,
+				model: row.model,
+				payloadBytes: row.payload_bytes,
+				priorHits: row.hit_count,
+			});
+			return value;
+		} catch {
+			// Includes a row whose payload no longer parses, e.g. written by an
+			// older shape. Recomputing is always correct; serving garbage is not.
+			return undefined;
+		}
+	}
+
+	private async write<T>(
+		cacheKey: string,
+		input: LlmResultCacheKeyInput,
+		value: T
+	): Promise<void> {
+		try {
+			if (value === undefined) {
+				return;
+			}
+			const payload = JSON.stringify(value);
+			if (payload.length > MAX_CACHEABLE_PAYLOAD_BYTES) {
+				this.log("llm_result_cache_payload_too_large", {
+					kind: input.kind,
+					payloadBytes: payload.length,
+					limitBytes: MAX_CACHEABLE_PAYLOAD_BYTES,
+				});
+				return;
+			}
+			await this.dao.put({
+				cacheKey,
+				kind: input.kind,
+				model: input.model,
+				payload,
+			});
+		} catch {
+			// A cache that fails a write must not fail the extraction that produced it.
+		}
+	}
+
+	private log(event: string, fields: Record<string, unknown>): void {
+		if (!isVerboseLlmSpendEnabled(this.env)) {
+			return;
+		}
+		try {
+			createLogger(
+				this.env as Record<string, unknown> | undefined,
+				"[LlmResultCache]"
+			).info(event, { event, ...fields });
+		} catch {
+			// Logging is best-effort.
+		}
+	}
+}
+
+/**
+ * Build a cache over an already-resolved DAO.
+ *
+ * The seam {@link createLlmResultCache} uses, and the one tests use to exercise
+ * hit/miss/degradation behaviour without a D1 binding.
+ */
+export function createLlmResultCacheForDao(
+	dao: LlmResultCacheDAO,
+	env?: EnvWithSecrets | Record<string, unknown>
+): LlmResultCache {
+	return new D1LlmResultCache({ dao, env });
+}
+
+/**
+ * Off only by explicit opt-out. Unlike the chunk gate this changes no model
+ * output — a hit returns a payload an identical call already produced — so the
+ * conservative default is "on", with a switch for turning it off during an
+ * incident without a deploy.
+ */
+export async function isLlmResultCacheEnabled(
+	env: EnvWithSecrets | Record<string, unknown> | undefined
+): Promise<boolean> {
+	if (!env) {
+		return false;
+	}
+	try {
+		const raw = await getEnvVar(
+			env as EnvWithSecrets,
+			"LLM_RESULT_CACHE_ENABLED",
+			false
+		);
+		const v = raw.trim().toLowerCase();
+		if (v === "") {
+			return true;
+		}
+		return !(v === "0" || v === "false" || v === "no" || v === "off");
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Build the cache for a worker env, or the no-op cache when it cannot be used.
+ *
+ * Never throws: a caller that cannot get a real cache gets one that always
+ * misses, so wiring this into a pipeline can only cost a model call it would
+ * have made anyway.
+ */
+export async function createLlmResultCache(
+	env: EnvWithSecrets | Record<string, unknown> | undefined
+): Promise<LlmResultCache> {
+	if (!(await isLlmResultCacheEnabled(env))) {
+		return NOOP_LLM_RESULT_CACHE;
+	}
+	try {
+		return createLlmResultCacheForDao(
+			getDAOFactory(env).llmResultCacheDAO,
+			env
+		);
+	} catch {
+		// No DB binding (unit tests, some queue contexts): degrade to no cache.
+		return NOOP_LLM_RESULT_CACHE;
+	}
+}

--- a/src/services/rag/entity-extraction-service.ts
+++ b/src/services/rag/entity-extraction-service.ts
@@ -16,6 +16,10 @@ import { RPG_EXTRACTION_PROMPTS } from "@/lib/prompts/rpg-extraction-prompts";
 import { parseOrThrow } from "@/lib/zod-utils";
 import type { StructuredPromptParts } from "@/services/llm/llm-provider";
 import { createLLMProvider } from "@/services/llm/llm-provider-factory";
+import {
+	type LlmResultCache,
+	NOOP_LLM_RESULT_CACHE,
+} from "@/services/llm/llm-result-cache";
 import type { TelemetryService } from "@/services/telemetry/telemetry-service";
 
 /**
@@ -91,6 +95,12 @@ export interface ExtractEntitiesOptions {
 	) => void | Promise<void>;
 	/** Called when Anthropic JSON repair pass runs (after first-pass parse failure). */
 	onJsonRepair?: () => void | Promise<void>;
+	/**
+	 * Set internally when the payload came from the result cache, so extraction
+	 * telemetry can separate "we extracted this" from "we already had it".
+	 * Callers do not set this.
+	 */
+	servedFromResultCache?: boolean;
 }
 
 export interface ExtractedRelationship {
@@ -115,9 +125,20 @@ export function extractionModelId(): string {
 }
 
 /**
- * Split the extraction prompt into the stable instruction prefix (identical for
- * every chunk of every document from the same source name — the part worth
+ * Split the extraction prompt into the stable instruction prefix (the part worth
  * caching) and the chunk-specific suffix.
+ *
+ * The prefix is identical for **every chunk of every document**, not just those
+ * sharing a source name: `formatStructuredContentPrompt` substitutes whole-word
+ * "document" into the template, and the template contains no whole-word match
+ * (`"doc": "document_id"` does not qualify — `_` is a word character). So
+ * `sourceName` never reaches the model, and the ~3.8k-token prefix is shared
+ * across the whole corpus. That is good for the prompt cache and for the result
+ * cache keyed on it; it also means the prompt's instruction to emit
+ * `"source": {"doc": ...}` asks for an id the model was never given. Nothing
+ * reads that field, so it is dead intent rather than a live defect — but see
+ * `tests/services/rag/entity-extraction-result-cache.test.ts`, which pins the
+ * premise so a prompt edit cannot silently change the cache's scope.
  *
  * Exported so the Message Batches path builds byte-identical prompts to the
  * inline path; see {@link import("@/lib/llm-structured-output")}.
@@ -183,7 +204,13 @@ export function parseExtractionResponseText(
 export class EntityExtractionService {
 	constructor(
 		private readonly llmApiKey: string | null = null,
-		private readonly telemetryService: TelemetryService | null = null
+		private readonly telemetryService: TelemetryService | null = null,
+		/**
+		 * Content-addressed result cache (issue #761, finding 8). Defaults to the
+		 * no-op cache so every existing construction site — and every unit test —
+		 * behaves exactly as before until an env-backed cache is passed in.
+		 */
+		private readonly resultCache: LlmResultCache = NOOP_LLM_RESULT_CACHE
 	) {}
 
 	async extractEntities(
@@ -209,15 +236,33 @@ export class EntityExtractionService {
 					}
 				: undefined;
 
-		// Use OpenAIProvider to generate structured JSON output
-		const parsed = await this.callStructuredModel(
-			promptParts.fullPrompt,
-			apiKey,
+		// The cached value is the validated payload, taken before entity IDs are
+		// minted below — those are campaign-scoped, and re-minting them per
+		// campaign is what lets the same document hit the cache in a second one.
+		const { value: parsed, cached } = await this.resultCache.getOrCompute<
+			z.infer<typeof EntityExtractionSchema> | undefined
+		>(
 			{
-				username: options.username,
-				onUsage: options.onUsage,
-				onJsonRepair: options.onJsonRepair,
-				structuredPromptParts,
+				kind: "entity_extraction",
+				model: extractionModelId(),
+				promptPrefix: promptParts.cacheablePrefix,
+				variablePart: promptParts.variableSuffix,
+			},
+			async () => {
+				const result = await this.callStructuredModel(
+					promptParts.fullPrompt,
+					apiKey,
+					{
+						username: options.username,
+						onUsage: options.onUsage,
+						onJsonRepair: options.onJsonRepair,
+						structuredPromptParts,
+					}
+				);
+				// A null here is the model producing no usable output, not an
+				// extraction that legitimately found nothing. Returning undefined
+				// keeps it out of the cache so the next attempt retries the model.
+				return result ?? undefined;
 			}
 		);
 
@@ -225,7 +270,10 @@ export class EntityExtractionService {
 			return [];
 		}
 
-		return this.mapExtractionPayload(parsed, options);
+		return this.mapExtractionPayload(parsed, {
+			...options,
+			servedFromResultCache: cached,
+		});
 	}
 
 	/**
@@ -286,6 +334,10 @@ export class EntityExtractionService {
 							sourceName: options.sourceName,
 							sourceType: options.sourceType,
 							sourceId: options.sourceId,
+							// A cached payload cost no tokens; without this the
+							// extraction count and the spend log disagree and neither
+							// explains why.
+							servedFromResultCache: options.servedFromResultCache === true,
 						},
 					})
 					.catch((_error) => {}),

--- a/src/services/rag/extraction-chunk-gate-rules.ts
+++ b/src/services/rag/extraction-chunk-gate-rules.ts
@@ -21,6 +21,8 @@
  * verdict is `ambiguous` and full extraction runs.
  */
 
+import { commonWordRatio, tokenizeWords } from "@/lib/english-prose-stats";
+
 export type ChunkGateVerdict =
 	/** Confidently not worth extracting — skip. */
 	| "non-substantive"
@@ -55,66 +57,6 @@ const BOILERPLATE_PHRASES = [
 	"copyright ©",
 ];
 
-/**
- * Words common enough that a chunk of real prose will contain several. A run of
- * page numbers or a heading index will contain almost none.
- */
-const COMMON_WORDS = new Set([
-	"the",
-	"a",
-	"an",
-	"and",
-	"or",
-	"but",
-	"if",
-	"of",
-	"to",
-	"in",
-	"on",
-	"at",
-	"for",
-	"with",
-	"from",
-	"by",
-	"as",
-	"is",
-	"are",
-	"was",
-	"were",
-	"be",
-	"been",
-	"has",
-	"have",
-	"had",
-	"can",
-	"may",
-	"will",
-	"would",
-	"this",
-	"that",
-	"they",
-	"their",
-	"you",
-	"your",
-	"it",
-	"its",
-	"not",
-	"when",
-	"which",
-	"who",
-	"all",
-	"any",
-	"each",
-	"more",
-	"than",
-	"then",
-	"into",
-	"out",
-	"up",
-	"do",
-	"does",
-]);
-
 export interface ChunkTextStats {
 	length: number;
 	/** Share of characters that are whitespace. */
@@ -122,7 +64,7 @@ export interface ChunkTextStats {
 	/** Share of non-whitespace characters that are digits or separators. */
 	digitRatio: number;
 	wordCount: number;
-	/** Share of words that appear in {@link COMMON_WORDS}. */
+	/** Share of words that appear in the shared common-word list. */
 	commonWordRatio: number;
 	/** Share of lines that end in a bare number (TOC / page-footer shape). */
 	pageNumberLineRatio: number;
@@ -152,8 +94,7 @@ export function computeChunkTextStats(text: string): ChunkTextStats {
 	const nonWhitespace = length - whitespaceCount;
 	const digitCount = (text.match(/[\d.,:;·—–\-|]/g) ?? []).length;
 
-	const words = text.toLowerCase().match(/[a-z']+/g) ?? [];
-	const commonWordCount = words.filter((w) => COMMON_WORDS.has(w)).length;
+	const words = tokenizeWords(text);
 
 	const lines = text
 		.split("\n")
@@ -185,7 +126,7 @@ export function computeChunkTextStats(text: string): ChunkTextStats {
 		whitespaceRatio: whitespaceCount / length,
 		digitRatio: nonWhitespace === 0 ? 0 : digitCount / nonWhitespace,
 		wordCount: words.length,
-		commonWordRatio: words.length === 0 ? 0 : commonWordCount / words.length,
+		commonWordRatio: commonWordRatio(words),
 		pageNumberLineRatio:
 			lines.length === 0 ? 0 : pageNumberLines / lines.length,
 		repeatedLineRatio: lines.length === 0 ? 0 : repeatedLines / lines.length,

--- a/tests/lib/llm-result-cache-key.test.ts
+++ b/tests/lib/llm-result-cache-key.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildLlmResultCacheKey,
+	type LlmResultCacheKeyInput,
+} from "../../src/lib/llm-result-cache-key";
+
+const BASE: LlmResultCacheKeyInput = {
+	kind: "entity_extraction",
+	model: "claude-sonnet-5",
+	promptPrefix: "Extract entities from the document.\n\nCONTENT START\n",
+	variablePart:
+		"The village of Harrow's Rest sits at the foot of the Grey Spine.",
+};
+
+describe("buildLlmResultCacheKey", () => {
+	it("is stable for identical input", async () => {
+		const a = await buildLlmResultCacheKey(BASE);
+		const b = await buildLlmResultCacheKey({ ...BASE });
+		expect(a.cacheKey).toBe(b.cacheKey);
+		expect(a.cacheKey).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("changes when the content changes", async () => {
+		const a = await buildLlmResultCacheKey(BASE);
+		const b = await buildLlmResultCacheKey({
+			...BASE,
+			variablePart: `${BASE.variablePart} It has been there a long time.`,
+		});
+		expect(a.cacheKey).not.toBe(b.cacheKey);
+	});
+
+	it("changes when the prompt changes, which is the whole point of hashing it", async () => {
+		// This is the property that replaces a hand-maintained prompt version:
+		// editing an instruction must not serve results the old instruction produced.
+		const a = await buildLlmResultCacheKey(BASE);
+		const b = await buildLlmResultCacheKey({
+			...BASE,
+			promptPrefix: `${BASE.promptPrefix}Also extract factions.\n`,
+		});
+		expect(a.cacheKey).not.toBe(b.cacheKey);
+	});
+
+	it("changes when the model changes, so a tier change does not serve stale output", async () => {
+		const a = await buildLlmResultCacheKey(BASE);
+		const b = await buildLlmResultCacheKey({
+			...BASE,
+			model: "claude-haiku-4-5",
+		});
+		expect(a.cacheKey).not.toBe(b.cacheKey);
+	});
+
+	it("changes when the kind changes", async () => {
+		const a = await buildLlmResultCacheKey(BASE);
+		const b = await buildLlmResultCacheKey({
+			...BASE,
+			kind: "character_sheet_parse",
+		});
+		expect(a.cacheKey).not.toBe(b.cacheKey);
+	});
+
+	it("cannot be collided by moving text across the prompt/content boundary", async () => {
+		// A naive `${prefix}|${content}` join would give these two the same key.
+		const a = await buildLlmResultCacheKey({
+			...BASE,
+			promptPrefix: "AB",
+			variablePart: "C",
+		});
+		const b = await buildLlmResultCacheKey({
+			...BASE,
+			promptPrefix: "A",
+			variablePart: "BC",
+		});
+		expect(a.cacheKey).not.toBe(b.cacheKey);
+	});
+
+	it("reports a prompt digest that ignores the content", async () => {
+		const a = await buildLlmResultCacheKey(BASE);
+		const b = await buildLlmResultCacheKey({
+			...BASE,
+			variablePart: "completely different content",
+		});
+		expect(a.promptDigest).toBe(b.promptDigest);
+	});
+});

--- a/tests/services/character-sheet/character-sheet-detection-service.test.ts
+++ b/tests/services/character-sheet/character-sheet-detection-service.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LlmResultCacheDAO } from "../../../src/dao/llm-result-cache-dao";
+import { CharacterSheetDetectionService } from "../../../src/services/character-sheet/character-sheet-detection-service";
+
+const generateStructuredOutput = vi.fn();
+
+vi.mock("@/services/llm/llm-provider-factory", () => ({
+	createLLMProvider: vi.fn(() => ({ generateStructuredOutput })),
+}));
+
+/** English, substantial, and carrying no character-sheet vocabulary at all. */
+const SESSION_NOTES = `The party arrived at the crossing well after dark and found the ferryman gone.
+His hut was open and the fire had burned down to nothing, which the group read as
+a bad sign rather than a coincidence. They argued about whether to wait until
+morning or take the boat themselves, and in the end they took it, poling across
+in near silence while the current pulled them steadily east of where they meant
+to land. On the far bank they found a cart turned on its side and the marks of
+something heavy dragged away from it toward the treeline. Nobody wanted to follow
+those marks in the dark, so they made camp against the overturned cart and set a
+watch. Around the third watch the youngest of them heard singing from somewhere
+out past the trees, faint and in no language she recognised, and she woke the
+others rather than investigate alone. By dawn the singing had stopped and the
+drag marks were gone, brushed over so carefully that only the ferryman's dog,
+which turned up sometime before sunrise, seemed to know where they had led.`;
+
+const SHEET = `Character Name: Eleanor Vance
+Class: Ranger   Level: 4   Race: Half-elf
+Hit Points: 34   Armor Class: 16
+Strength 12  Dexterity 18  Constitution 14
+Skills: Survival +7, Perception +7
+Equipment: longbow, studded leather, rope
+Background: Outlander. Personality traits: quiet, watchful.
+Spells: Hunter's Mark, Cure Wounds`;
+
+function inMemoryDao(): LlmResultCacheDAO {
+	const rows = new Map<string, { payload: string; model: string }>();
+	return {
+		isSchemaReady: async () => true,
+		get: async (cacheKey: string) =>
+			rows.has(cacheKey)
+				? ({
+						cache_key: cacheKey,
+						...rows.get(cacheKey),
+						hit_count: 0,
+					} as never)
+				: null,
+		put: async (input: {
+			cacheKey: string;
+			model: string;
+			payload: string;
+		}) => {
+			if (!rows.has(input.cacheKey)) {
+				rows.set(input.cacheKey, {
+					payload: input.payload,
+					model: input.model,
+				});
+			}
+		},
+		recordHit: async () => {},
+	} as unknown as LlmResultCacheDAO;
+}
+
+async function makeCache() {
+	const { createLlmResultCacheForDao } = await import(
+		"../../../src/services/llm/llm-result-cache"
+	);
+	return createLlmResultCacheForDao(inMemoryDao());
+}
+
+describe("CharacterSheetDetectionService", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		generateStructuredOutput.mockResolvedValue({
+			isCharacterSheet: true,
+			confidence: 0.92,
+			characterName: "Eleanor Vance",
+			detectedGameSystem: "D&D 5e",
+		});
+	});
+
+	describe("deterministic pre-screen (finding 5a)", () => {
+		it("answers without a model call for prose carrying no sheet vocabulary", async () => {
+			const service = new CharacterSheetDetectionService("key");
+			const result = await service.detectCharacterSheet(SESSION_NOTES);
+
+			expect(result.isCharacterSheet).toBe(false);
+			expect(generateStructuredOutput).not.toHaveBeenCalled();
+		});
+
+		it("answers without a model call for empty content", async () => {
+			const service = new CharacterSheetDetectionService("key");
+			expect((await service.detectCharacterSheet("   ")).isCharacterSheet).toBe(
+				false
+			);
+			expect(generateStructuredOutput).not.toHaveBeenCalled();
+		});
+
+		it("still sends a real character sheet to the model", async () => {
+			// The pre-screen only ever short-circuits a negative. A positive verdict
+			// is never taken deterministically, so no upload is misclassified as a
+			// character sheet without the model agreeing.
+			const service = new CharacterSheetDetectionService("key");
+			const result = await service.detectCharacterSheet(SHEET);
+
+			expect(generateStructuredOutput).toHaveBeenCalledTimes(1);
+			expect(result.isCharacterSheet).toBe(true);
+			expect(result.characterName).toBe("Eleanor Vance");
+		});
+	});
+
+	describe("result cache (finding 8)", () => {
+		it("detects the same document twice with one model call", async () => {
+			const service = new CharacterSheetDetectionService(
+				"key",
+				await makeCache()
+			);
+
+			await service.detectCharacterSheet(SHEET);
+			const second = await service.detectCharacterSheet(SHEET);
+
+			expect(generateStructuredOutput).toHaveBeenCalledTimes(1);
+			expect(second.characterName).toBe("Eleanor Vance");
+		});
+
+		it("does not cache a model failure, so the next upload retries", async () => {
+			const service = new CharacterSheetDetectionService(
+				"key",
+				await makeCache()
+			);
+			generateStructuredOutput.mockRejectedValueOnce(
+				new Error("AI_NoOutputGeneratedError: No output generated")
+			);
+
+			const failed = await service.detectCharacterSheet(SHEET);
+			expect(failed.isCharacterSheet).toBe(false);
+
+			const retried = await service.detectCharacterSheet(SHEET);
+			expect(retried.isCharacterSheet).toBe(true);
+			expect(generateStructuredOutput).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	it("applies the confidence threshold unchanged", () => {
+		const service = new CharacterSheetDetectionService("key");
+		expect(
+			service.isConfidentDetection({ isCharacterSheet: true, confidence: 0.71 })
+		).toBe(true);
+		expect(
+			service.isConfidentDetection({ isCharacterSheet: true, confidence: 0.69 })
+		).toBe(false);
+		expect(
+			service.isConfidentDetection({
+				isCharacterSheet: false,
+				confidence: 0.99,
+			})
+		).toBe(false);
+	});
+});

--- a/tests/services/character-sheet/character-sheet-indicators.test.ts
+++ b/tests/services/character-sheet/character-sheet-indicators.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+	classifyCharacterSheetAdvisory,
+	classifyCharacterSheetDecisively,
+	scoreCharacterSheetIndicators,
+} from "../../../src/services/character-sheet/character-sheet-indicators";
+
+/** Campaign prose: English, substantial, and carrying no sheet vocabulary. */
+const SESSION_NOTES = `The party arrived at the crossing well after dark and found the ferryman gone.
+His hut was open and the fire had burned down to nothing, which the group read as
+a bad sign rather than a coincidence. They argued about whether to wait until
+morning or take the boat themselves, and in the end they took it, poling across
+in near silence while the current pulled them steadily east of where they meant
+to land. On the far bank they found a cart turned on its side and the marks of
+something heavy dragged away from it toward the treeline. Nobody wanted to follow
+those marks in the dark, so they made camp against the overturned cart and set a
+watch. Around the third watch the youngest of them heard singing from somewhere
+out past the trees, faint and in no language she recognised, and she woke the
+others rather than investigate alone. By dawn the singing had stopped and the
+drag marks were gone, brushed over so carefully that only the ferryman's dog,
+which turned up sometime before sunrise, seemed to know where they had led.`;
+
+/** A minimal but unmistakable sheet, deliberately not D&D. */
+const COC_SHEET = `INVESTIGATOR SHEET
+Character Name: Eleanor Vance
+Occupation: Journalist   Age: 34
+Strength 55  Constitution 60  Power 70  Dexterity 65
+Appearance 60  Size 50  Intelligence 75  Education 80
+Hit Points: 11   Sanity: 70   Luck: 55
+Skills: Library Use 70%, Persuade 55%, Spot Hidden 45%, Occult 20%
+Equipment: notebook, .38 revolver, electric torch, press credentials
+Backstory: came to Arkham chasing a story about the Miskatonic dig.`;
+
+describe("scoreCharacterSheetIndicators", () => {
+	it("counts distinct concept groups, not repeated hits", () => {
+		const repeated = scoreCharacterSheetIndicators(
+			"hit points hit points hit points hit points"
+		);
+		expect(repeated.groupsMatched).toBe(1);
+		expect(repeated.matchedGroups).toEqual(["vitality"]);
+	});
+
+	it("recognises a non-D&D sheet through system-agnostic vocabulary", () => {
+		const score = scoreCharacterSheetIndicators(COC_SHEET);
+		expect(score.groupsMatched).toBeGreaterThanOrEqual(6);
+		expect(score.matchedGroups).toContain("attributes");
+		expect(score.matchedGroups).toContain("equipment");
+	});
+});
+
+describe("classifyCharacterSheetDecisively", () => {
+	it("rejects empty content", () => {
+		expect(classifyCharacterSheetDecisively("")?.rule).toBe(
+			"empty-or-whitespace"
+		);
+		expect(classifyCharacterSheetDecisively("  \n\t ")?.verdict).toBe(
+			"not-character-sheet"
+		);
+	});
+
+	it("skips the model for substantial English prose with no sheet vocabulary", () => {
+		const match = classifyCharacterSheetDecisively(SESSION_NOTES);
+		expect(match?.rule).toBe("no-indicators-in-english-prose");
+		expect(match?.verdict).toBe("not-character-sheet");
+	});
+
+	it("defers on non-English text, where an absent English keyword proves nothing", () => {
+		// Same shape of document, no English connective words. The absence rule
+		// must not fire here: a French sheet has to reach the model.
+		const french = Array(40)
+			.fill(
+				"Le bateau glissait sur une eau lourde pendant que les voyageurs se taisaient."
+			)
+			.join(" ");
+		expect(classifyCharacterSheetDecisively(french)).toBeNull();
+	});
+
+	it("defers on short text, where an absence is not yet meaningful", () => {
+		expect(
+			classifyCharacterSheetDecisively("A short note about the road.")
+		).toBe(null);
+	});
+
+	it("never decisively accepts — a positive always costs a model call", () => {
+		expect(classifyCharacterSheetDecisively(COC_SHEET)).toBeNull();
+	});
+});
+
+describe("classifyCharacterSheetAdvisory", () => {
+	it("calls a dense, short document a character sheet", () => {
+		const match = classifyCharacterSheetAdvisory(COC_SHEET);
+		expect(match.verdict).toBe("character-sheet");
+		expect(match.rule).toBe("dense-indicator-coverage");
+	});
+
+	it("calls a long document reference material regardless of coverage", () => {
+		const rulebook = `${COC_SHEET}\n`.repeat(2000);
+		expect(rulebook.length).toBeGreaterThan(60_000);
+		const match = classifyCharacterSheetAdvisory(rulebook);
+		expect(match.verdict).toBe("not-character-sheet");
+		expect(match.rule).toBe("rulebook-length");
+	});
+
+	it("defers when coverage falls between the confident bands", () => {
+		const middling =
+			"Notes on the caravan: the guards carry weapons and armour, and the " +
+			"caravan master keeps a ledger of every skill he has had to hire for. " +
+			"He will not say what the third wagon holds. ".repeat(4);
+		const match = classifyCharacterSheetAdvisory(middling);
+		expect(["ambiguous", "not-character-sheet"]).toContain(match.verdict);
+	});
+
+	it("passes decisive matches straight through", () => {
+		expect(classifyCharacterSheetAdvisory(SESSION_NOTES).rule).toBe(
+			"no-indicators-in-english-prose"
+		);
+	});
+});

--- a/tests/services/llm/llm-result-cache.test.ts
+++ b/tests/services/llm/llm-result-cache.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LlmResultCacheDAO } from "../../../src/dao/llm-result-cache-dao";
+import type { LlmResultCacheKeyInput } from "../../../src/lib/llm-result-cache-key";
+import {
+	createLlmResultCacheForDao,
+	MAX_CACHEABLE_PAYLOAD_BYTES,
+	NOOP_LLM_RESULT_CACHE,
+} from "../../../src/services/llm/llm-result-cache";
+
+const KEY: LlmResultCacheKeyInput = {
+	kind: "entity_extraction",
+	model: "claude-sonnet-5",
+	promptPrefix: "Extract entities.",
+	variablePart: "A village at the foot of the Grey Spine.",
+};
+
+/** In-memory stand-in for the D1-backed DAO. */
+function fakeDao(overrides: Partial<LlmResultCacheDAO> = {}) {
+	const rows = new Map<
+		string,
+		{ payload: string; model: string; payload_bytes: number; hit_count: number }
+	>();
+	const dao = {
+		isSchemaReady: vi.fn(async () => true),
+		get: vi.fn(async (cacheKey: string) => {
+			const row = rows.get(cacheKey);
+			return row ? ({ cache_key: cacheKey, ...row } as never) : null;
+		}),
+		put: vi.fn(
+			async (input: { cacheKey: string; model: string; payload: string }) => {
+				if (!rows.has(input.cacheKey)) {
+					rows.set(input.cacheKey, {
+						payload: input.payload,
+						model: input.model,
+						payload_bytes: input.payload.length,
+						hit_count: 0,
+					});
+				}
+			}
+		),
+		recordHit: vi.fn(async () => {}),
+		...overrides,
+	} as unknown as LlmResultCacheDAO;
+	return { dao, rows };
+}
+
+describe("LlmResultCache", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("computes on a miss and serves the stored value on the next call", async () => {
+		const { dao } = fakeDao();
+		const cache = createLlmResultCacheForDao(dao);
+		const compute = vi.fn(async () => ({ npcs: [{ name: "Ilsa Vantry" }] }));
+
+		const first = await cache.getOrCompute(KEY, compute);
+		expect(first.cached).toBe(false);
+		expect(compute).toHaveBeenCalledTimes(1);
+
+		const second = await cache.getOrCompute(KEY, compute);
+		expect(second.cached).toBe(true);
+		expect(second.value).toEqual({ npcs: [{ name: "Ilsa Vantry" }] });
+		// The point of the whole exercise: no second model call.
+		expect(compute).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not serve one prompt's result to another", async () => {
+		const { dao } = fakeDao();
+		const cache = createLlmResultCacheForDao(dao);
+		await cache.getOrCompute(KEY, async () => "old");
+
+		const withEditedPrompt = await cache.getOrCompute(
+			{ ...KEY, promptPrefix: "Extract entities and factions." },
+			async () => "new"
+		);
+		expect(withEditedPrompt.cached).toBe(false);
+		expect(withEditedPrompt.value).toBe("new");
+	});
+
+	it("does not cache an undefined result, so a bad model response is retried", async () => {
+		const { dao, rows } = fakeDao();
+		const cache = createLlmResultCacheForDao(dao);
+
+		await cache.getOrCompute(KEY, async () => undefined);
+		expect(rows.size).toBe(0);
+
+		const retried = await cache.getOrCompute(KEY, async () => "recovered");
+		expect(retried.cached).toBe(false);
+		expect(retried.value).toBe("recovered");
+	});
+
+	it("skips storing an oversized payload rather than writing a huge row", async () => {
+		const { dao, rows } = fakeDao();
+		const cache = createLlmResultCacheForDao(dao);
+		const huge = "x".repeat(MAX_CACHEABLE_PAYLOAD_BYTES + 10);
+
+		const result = await cache.getOrCompute(KEY, async () => huge);
+		expect(result.value).toBe(huge);
+		expect(rows.size).toBe(0);
+		expect(dao.put).not.toHaveBeenCalled();
+	});
+
+	it("degrades to a plain call when the table has not been migrated yet", async () => {
+		const { dao } = fakeDao({
+			isSchemaReady: vi.fn(async () => false),
+		} as Partial<LlmResultCacheDAO>);
+		const cache = createLlmResultCacheForDao(dao);
+		const compute = vi.fn(async () => "computed");
+
+		expect((await cache.getOrCompute(KEY, compute)).value).toBe("computed");
+		expect((await cache.getOrCompute(KEY, compute)).cached).toBe(false);
+		expect(dao.get).not.toHaveBeenCalled();
+	});
+
+	it("treats a read failure as a miss instead of failing the pipeline", async () => {
+		const { dao } = fakeDao({
+			get: vi.fn(async () => {
+				throw new Error("D1 unavailable");
+			}),
+		} as Partial<LlmResultCacheDAO>);
+		const cache = createLlmResultCacheForDao(dao);
+
+		const result = await cache.getOrCompute(KEY, async () => "computed");
+		expect(result.value).toBe("computed");
+		expect(result.cached).toBe(false);
+	});
+
+	it("treats a write failure as a miss instead of failing the pipeline", async () => {
+		const { dao } = fakeDao({
+			put: vi.fn(async () => {
+				throw new Error("D1 unavailable");
+			}),
+		} as Partial<LlmResultCacheDAO>);
+		const cache = createLlmResultCacheForDao(dao);
+
+		const result = await cache.getOrCompute(KEY, async () => "computed");
+		expect(result.value).toBe("computed");
+	});
+
+	it("recomputes when a stored payload no longer parses", async () => {
+		const { dao, rows } = fakeDao();
+		const cache = createLlmResultCacheForDao(dao);
+		await cache.getOrCompute(KEY, async () => ({ ok: true }));
+		for (const [key, row] of rows) {
+			rows.set(key, { ...row, payload: "{not json" });
+		}
+
+		const result = await cache.getOrCompute(KEY, async () => ({ ok: false }));
+		expect(result.cached).toBe(false);
+		expect(result.value).toEqual({ ok: false });
+	});
+
+	it("checks the schema once, not once per chunk", async () => {
+		const { dao } = fakeDao();
+		const cache = createLlmResultCacheForDao(dao);
+		await cache.getOrCompute(KEY, async () => 1);
+		await cache.getOrCompute({ ...KEY, variablePart: "other" }, async () => 2);
+		await cache.getOrCompute({ ...KEY, variablePart: "third" }, async () => 3);
+		expect(dao.isSchemaReady).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("NOOP_LLM_RESULT_CACHE", () => {
+	it("always computes, so an unwired call site behaves exactly as before", async () => {
+		const compute = vi.fn(async () => "value");
+		const a = await NOOP_LLM_RESULT_CACHE.getOrCompute(KEY, compute);
+		const b = await NOOP_LLM_RESULT_CACHE.getOrCompute(KEY, compute);
+		expect(a.cached).toBe(false);
+		expect(b.cached).toBe(false);
+		expect(compute).toHaveBeenCalledTimes(2);
+	});
+});

--- a/tests/services/rag/entity-extraction-result-cache.test.ts
+++ b/tests/services/rag/entity-extraction-result-cache.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LlmResultCacheDAO } from "../../../src/dao/llm-result-cache-dao";
+import {
+	buildExtractionPromptParts,
+	EntityExtractionService,
+} from "../../../src/services/rag/entity-extraction-service";
+
+const generateStructuredOutput = vi.fn();
+
+vi.mock("@/services/llm/llm-provider-factory", () => ({
+	createLLMProvider: vi.fn(() => ({ generateStructuredOutput })),
+}));
+
+const PAYLOAD = {
+	meta: { source: { doc: "Harrow's Rest Gazetteer" } },
+	npcs: [{ id: "npc-1", name: "Ilsa Vantry", summary: "The miller." }],
+	locations: [{ id: "loc-1", name: "Harrow's Rest" }],
+};
+
+/** In-memory stand-in for the D1-backed cache DAO. */
+function inMemoryDao(): LlmResultCacheDAO {
+	const rows = new Map<string, { payload: string; model: string }>();
+	return {
+		isSchemaReady: async () => true,
+		get: async (cacheKey: string) =>
+			rows.has(cacheKey)
+				? ({
+						cache_key: cacheKey,
+						...rows.get(cacheKey),
+						hit_count: 0,
+					} as never)
+				: null,
+		put: async (input: {
+			cacheKey: string;
+			model: string;
+			payload: string;
+		}) => {
+			if (!rows.has(input.cacheKey)) {
+				rows.set(input.cacheKey, {
+					payload: input.payload,
+					model: input.model,
+				});
+			}
+		},
+		recordHit: async () => {},
+	} as unknown as LlmResultCacheDAO;
+}
+
+async function makeCache() {
+	const { createLlmResultCacheForDao } = await import(
+		"../../../src/services/llm/llm-result-cache"
+	);
+	return createLlmResultCacheForDao(inMemoryDao());
+}
+
+const OPTIONS = {
+	content: "The village of Harrow's Rest sits at the foot of the Grey Spine.",
+	sourceName: "Harrow's Rest Gazetteer",
+	sourceId: "resource-1",
+	sourceType: "file_upload",
+	llmApiKey: "test-key",
+};
+
+describe("EntityExtractionService result cache (issue #761, finding 8)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		generateStructuredOutput.mockResolvedValue(PAYLOAD);
+	});
+
+	it("calls the model once for repeated extraction of identical content", async () => {
+		const service = new EntityExtractionService(null, null, await makeCache());
+
+		await service.extractEntities({ ...OPTIONS, campaignId: "campaign-a" });
+		await service.extractEntities({ ...OPTIONS, campaignId: "campaign-a" });
+
+		expect(generateStructuredOutput).toHaveBeenCalledTimes(1);
+	});
+
+	it("serves a second campaign from the cache but re-scopes the entity IDs", async () => {
+		// This is the property that makes the cache worth having: the stored
+		// payload is campaign-independent, so adding the same document to another
+		// campaign is a hit — while the entities it produces still belong to that
+		// campaign, not the one that paid for the extraction.
+		const service = new EntityExtractionService(null, null, await makeCache());
+
+		const first = await service.extractEntities({
+			...OPTIONS,
+			campaignId: "campaign-a",
+		});
+		const second = await service.extractEntities({
+			...OPTIONS,
+			campaignId: "campaign-b",
+		});
+
+		expect(generateStructuredOutput).toHaveBeenCalledTimes(1);
+		expect(first.map((e) => e.name).sort()).toEqual(
+			second.map((e) => e.name).sort()
+		);
+		expect(first.every((e) => e.id.startsWith("campaign-a_"))).toBe(true);
+		expect(second.every((e) => e.id.startsWith("campaign-b_"))).toBe(true);
+		expect(second.every((e) => e.metadata.campaignId === "campaign-b")).toBe(
+			true
+		);
+	});
+
+	it("misses when the content differs", async () => {
+		const service = new EntityExtractionService(null, null, await makeCache());
+
+		await service.extractEntities({ ...OPTIONS, campaignId: "campaign-a" });
+		await service.extractEntities({
+			...OPTIONS,
+			campaignId: "campaign-a",
+			content: "A different chunk entirely.",
+		});
+
+		expect(generateStructuredOutput).toHaveBeenCalledTimes(2);
+	});
+
+	it("hits across source names, because the extraction prompt does not contain one", async () => {
+		// `formatStructuredContentPrompt(resourceName)` substitutes whole-word
+		// "document", and the 15k-character prompt contains no whole-word match —
+		// the only near-miss is `"doc": "document_id"`, where `_` is a word
+		// character. So the rendered prompt is byte-identical for every source, and
+		// the same chunk text extracted under two different file names is genuinely
+		// the same call. See `prompt-does-not-vary-by-source-name` below, which
+		// pins that premise so this test cannot quietly start lying.
+		const service = new EntityExtractionService(null, null, await makeCache());
+
+		await service.extractEntities({ ...OPTIONS, campaignId: "campaign-a" });
+		await service.extractEntities({
+			...OPTIONS,
+			campaignId: "campaign-a",
+			sourceName: "A Different Sourcebook",
+		});
+
+		expect(generateStructuredOutput).toHaveBeenCalledTimes(1);
+	});
+
+	it("prompt-does-not-vary-by-source-name", () => {
+		// The premise of the test above. If someone adds a whole-word "document"
+		// to the extraction prompt, the source name starts reaching the model, the
+		// cacheable prefix stops being shared across documents, and this fails
+		// first — which is the point.
+		const a = buildExtractionPromptParts("Alpha Sourcebook", "chunk");
+		const b = buildExtractionPromptParts("Beta Gazetteer", "chunk");
+		expect(a.cacheablePrefix).toBe(b.cacheablePrefix);
+		expect(a.cacheablePrefix).not.toContain("Alpha Sourcebook");
+	});
+
+	it("retries the model when the first call produced no usable output", async () => {
+		const service = new EntityExtractionService(null, null, await makeCache());
+		generateStructuredOutput.mockRejectedValueOnce(
+			new Error("AI_NoObjectGeneratedError: No object generated")
+		);
+
+		const empty = await service.extractEntities({
+			...OPTIONS,
+			campaignId: "campaign-a",
+		});
+		expect(empty).toEqual([]);
+
+		const recovered = await service.extractEntities({
+			...OPTIONS,
+			campaignId: "campaign-a",
+		});
+		expect(recovered.length).toBeGreaterThan(0);
+		expect(generateStructuredOutput).toHaveBeenCalledTimes(2);
+	});
+
+	it("calls the model every time when no cache is supplied", async () => {
+		const service = new EntityExtractionService(null);
+
+		await service.extractEntities({ ...OPTIONS, campaignId: "campaign-a" });
+		await service.extractEntities({ ...OPTIONS, campaignId: "campaign-a" });
+
+		expect(generateStructuredOutput).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
Finishes the tractable remainder of the #761 umbrella: findings **8**, **5**, and **9**. #765 already landed findings 1, 2, 3, 4, 6 and 7, so what was left was the content-hash cache, the character-sheet path, and the `prepareStep` investigation.

Follows the issue's own discipline throughout — **measure before optimising, layer cheapest-first, and say plainly when the proposed change is the wrong trade.**

## Finding 8 — content-hash result cache

`CommunitySummaryService.generateOrGetSummary` already checked for an existing result before calling a model. That was the only place doing it, so re-uploading the same PDF, adding a document to a second campaign, or retrying a failed index re-paid full extraction cost on Sonnet 5 every time.

New D1 table `llm_result_cache` (+ `d1-bootstrap.sql`), `LlmResultCacheDAO`, and an `LlmResultCache` service wired into three call sites:

| Kind | Tier | Why it repeats |
|---|---|---|
| `entity_extraction` | `PIPELINE_STRUCTURED` (Sonnet 5) | Every chunk of every uploaded document |
| `character_sheet_detection` | `ANALYSIS` (Haiku 4.5) | Runs on **every** upload, sheet or not |
| `character_sheet_parse` | `SESSION_PLANNING` (Sonnet 5) | A full document in one call |

Three decisions worth reviewing:

**The key hashes the rendered prompt, not a version constant.** The issue asks for `(model, prompt-version, chunk-content)`. I did not add a `PROMPT_VERSION` constant — it is a step someone eventually does not take, and a cache silently serving results from a superseded prompt is worse than no cache. Hashing the prompt text means an instruction edit and a content edit invalidate by the same mechanism. Components are hashed to fixed-length hex *before* being joined, so text cannot be shuffled across the prompt/content boundary into a collision (a plain `${a}|${b}` join cannot promise that; there is a test for it).

**The cached payload is campaign-independent.** This constrains where the cache sits. For extraction it wraps the model call only — the stored value is the validated payload captured *before* `mapExtractionPayload` mints campaign-scoped entity IDs. So adding the same document to a second campaign is a hit that still produces entities belonging to *that* campaign. One layer higher and it would only hit on a literal re-upload into the same campaign, which is the rarer case. `serves a second campaign from the cache but re-scopes the entity IDs` is the test that pins this.

**Every failure is a miss.** Missing table, missing binding, D1 error, unparseable row — all fall through to the model. The not-yet-migrated window is real, not hypothetical: merging to `main` deploys the Worker automatically while D1 migrations are applied separately. A model failure is also never cached (compute returns `undefined`), so one bad response cannot become permanent for a document.

On by default — a hit changes no model output — with `LLM_RESULT_CACHE_ENABLED=false` as a no-deploy kill switch. Eviction is age alone (90 days, on the existing fast cron beside the usage-log prunes); a stale prompt's rows are already unreachable because their key can never be derived again, so they cost storage, not correctness.

## Finding 5a — deterministic character-sheet pre-screen

Detection runs a model on **every** uploaded file, over up to three 10,000-character chunks, to answer one boolean. Same two-layer shape #759 established and #765 reused for the chunk gate:

- `classifyCharacterSheetDecisively` — short-circuits, and holds only rules with no failure mode.
- `classifyCharacterSheetAdvisory` — the full rule set, evaluated on every detection, logged against the model's answer, never routed on. `ambiguous` is recorded as a deferral, not a disagreement.

The one decisive rule that does real work is an **absence** rule, and absence is the dangerous kind. A document matching none of eleven concept groups — no name label, no stat, no class, no health, no gear, no skills, no spells — is not a character sheet in any system. But that only holds in a language whose vocabulary we know, so it additionally requires English prose density before firing. A French sheet matches no English indicator and must reach the model, not be skipped. That is the reason `src/lib/english-prose-stats.ts` exists (extracted from the chunk gate's local copy, now shared by both pre-gates) and it has its own test.

The screen never decisively *accepts*. A wrong positive would create a bogus PC entity, so a positive verdict always still costs a model call.

## Finding 5b — measured, and deliberately not implemented

The issue proposes merging detect + parse into one Sonnet call returning `isCharacterSheet` alongside the parsed data. **The arithmetic says that is a cost regression**, so I documented it on the service instead of shipping it:

| Path | Today | Merged |
|---|---|---|
| True positive | ~7.5k tok on ANALYSIS + full doc on SESSION_PLANNING | full doc on SESSION_PLANNING |
| True negative | ~7.5k tok on ANALYSIS | **full doc on SESSION_PLANNING** |

Detection caps input at three 10,000-character chunks; parsing sends up to 200,000. Merging saves a few percent on a true positive and pays roughly **20×** on a true negative — and most uploads are true negatives, the case it is worst for. "Returns early on `false`" does not rescue it: the early return saves *output* tokens and the cost here is *input*.

It becomes a win only behind a pre-screen confident enough to route positives deterministically, which is exactly what the advisory telemetry added here is there to justify. Until that data exists, two calls.

## Finding 9 — investigated; the interference is worse than the issue thought

The issue frames this as a caching nit conditional on #734. Tracing it turned up a second, live effect:

`MAX_CONTEXT_MESSAGES = 32` keeps up to 32 recent turns and folds older ones into a summary. `prepareStep` then compresses at `> 30` down to the last 15. Once the summariser's window is full, **that branch fires on step one, before any tool traffic**, and cuts history to 15. The effective conversation window is 15, not 32, on exactly the long conversations the summariser exists for. (The summary block itself survives — it rides in the system prompt.)

The issue also asks whether the rolling summarisation can subsume this second mechanism. **It cannot**: the summariser runs once, before any step exists, over persisted conversation history; `prepareStep` bounds what a tool loop adds *during* the turn. They guard different overflow sources.

No behaviour change here — deliberately. Changing the window changes chat behaviour, and truncating from anywhere but the end risks orphaning a tool-call/tool-result pair, which Anthropic rejects outright (cf. #782). Both findings are now documented at the call site so #734 inherits them rather than rediscovering them.

## An unrelated bug found while verifying cache keys

A test asserting "different source names should miss the cache" failed. The cache was right and the test was wrong:

`formatStructuredContentPrompt(resourceName)` does `STRUCTURED_CONTENT.replace(/\bdocument\b/g, resourceName)`, and the 15,355-character prompt contains **zero** whole-word matches for `document`. The only near-miss is `"doc": "document_id"`, where `_` is a word character so `\b` never fires. Verified: two different source names render byte-identical prompts.

Two consequences pulling opposite ways:

- **Good.** The prompt-cache prefix is identical across *every* document, not just chunks sharing a source name as the code comment claimed — a far better hit rate, and ~3.8k tokens, comfortably over Sonnet's 1,024-token minimum.
- **Latent.** The prompt instructs the model to emit `"source": {"doc": "document_id"}` for an id it was never given, so `meta.source.doc` is invented. Nothing downstream reads it, so this is dead intent rather than a live defect — **I have not changed the prompt**, since that is a model-behaviour change that deserves its own decision.

The stale comment is corrected, and `prompt-does-not-vary-by-source-name` pins the premise so a prompt edit cannot silently change the cache's scope.

## Not in this PR

Called out rather than silently dropped:

- **#734** (streaming chat path caching) — its own open issue, and the highest-value remaining item.
- **Finding 10, retry counts** — #765 already established this is not implementable as asked: the AI SDK exposes no retry count on `generateText`'s result.
- **Finding 10, effort sweep and embeddings** — both are explicitly "measure before committing" in the issue, and measuring needs production traffic and an API key, neither available here.
- **Finding 10, two-stage triage for `digest-quality-service`** — plausible, but it is a quality change to digest scoring, not a mechanical one; it wants its own PR and its own before/after.
- **Finding 10, OpenAI tier drift / #737 doc drift** — #737 owns it. `docs/MODEL_CONFIGURATION.md` is still badly stale and I did not half-correct it.
- **`complexity-baseline.json`** — `npm run complexity` reports 6 baseline entries improved, but every one is in a file this PR does not touch (`ResourceSidePanel.tsx`, `useChatSession.ts`, `useCampaignAddition.ts`, `campaigns.ts`, `library-metadata-service.ts`). They are stale drift from other merged PRs. I reverted the regenerated file rather than sweep unrelated churn into this diff — the gate passes without it, and it is worth a one-line follow-up commit on `main`.

## Wiki

`docs/LLM_RESULT_CACHE.md` is new and **is** registered in `FILE_MAPPINGS` and the sidebar, so it will actually sync. `npm run wiki:sync:dry-run` on this branch shows:

```
 M API-Reference.md
 M Deployment.md
 M Technical/Library-Entity-Pipeline.md
 M _Sidebar.md
?? Technical/Database-Migrations.md
?? Technical/Generated-Audio.md
?? Technical/LLM-Batch-Processing.md
?? Technical/LLM-Result-Cache.md
```

Only `Technical/LLM-Result-Cache.md` and the `_Sidebar.md` line are from this PR — **the wiki is already several merges behind** on the rest. No sync has been run (that would publish unmerged docs); it needs `npm run wiki:sync` from `main` after this squash-merges.

## Verification

Everything below was run on this branch, rebased onto `962a59d6` (current `main`):

- `npm run check` — exit 0
- `npm run complexity` — exit 0
- `node scripts/d1/check-migrations.mjs` — exit 0 (`0035_llm_result_cache.sql` checked, bootstrap parity confirmed)
- `npm run build` — exit 0
- `npx vitest run` — **2,105 tests across 217 files, all passing**
- Playwright e2e — **not run locally**; leaving that to CI.
- **No LLM provider calls and no D1 queries were made.** All new behaviour is covered by unit tests against mocked providers and an in-memory DAO stub. In particular the cache has **not** been exercised against a real D1 binding — the migration and DAO SQL are reviewed, not executed.

## How to see this change

```bash
gh pr checkout <PR#>
npm ci            # new files only, but the worktree needs deps
```

There is no user-visible difference — this is cost plumbing. The behaviour is proved by tests:

```bash
# Finding 8: the cache saves the call, and does not leak one campaign's IDs into another.
npx vitest run tests/services/rag/entity-extraction-result-cache.test.ts

# The key: prompt edits and tier changes invalidate; text cannot be shuffled into a collision.
npx vitest run tests/lib/llm-result-cache-key.test.ts

# Degradation: unmigrated table, D1 error, unparseable row, oversized payload — all still work.
npx vitest run tests/services/llm/llm-result-cache.test.ts

# Finding 5a: the pre-screen, including the non-English case it must not fire on.
npx vitest run tests/services/character-sheet/
```

**What you should see:** all green. The three that carry the argument of this PR:

- `entity-extraction-result-cache.test.ts` → *"serves a second campaign from the cache but re-scopes the entity IDs"*. Move the `getOrCompute` wrapper in `extractEntities` to enclose `mapExtractionPayload` as well and this fails — the second campaign gets `campaign-a_` entity IDs. That is the bug the layering choice avoids.
- `character-sheet-indicators.test.ts` → *"defers on non-English text, where an absent English keyword proves nothing"*. Delete the `englishDensity` condition in `classifyCharacterSheetDecisively` and it fails — which is a French character sheet being silently skipped.
- `llm-result-cache.test.ts` → *"degrades to a plain call when the table has not been migrated yet"*. This is the deploy window between `main` shipping the Worker and the migration being applied.

To watch it live, set `LORESMITH_VERBOSE_LLM_USAGE=true` and grep a `wrangler tail` for `llm_result_cache_hit` (a model call that did not happen) and `character_sheet_detection_decision` (group by `advisoryRule` + `advisoryAgreed` for the per-rule disagreement rate that decides what gets promoted). **I did not run this against a deployed Worker** — no API key in this environment.

Note the migration must be applied before the cache does anything; until then every lookup degrades to a miss, silently and safely.

Part of #761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

