### PR TITLE
feat(audio): route chat to a dedicated audio agent (#788)

### DIFF
--- a/docs/GENERATED_AUDIO.md
+++ b/docs/GENERATED_AUDIO.md
@@ -58,6 +58,66 @@ HTTP route ─┘         │                         (routes on kind)    └─
 | `src/dao/campaign-audio-dao.ts` | `campaign_audio` rows |
 | `src/routes/campaign-audio.ts` | GM-only HTTP surface |
 | `src/tools/campaign-context/audio-tools.ts` | Conversational access |
+| `src/agents/audio-agent.ts` | The agent that owns those tools in chat |
+
+## Reaching it from chat
+
+Audio is its own agent, not a set of extra responsibilities on the campaign
+context agent. That split is the fix for
+[#788](https://github.com/ofisk/loresmith-ai/issues/788), where the entire
+feature shipped working and unreachable: the tools were registered inside
+`campaignContextToolsBundle`, whose routing description mentions entities,
+search, and world state and says nothing about sound. `AgentRouter` builds its
+classifier prompt from exactly those descriptions, so "generate music" had no
+signal pointing anywhere useful and landed on an agent that truthfully answered
+that it could not produce audio.
+
+The lesson generalizes past audio: **a tool is only reachable if some agent's
+routing description describes it.** Registering a tool in a bundle is not
+enough, and the failure is silent — it looks like a hallucinated capability
+denial rather than a configuration problem.
+
+Routing to `audio` happens on two layers:
+
+- **Deterministic** (`agent-routing-fast-path.ts`) — anchored patterns match
+  requests whose audio noun is the direct object of a generation verb
+  ("generate music", "make ambience for the crypt scene"). These skip the
+  classifier entirely. The anchoring is what keeps them safe: "generate a
+  summary of the music the bards play" is a campaign question and does not
+  match.
+- **Classifier** — everything looser, steered by the agent description and the
+  routing rule in `agent-routing-prompts.ts`.
+
+The agent is GM-only with **no** player subset. `buildAudioTitle` names tracks
+after campaign entities, so "Theme: The Betrayer's Reveal" spoils a session
+merely by appearing in a list. `getToolsForRole` returns an empty bundle for
+player roles, matching the route-level gate in `src/routes/campaign-audio.ts`.
+
+Two prompt rules exist to prevent specific regressions:
+
+- A capability gap is stated once and never retried. The agent may not offer a
+  retry, suggest trying later, or speculate that the capability might arrive.
+- The agent must never fall back to writing a prompt for an external music,
+  sound, or voice service. Handing the GM text to paste into another product is
+  the exact behavior this feature was built to replace, and it is what #788
+  observed in production.
+
+### The gap is stated, not explained
+
+`UNAVAILABLE_REASON` in the provider factory is written for developers, and it
+names the platform and the missing vendor. The GM never reads it.
+`sanitizeUserFacingText` (added in
+[#787](https://github.com/ofisk/loresmith-ai/issues/787)) redacts any tool error
+containing that vocabulary — "Cloudflare", "Workers AI", "audio provider", "not
+configured" all match — and replaces the whole message with "That's not
+something I can do right now." The raw text is logged instead.
+
+So when you are debugging an unavailable kind, read the logs; the chat
+transcript will only ever show the plain-language stand-in. This is deliberate:
+#788 originally asked for the gap to be explained to the GM as "music requires
+an external provider that is not configured", and #787 superseded that. The
+substance survives — no retry, no rival-service prompt, a clear statement that
+it cannot be done — and only the reason is withheld.
 
 ## Generation is always asynchronous
 

--- a/src/agents/audio-agent.ts
+++ b/src/agents/audio-agent.ts
@@ -1,0 +1,89 @@
+import { isGMRole } from "@/constants/campaign-roles";
+import {
+	gmAudioToolsBundle,
+	playerAudioToolsBundle,
+} from "@/tools/campaign-context/audio-agent-tools-bundle";
+import type { CampaignRole } from "@/types/campaign";
+import { BaseAgent } from "./base-agent";
+import {
+	buildSystemPrompt,
+	createToolMappingFromObjects,
+} from "./system-prompts";
+
+/**
+ * System prompt for the Audio Agent (issue #788).
+ *
+ * Three rules here are load-bearing and are the reason this agent exists
+ * separately rather than as more responsibilities bolted onto the campaign
+ * context agent:
+ *
+ * 1. A capability gap is a gap, not a transient failure. When a kind of audio
+ *    has no way to be produced the tool returns a 501; that is final.
+ * 2. Never substitute a text prompt for another audio product. Handing the GM
+ *    something to paste into a different service is the exact behavior this
+ *    feature replaces, and is what #788 observed in production.
+ * 3. Generation is asynchronous. The tool answers "started", never "here it is".
+ *
+ * Rules 1 and 2 are worded carefully to stay inside the always-on
+ * NO_IMPLEMENTATION_DETAILS_RULE that #787 added to every agent prompt. #788
+ * asked for the gap to be explained as "music requires an external provider
+ * that is not configured", but #787 merged after that was written and forbids
+ * exactly that sentence — and `sanitizeUserFacingText` now redacts the
+ * capability reason before the model ever sees it, so the wording is not
+ * reachable anyway. The substance #788 wanted survives intact: say plainly that
+ * this cannot be done, offer no retry, and never fall back to a prompt for
+ * another product. Only the explanation of *why* is withheld.
+ */
+const AUDIO_AGENT_SYSTEM_PROMPT = buildSystemPrompt({
+	agentName: "Audio Agent",
+	responsibilities: [
+		"Generate campaign audio: scene ambience (a continuous background bed), sound effects (a one-shot fired on a beat), theme music, creature vocalizations, and spoken NPC dialogue. Pick the kind from what the user is describing, not from the word they happened to use.",
+		"Ground each request in the campaign before generating: resolve the location, monster, or NPC they named to a real entity so the audio prompt is built from campaign detail rather than from the user's phrasing.",
+		"List existing tracks with listCampaignAudioTool when the user asks what audio a campaign already has, or before generating something that may already exist.",
+		"Delete tracks with deleteCampaignAudioTool when asked, after confirming which track they mean.",
+		"Report gaps plainly: when a kind of audio cannot be created, say once and in plain words that you are not able to make it, and offer what you can make instead.",
+	],
+	tools: createToolMappingFromObjects(gmAudioToolsBundle),
+	workflowGuidelines: [
+		"Choose the kind deliberately: ambience for a looping bed under a scene, sfx for a single short sound fired on a beat (a door slam, a spell discharge), music for a theme, creature for a monster vocalization, voice for an NPC speaking a line. Ambience and sfx are not interchangeable: they get different lengths and different looping.",
+		"When the user names a place, creature, or character (e.g. 'ambience for the crypt', 'the Betrayer's theme'), call searchCampaignContext or listAllEntities first and pass the matching entityId to generateCampaignAudioTool. That entity's description is what gives the track its specific sensory detail. Use scene for the beat it plays under, and hint only for the user's own steer in their own words.",
+		"Do not write the sound design yourself. LoreSmith builds it from the campaign, so passing a long invented description in hint replaces real campaign detail with your guess.",
+		"For kind=voice you must pass line: the exact words the NPC speaks, verbatim and with no stage direction, because text-to-speech reads aloud anything you add.",
+		"After calling generateCampaignAudioTool, tell the user the track is being generated and that they will get a notification when it is ready. Never say the audio is ready, describe how it sounds, or offer a link to play it in the same turn: the tool starts the job, it does not finish it.",
+		"If a kind of audio comes back as something you cannot do, say plainly that you are not able to make that kind of audio, and stop. Do not retry, do not suggest trying again later, do not guess at or explain the reason, and do not quietly make a different kind instead. If another kind would genuinely serve the same scene, offer it as a choice and name the swap.",
+		"Never ask for campaignId. The runtime injects the currently selected campaign.",
+	],
+	importantNotes: [
+		"CRITICAL - Never hand the user text to take somewhere else. If you cannot make the audio they asked for, do NOT write, offer, or describe a prompt, a lyric sheet, or a shot list for any other music, sound, or voice service, and never name such a service. Producing a prompt to paste elsewhere instead of the audio itself is the exact failure this was built to eliminate. Say what you cannot make, offer what you can, and leave it there.",
+		"CRITICAL - Audio you cannot make is not a glitch. Never describe it as a hiccup, a timeout, a temporary problem, or something that might work on a second attempt. Never offer to retry, and never suggest it may become possible later.",
+		"CRITICAL - Audio is GM-only. Track titles are drawn from the campaign's own people and places, so a title alone can spoil an upcoming reveal. If you cannot act on audio this turn, the person you are talking to is not the GM of this campaign: tell them audio for the campaign is handled by their GM, and do not describe, list, or hint at any track.",
+		"You cannot play audio. You create, list, and delete tracks; the campaign audio panel is where they are played.",
+	],
+	conversationRules: "minimal",
+});
+
+/**
+ * Audio Agent: generates, lists, and deletes generated campaign audio.
+ *
+ * Split out from the campaign context agent because audio is a distinct intent
+ * with its own vocabulary ("ambience", "theme", "what does it sound like"), and
+ * burying the tools inside an entity-Q&A agent left them unreachable from chat
+ * for the entire life of the feature (#788).
+ */
+export class AudioAgent extends BaseAgent {
+	static readonly agentMetadata = {
+		type: "audio",
+		description:
+			"Generates campaign audio: scene ambience, one-shot sound effects, theme music, creature vocalizations, and spoken NPC dialogue. Also lists and deletes existing tracks. Use for 'generate music', 'make ambience for the crypt', 'what does the villain's theme sound like', 'give me a door-slam effect', 'read this line in the NPC's voice'.",
+		systemPrompt: AUDIO_AGENT_SYSTEM_PROMPT,
+		tools: gmAudioToolsBundle,
+	};
+
+	constructor(ctx: DurableObjectState, env: any, model: any) {
+		super(ctx, env, model, gmAudioToolsBundle);
+	}
+
+	protected getToolsForRole(role: CampaignRole | null): Record<string, any> {
+		return isGMRole(role) ? gmAudioToolsBundle : playerAudioToolsBundle;
+	}
+}

--- a/src/lib/agent-registry.ts
+++ b/src/lib/agent-registry.ts
@@ -88,6 +88,7 @@ export class AgentRegistryService {
 		const { EncounterBuilderAgent } = await import(
 			"../agents/encounter-builder-agent"
 		);
+		const { AudioAgent } = await import("../agents/audio-agent");
 		const { AgentRouter } = await import("./agent-router");
 
 		// Register Campaign Agent
@@ -205,6 +206,15 @@ export class AgentRegistryService {
 			EncounterBuilderAgent.agentMetadata.tools,
 			EncounterBuilderAgent.agentMetadata.systemPrompt,
 			EncounterBuilderAgent.agentMetadata.description
+		);
+
+		// Register Audio Agent (generated campaign audio)
+		AgentRouter.registerAgent(
+			AudioAgent.agentMetadata.type as AgentType,
+			AudioAgent,
+			AudioAgent.agentMetadata.tools,
+			AudioAgent.agentMetadata.systemPrompt,
+			AudioAgent.agentMetadata.description
 		);
 
 		AgentRegistryService.initialized = true;

--- a/src/lib/agent-router.ts
+++ b/src/lib/agent-router.ts
@@ -20,6 +20,7 @@ import {
 } from "./prompts/agent-routing-prompts";
 
 export type AgentType =
+	| "audio"
 	| "campaign"
 	| "campaign-context"
 	| "recap"

--- a/src/lib/agent-routing-fast-path.ts
+++ b/src/lib/agent-routing-fast-path.ts
@@ -137,28 +137,75 @@ const DECISIVE_PHRASE_LOOKUP: ReadonlyMap<
 );
 
 /**
+ * Anchored patterns for intents whose vocabulary has exactly one destination.
+ *
+ * Unlike the phrase table these match a *prefix* of the message, so they cover
+ * open-ended objects ("generate music for this campaign", "make ambience for
+ * the crypt scene") that no fixed phrase list could enumerate. They are still
+ * decisive, so the same bar applies: the pattern must be anchored at the start
+ * of the message and must not fire on a request that merely mentions the topic.
+ *
+ * The anchoring is what keeps them honest. "generate music" is an audio
+ * request; "generate a summary of the music the bards play" is a campaign
+ * question, and the determiner group deliberately excludes it by requiring the
+ * audio noun to be the direct object of the verb.
+ */
+const DECISIVE_PATTERNS: ReadonlyArray<{
+	rule: string;
+	agent: string;
+	reason: string;
+	pattern: RegExp;
+}> = [
+	{
+		rule: "pattern:audio-generation",
+		agent: "audio",
+		reason: "Audio generation request",
+		pattern:
+			/^(?:please\s+|hey,?\s+|ok(?:ay)?,?\s+|can you\s+|could you\s+|go ahead and\s+|i want you to\s+|i'?d like you to\s+)*(?:generate|make|create|produce|compose)\s+(?:me\s+)?(?:some\s+|a\s+|an\s+|the\s+)?(?:new\s+|short\s+|long\s+|quick\s+|custom\s+|looping\s+|background\s+)*(?:music|ambience|ambiance|soundscape|sound\s?effects?|sfx|audio(?:\s+track)?|theme\s+(?:music|song|tune)|creature\s+(?:sound|noise|vocali[sz]ation)s?)\b/i,
+	},
+	{
+		rule: "pattern:audio-library",
+		agent: "audio",
+		reason: "Generated audio library request",
+		pattern:
+			/^(?:please\s+|can you\s+|could you\s+)*(?:list|show(?:\s+me)?|delete|remove|what)\s+(?:me\s+)?(?:all\s+|the\s+|my\s+|any\s+)?(?:audio\s+tracks?|generated\s+audio|audio\s+for\s+this\s+campaign)\b/i,
+	},
+];
+
+/**
  * Layer 2: match a message we can route without a model call.
  *
- * Matching is whole-message equality on the normalized text, never substring
- * containment — "what should I do next about the grappling rules" is genuinely
- * ambiguous between `recap` and `rules-reference`, so it must reach the
- * classifier. Returns null for anything not in the table.
+ * Phrase matching is whole-message equality on the normalized text, never
+ * substring containment — "what should I do next about the grappling rules" is
+ * genuinely ambiguous between `recap` and `rules-reference`, so it must reach
+ * the classifier.
+ *
+ * Anchored patterns run second, for intents whose object is open-ended and so
+ * cannot be enumerated as phrases. Returns null when neither layer matches.
  */
 export function matchDecisiveRoute(userMessage: string): FastPathMatch | null {
 	const normalized = normalizeForMatching(userMessage);
 	if (!normalized) {
 		return null;
 	}
+
 	const hit = DECISIVE_PHRASE_LOOKUP.get(normalized);
-	if (!hit) {
-		return null;
+	if (hit) {
+		return {
+			agent: hit.agent,
+			confidence: 100,
+			reason: hit.reason,
+			rule: `phrase:${normalized.slice(0, 40)}`,
+		};
 	}
-	return {
-		agent: hit.agent,
-		confidence: 100,
-		reason: hit.reason,
-		rule: `phrase:${normalized.slice(0, 40)}`,
-	};
+
+	for (const { rule, agent, reason, pattern } of DECISIVE_PATTERNS) {
+		if (pattern.test(normalized)) {
+			return { agent, confidence: 100, reason, rule };
+		}
+	}
+
+	return null;
 }
 
 /**
@@ -238,6 +285,15 @@ const ADVISORY_RULES: ReadonlyArray<{
 		agent: "onboarding",
 		pattern:
 			/\b(how do i (use|upload|get started)|which boost|help me choose a boost|running out of capacity)/i,
+	},
+	{
+		// Last, deliberately: "build an encounter with creepy ambience" is an
+		// encounter request that happens to mention sound, and the rules above
+		// should claim it first. What reaches here is audio and nothing else.
+		rule: "advisory:audio",
+		agent: "audio",
+		pattern:
+			/\b(ambience|ambiance|soundscape|sound effects?|theme (music|song)|background music|creature (sound|noise)|npc voice|in (the|his|her|their) voice|what does .{1,40} sound like)\b/i,
 	},
 ];
 

--- a/src/lib/prompts/agent-routing-prompts.ts
+++ b/src/lib/prompts/agent-routing-prompts.ts
@@ -47,6 +47,7 @@ Routing rules:
 - Loot and rewards (encounter loot, dragon hoard treasure, meaningful magic item rewards, track distributed loot) → "loot-reward"
 - Rules reference questions (grappling, concentration checks, action economy, spellcasting rules, stat block lookups, "what does the rule say", "does our house rule apply") → "rules-reference"
 - Encounter building and scaling (build an encounter, scale this fight, medium-difficulty combat near a location, prepare monster lineup and tactics) → "encounter-builder"
+- Generated audio (generate music, make ambience for a scene, a one-shot sound effect, a creature vocalization, speaking an NPC line aloud, listing or deleting generated tracks, "what does X sound like") → "audio". Route here even when the request also names a location, NPC, or monster: the audio agent resolves that entity itself. Do NOT route to "campaign-context" merely because an entity is mentioned.
 - General help/how-to questions about using the application → "onboarding"
 - Boost/credits selection (which boost, help me choose, running out of capacity when adding documents, need more room for documents) → "onboarding"
 
@@ -72,6 +73,12 @@ Examples:
 - "Build a medium-difficulty encounter for a level 7 party near Ashfen Marsh" → encounter-builder|95|Encounter generation
 - "Scale this encounter up for five level 9 characters" → encounter-builder|95|Encounter scaling
 - "let's do a readout" / "construct the readout" / "give me the session plan" / "I'm ready for the readout" → recap|95|Session plan readout (from completed next steps)
+- "generate music for this campaign" → audio|95|Audio generation
+- "Make ambience for the crypt scene" → audio|95|Scene ambience generation
+- "Give me a door-slam sound effect" → audio|95|Sound effect generation
+- "What does the Betrayer's theme sound like?" → audio|90|Theme music generation
+- "Read this line in Sera's voice: 'You should not have come here.'" → audio|95|NPC voice generation
+- "What audio tracks does this campaign have?" → audio|90|Generated audio listing
 - "how do I upload files?" → onboarding|85|General help
 - "which boost should I get?" / "help me choose a boost" / "I'm running out of capacity" → onboarding|90|Boost selection`;
 }

--- a/src/tools/campaign-context/audio-agent-tools-bundle.ts
+++ b/src/tools/campaign-context/audio-agent-tools-bundle.ts
@@ -1,0 +1,34 @@
+// Audio agent tools bundle (issue #788)
+
+import { campaignAudioToolsBundle } from "./audio-tools";
+import { listAllEntities, searchCampaignContext } from "./search-tools";
+
+/**
+ * GM toolset for the audio agent.
+ *
+ * The three audio tools alone are not enough to satisfy the reason this feature
+ * exists. `prepareAudioGeneration` loads campaign tone from the campaign record
+ * on its own, but entity detail is only pulled when an `entityId` is supplied —
+ * so without a way to resolve "the crypt" to an entity, the agent would fall
+ * back to echoing the GM's own words into `hint`. That is precisely the
+ * "describing your world back to the machine" failure `docs/GENERATED_AUDIO.md`
+ * calls out as the thing generated audio is supposed to replace.
+ *
+ * The two search tools are read-only and already part of the player-safe
+ * campaign context bundle, so including them widens no permission.
+ */
+export const gmAudioToolsBundle = {
+	...campaignAudioToolsBundle,
+	searchCampaignContext,
+	listAllEntities,
+};
+
+/**
+ * Players get nothing.
+ *
+ * Unlike campaign context, audio has no player-safe subset: titles are built
+ * from campaign entities by `buildAudioTitle`, so a track called
+ * "Theme: The Betrayer's Reveal" spoils a session merely by being listed. This
+ * mirrors the route-level GM gate in `src/routes/campaign-audio.ts`.
+ */
+export const playerAudioToolsBundle: Record<string, never> = {};

--- a/src/tools/campaign-context/context-tools-bundle.ts
+++ b/src/tools/campaign-context/context-tools-bundle.ts
@@ -3,11 +3,6 @@
 import { showCampaignDetails } from "@/tools/campaign/core-tools";
 import { searchVisualInspirationTool } from "@/tools/campaign/file-tools";
 import { getMessageHistory } from "@/tools/message-history-tools";
-import {
-	deleteCampaignAudioTool,
-	generateCampaignAudioTool,
-	listCampaignAudioTool,
-} from "./audio-tools";
 import { getChecklistStatusTool } from "./checklist-tools";
 import { captureConversationalContext } from "./context-capture-tools";
 import {
@@ -82,11 +77,11 @@ export const campaignContextToolsBundle = {
 	captureConversationalContext,
 	generateHandoutTool,
 	exportHandoutTool,
-	// Generated audio (#756). GM-only: a track title is built from campaign
-	// entities, so listing tracks reveals what is coming.
-	generateCampaignAudioTool,
-	listCampaignAudioTool,
-	deleteCampaignAudioTool,
+	// Generated audio (#756) is deliberately NOT here. It lives on the audio
+	// agent (#788): this agent's prompt never documented the audio tools, so the
+	// model was handed capabilities it was never told it had, while the router
+	// had no description pointing audio requests at this agent in the first
+	// place. See `src/tools/campaign-context/audio-agent-tools-bundle.ts`.
 };
 
 /** Player-facing subset: search, list (sanitized), campaign details, message history */

--- a/tests/agents/audio-agent.test.ts
+++ b/tests/agents/audio-agent.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { AudioAgent } from "../../src/agents/audio-agent";
+import {
+	NO_IMPLEMENTATION_DETAILS_RULE,
+	PLAIN_LANGUAGE_RULE,
+} from "../../src/agents/system-prompts";
+import { CAMPAIGN_ROLES } from "../../src/constants/campaign-roles";
+import type { CampaignRole } from "../../src/types/campaign";
+
+/**
+ * Issue #788. The audio feature shipped fully working and completely
+ * unreachable: its tools lived on an agent whose routing description never
+ * mentioned sound, so the classifier had no signal to route on and chat
+ * answered "I cannot generate audio".
+ *
+ * These tests pin the two properties that made it unreachable — a description
+ * the router can actually match, and a GM-only toolset — plus the prompt rules
+ * that keep a missing provider from being reported as a retryable blip or
+ * papered over with a Suno prompt.
+ */
+
+/**
+ * `getToolsForRole` is protected and does not touch `this`, so it is called off
+ * the prototype rather than standing up a Durable Object to reach it.
+ */
+function toolsForRole(role: CampaignRole | null): Record<string, unknown> {
+	const getToolsForRole = (
+		AudioAgent.prototype as unknown as {
+			getToolsForRole: (r: CampaignRole | null) => Record<string, unknown>;
+		}
+	).getToolsForRole;
+	return getToolsForRole.call(AudioAgent.prototype, role);
+}
+
+const AUDIO_TOOLS = [
+	"generateCampaignAudioTool",
+	"listCampaignAudioTool",
+	"deleteCampaignAudioTool",
+];
+
+describe("AudioAgent role gating", () => {
+	it("gives GM roles the full audio toolset", () => {
+		for (const role of [
+			CAMPAIGN_ROLES.OWNER,
+			CAMPAIGN_ROLES.EDITOR_GM,
+			CAMPAIGN_ROLES.READONLY_GM,
+		]) {
+			const tools = toolsForRole(role);
+			for (const name of AUDIO_TOOLS) {
+				expect(tools[name], `${role} should have ${name}`).toBeDefined();
+			}
+		}
+	});
+
+	// Audio has no player-safe subset: `buildAudioTitle` names tracks after
+	// campaign entities, so "Theme: The Betrayer's Reveal" spoils a session by
+	// existing. Players get an empty bundle, not a sanitized one.
+	it("gives player roles no tools at all", () => {
+		for (const role of [
+			CAMPAIGN_ROLES.EDITOR_PLAYER,
+			CAMPAIGN_ROLES.READONLY_PLAYER,
+		]) {
+			expect(toolsForRole(role)).toEqual({});
+		}
+	});
+
+	it("gives an unknown role no tools", () => {
+		expect(toolsForRole(null)).toEqual({});
+	});
+
+	it("lets a GM resolve entities so prompts are built from campaign context", () => {
+		const tools = toolsForRole(CAMPAIGN_ROLES.OWNER);
+		expect(tools.searchCampaignContext).toBeDefined();
+		expect(tools.listAllEntities).toBeDefined();
+	});
+});
+
+describe("AudioAgent routing metadata", () => {
+	it("registers under the audio agent type", () => {
+		expect(AudioAgent.agentMetadata.type).toBe("audio");
+	});
+
+	// The root cause of #788: the description is the only thing the classifier
+	// sees, and the one it had said nothing about sound.
+	it("describes the vocabulary an audio request actually uses", () => {
+		const description = AudioAgent.agentMetadata.description.toLowerCase();
+		for (const term of [
+			"ambience",
+			"sound effect",
+			"music",
+			"voice",
+			"generate music",
+		]) {
+			expect(description, `description should mention "${term}"`).toContain(
+				term
+			);
+		}
+	});
+});
+
+describe("AudioAgent system prompt", () => {
+	const prompt = AudioAgent.agentMetadata.systemPrompt;
+
+	it("forbids substituting a prompt for another service", () => {
+		expect(prompt).toMatch(/never hand the user text to take somewhere else/i);
+		expect(prompt).toMatch(/never name such a service/i);
+	});
+
+	it("forbids treating an impossible request as retryable", () => {
+		expect(prompt).toMatch(/is not a glitch/i);
+		expect(prompt).toMatch(/never offer to retry/i);
+	});
+
+	// #787 (merged after #788 was written) bans explaining a gap in terms of
+	// setup, and `sanitizeUserFacingText` redacts the capability reason before
+	// the model sees it. So the gap is stated, never justified — and the agent
+	// must not prime itself with the names of the services it must not offer.
+	//
+	// The shared rules are stripped first: #787's own text quotes "an audio
+	// provider isn't configured" as an example of what never to say, so asserting
+	// over the assembled prompt would only re-test that boilerplate.
+	it("states a gap without naming setup or a rival service", () => {
+		const ownText = prompt
+			.replace(NO_IMPLEMENTATION_DETAILS_RULE, "")
+			.replace(PLAIN_LANGUAGE_RULE, "");
+
+		expect(ownText).not.toMatch(/not configured/i);
+		expect(ownText).not.toMatch(/\b(suno|udio|aiva|elevenlabs|cloudflare)\b/i);
+		expect(ownText).not.toMatch(/\b(audio|music|voice|speech)\s+providers?\b/i);
+	});
+
+	it("sets asynchronous expectations for generation", () => {
+		expect(prompt).toMatch(/notification when it is ready/i);
+		expect(prompt).toMatch(/never say the audio is ready/i);
+	});
+
+	it("requires grounding a request in campaign entities before generating", () => {
+		expect(prompt).toContain("searchCampaignContext");
+		expect(prompt).toMatch(/pass the matching entityid/i);
+	});
+});

--- a/tests/agents/role-based-tool-filtering.test.ts
+++ b/tests/agents/role-based-tool-filtering.test.ts
@@ -69,6 +69,21 @@ describe("Role-based tool filtering", () => {
 			expect(campaignContextToolsBundle.exportHandoutTool).toBeDefined();
 		});
 
+		// Issue #788: the audio tools used to live here, on an agent whose prompt
+		// never documented them and whose routing description never mentioned
+		// sound. They belong to the audio agent now.
+		it("campaignContextToolsBundle should not carry the audio tools", () => {
+			expect(
+				(campaignContextToolsBundle as any).generateCampaignAudioTool
+			).toBeUndefined();
+			expect(
+				(campaignContextToolsBundle as any).listCampaignAudioTool
+			).toBeUndefined();
+			expect(
+				(campaignContextToolsBundle as any).deleteCampaignAudioTool
+			).toBeUndefined();
+		});
+
 		it("playerCampaignContextToolsBundle should exclude GM-only tools", () => {
 			expect(
 				playerCampaignContextToolsBundle.searchCampaignContext

--- a/tests/lib/agent-router-routing.test.ts
+++ b/tests/lib/agent-router-routing.test.ts
@@ -32,6 +32,7 @@ const AGENTS = [
 	"onboarding",
 	"resources",
 	"rules-reference",
+	"audio",
 ] as const;
 
 function registerTestAgents() {
@@ -104,6 +105,29 @@ describe("AgentRouter.routeMessage layering", () => {
 		expect(recap.agent).toBe("session-digest");
 		expect(recap.source).toBe("deterministic");
 
+		expect(generateTextMock).not.toHaveBeenCalled();
+	});
+
+	// Issue #788: this exact message reached an agent with no audio tools and
+	// was answered with a flat "I cannot generate audio".
+	it("routes audio generation to the audio agent without calling the model", async () => {
+		const intent = await AgentRouter.routeMessage(
+			"generate music for this campaign"
+		);
+
+		expect(intent.agent).toBe("audio");
+		expect(intent.source).toBe("deterministic");
+		expect(intent.confidence).toBe(100);
+		expect(generateTextMock).not.toHaveBeenCalled();
+	});
+
+	it("routes scene ambience to the audio agent without calling the model", async () => {
+		const intent = await AgentRouter.routeMessage(
+			"Make ambience for the crypt scene"
+		);
+
+		expect(intent.agent).toBe("audio");
+		expect(intent.source).toBe("deterministic");
 		expect(generateTextMock).not.toHaveBeenCalled();
 	});
 

--- a/tests/lib/agent-routing-fast-path.test.ts
+++ b/tests/lib/agent-routing-fast-path.test.ts
@@ -24,6 +24,7 @@ const REGISTERED = [
 	"loot-reward",
 	"rules-reference",
 	"encounter-builder",
+	"audio",
 ];
 
 describe("resolveExplicitAgentHint", () => {
@@ -125,6 +126,66 @@ describe("matchDecisiveRoute", () => {
 		expect(matchDecisiveRoute("")).toBeNull();
 		expect(matchDecisiveRoute("   ")).toBeNull();
 	});
+
+	// Issue #788: "generate music" used to reach a classifier with no audio
+	// signal in any agent description, and answered that it could not make audio.
+	describe("audio (issue #788)", () => {
+		it("routes audio generation requests to the audio agent", () => {
+			for (const message of [
+				"generate music for this campaign",
+				"Make ambience for the crypt scene",
+				"create a soundscape for the tavern",
+				"please generate some theme music for the villain",
+				"can you make a short sound effect for a door slam?",
+				"compose music",
+				"produce an audio track for the final battle",
+				"create a creature sound for the owlbear",
+			]) {
+				expect(matchDecisiveRoute(message)?.agent, message).toBe("audio");
+			}
+		});
+
+		it("routes library requests to the audio agent", () => {
+			for (const message of [
+				"list audio tracks",
+				"show me the audio tracks for this campaign",
+				"what audio tracks do we have?",
+				"delete the audio track called Crypt Bed",
+			]) {
+				expect(matchDecisiveRoute(message)?.agent, message).toBe("audio");
+			}
+		});
+
+		it("reports full confidence and an attributable rule", () => {
+			const match = matchDecisiveRoute("generate music for this campaign");
+			expect(match).toMatchObject({
+				agent: "audio",
+				confidence: 100,
+				rule: "pattern:audio-generation",
+			});
+			expect(match?.reason).toBeTruthy();
+		});
+
+		// The anchoring is the whole safety argument for making these decisive:
+		// the audio noun has to be what the verb acts on, not merely present.
+		it("does not fire when the audio word is not the object of the verb", () => {
+			expect(
+				matchDecisiveRoute("generate a summary of the music the bards play")
+			).toBeNull();
+			expect(
+				matchDecisiveRoute("who composed the music in the elven court?")
+			).toBeNull();
+			expect(
+				matchDecisiveRoute("build an encounter with creepy ambience")
+			).toBeNull();
+			expect(
+				matchDecisiveRoute("what is the theme of this campaign?")
+			).toBeNull();
+			expect(
+				matchDecisiveRoute("create a character who plays music")
+			).toBeNull();
+		});
+	});
 });
 
 describe("matchAdvisoryRoute", () => {
@@ -148,6 +209,23 @@ describe("matchAdvisoryRoute", () => {
 				"What should the players find after defeating the bandit captain?"
 			)?.agent
 		).toBe("loot-reward");
+	});
+
+	it("guesses audio for looser sound requests", () => {
+		expect(
+			matchAdvisoryRoute("What does the Betrayer's theme sound like?")?.agent
+		).toBe("audio");
+		expect(matchAdvisoryRoute("I want a dripping cave soundscape")?.agent).toBe(
+			"audio"
+		);
+	});
+
+	// Audio is deliberately the last advisory rule: an encounter request that
+	// mentions sound is still an encounter request.
+	it("lets an earlier rule claim a message that only mentions sound", () => {
+		expect(
+			matchAdvisoryRoute("Build an encounter with creepy ambience")?.agent
+		).toBe("encounter-builder");
 	});
 
 	it("carries a rule id so disagreement can be attributed per rule", () => {


### PR DESCRIPTION
Implements **Part A** of #788. Part B (production secrets) is a config action for the maintainer and is called out at the bottom.

## What was wrong

Generated audio shipped fully working and completely unreachable. The three audio tools were registered inside `campaignContextToolsBundle`, whose routing description mentions entities, search, and world state and says nothing about sound. `AgentRouter` builds its Layer 3 classifier prompt from exactly those descriptions, so "generate music" had no signal pointing anywhere useful, landed on some other agent, and got a truthful "I can't produce audio" — which reads like a hallucinated capability denial rather than the configuration problem it was.

The generalizable lesson, now written into `docs/GENERATED_AUDIO.md`: **a tool is only reachable if some agent's routing description describes it.** Registering it in a bundle is not enough, and the failure is silent.

## What changed

- **`src/agents/audio-agent.ts`** (new) — `AudioAgent`, GM-only, with a description built from the vocabulary an audio request actually uses.
- **`src/tools/campaign-context/audio-agent-tools-bundle.ts`** (new) — `gmAudioToolsBundle` / `playerAudioToolsBundle`, following the repo's existing bundle convention.
- **`src/lib/agent-router.ts`** — `"audio"` added to `AgentType`.
- **`src/lib/agent-registry.ts`** — registered.
- **`src/lib/agent-routing-fast-path.ts`** — new `DECISIVE_PATTERNS` layer plus an advisory rule.
- **`src/lib/prompts/agent-routing-prompts.ts`** — routing rule and six examples for the classifier.
- **`src/tools/campaign-context/context-tools-bundle.ts`** — audio tools removed (see below).
- **`docs/GENERATED_AUDIO.md`** — a "Reaching it from chat" section.

### Three deviations from the issue, deliberate

**1. The audio tools were removed from `campaignContextToolsBundle`, not just duplicated.** That agent's system prompt never documented them, so the model was handed capabilities it was never told it had, while the router had no description pointing audio requests there. Leaving them would preserve the exact ambiguity that caused the bug. A regression test in `role-based-tool-filtering.test.ts` pins their absence.

**2. The audio agent gets two search tools, not only the three audio tools.** The issue says the toolset "needs no new assembly", but acceptance criterion 3 asks that "ambience for the crypt scene" be built from the entity graph. `prepareAudioGeneration` only loads entity detail when given an `entityId`, and `campaignAudioToolsBundle` has no way to resolve one — so the agent would have fallen back to echoing the GM's own words into `hint`, which is the failure the feature exists to replace. `searchCampaignContext` and `listAllEntities` are read-only and already in the player-safe bundle, so this widens no permission.

**3. Acceptance criterion 4 could not be implemented as written, because #787 superseded it.** #787 merged after #788 was filed and bans every agent from explaining a failure "in terms of setup, configuration, availability of a provider" — naming "an audio provider isn't configured" as an explicit example of what never to say. It also added `sanitizeUserFacingText`, which redacts any tool error containing "Cloudflare", "Workers AI", "audio provider", or "not configured" **before the model sees it**. The audio `UNAVAILABLE_REASON` strings match all four, so the requested wording is unreachable regardless of prompting.

The substance of the criterion is fully preserved — the agent says plainly it cannot make that audio, offers no retry, never speculates that it might work later, and never falls back to a prompt for another service. Only the *reason* is withheld, and it goes to the logs instead. This is documented in `docs/GENERATED_AUDIO.md` under "The gap is stated, not explained". **If you'd rather have the reason surfaced to GMs, that's a change to #787's policy and I'd take it as a follow-up.**

### On the decisive routing layer

`matchDecisiveRoute` was exact whole-message equality only, though its own header comment already advertised "anchored patterns". Audio needs them, since "generate music for this campaign" can never be a fixed-phrase hit. The anchoring is the entire safety argument: the audio noun must be the direct object of a generation verb, so `generate music` routes but `generate a summary of the music the bards play` does not. Negative cases are tested explicitly.

Advisory audio is deliberately the **last** rule, so "build an encounter with creepy ambience" is still claimed by encounter-builder.

## Verification

- `npm run check` — clean (9 warnings, all pre-existing in files I did not touch)
- `npx vitest run` — **2084 passed, 213 files**, none skipped
- `npm run test:coverage` — branches 74.37%, above the 70% gate
- `npm run complexity` — passed
- `npm run wiki:sync:dry-run` — `Technical/Generated-Audio.md` appears (it is registered in `FILE_MAPPINGS`; it shows as new because the wiki is already a merge behind from earlier PRs)
- Rebased on `origin/main` @ 962a59d6

Not run: e2e (no local server in this session), and no live generation — Part B is unset, so nothing could have been generated end to end.

## How to see this change

```bash
gh pr checkout 791
```

This has no visible UI surface of its own; it changes which agent answers a message. The routing decision is what to look at, and it is fully covered by tests:

```bash
npx vitest run tests/lib/agent-router-routing.test.ts tests/lib/agent-routing-fast-path.test.ts tests/agents/audio-agent.test.ts
```

**What you should see:** `routes audio generation to the audio agent without calling the model` passes. Before this branch, "generate music for this campaign" reached the LLM classifier with no audio signal in any agent description; now it resolves to `audio` with `source: "deterministic"` and confidence 100, without a model call at all.

To exercise it in the app, the two-terminal setup from `docs/DEV_SETUP.md` (`npm run dev:cloudflare`, then `npm run start`), then `http://localhost:5173` → pick a campaign → chat → "generate music for this campaign". **I did not run this**, since it needs a seeded local campaign and a GM session.

With the secrets unset — which is the state on dev and prod today — the honest expected result is: `voice` works (Workers AI needs no configuration, confirming the Part A / Part B split), and music/ambience/sfx reply that LoreSmith cannot make that audio, with no retry offered and no Suno prompt. That is the #788 fix even before Part B.

## Part B is not in this PR

Setting production secrets is a maintainer action:

```bash
wrangler secret put ELEVENLABS_API_KEY
wrangler secret put AI_GATEWAY_ACCOUNT_ID
wrangler secret put AI_GATEWAY_ID
```

All three are required together. Worth also confirming `migrations/0033_campaign_audio.sql` is applied to prod (`wrangler d1 migrations list --remote`) — prod deploys ship the Worker from `main` automatically but not always the schema.

Closes #788 for Part A. Recommend keeping the issue open until Part B lands, or splitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
