### PR TITLE
Chat header quick actions: response feedback, Idea button, session recap

### DIFF
--- a/src/components/app/AppHeader.tsx
+++ b/src/components/app/AppHeader.tsx
@@ -1,10 +1,8 @@
-import { NotePencil, SidebarSimple } from "@phosphor-icons/react";
+import { SidebarSimple } from "@phosphor-icons/react";
 import loresmith from "@/assets/loresmith.png";
 import { Button } from "@/components/button/Button";
 
 interface AppHeaderProps {
-	onSessionRecapRequest?: () => void;
-	selectedCampaignId: string | null;
 	onToggleSidebarCollapse?: () => void;
 	isCollapsed?: boolean;
 }
@@ -15,8 +13,6 @@ interface AppHeaderProps {
  * desktop sidebar and the off-canvas mobile sidebar.
  */
 export function AppHeader({
-	onSessionRecapRequest,
-	selectedCampaignId,
 	onToggleSidebarCollapse,
 	isCollapsed = false,
 }: AppHeaderProps) {
@@ -36,28 +32,6 @@ export function AppHeader({
 							<SidebarSimple size={18} />
 						</Button>
 					</div>
-				)}
-				{onSessionRecapRequest && (
-					<Button
-						variant="ghost"
-						size="md"
-						shape="square"
-						className="tour-session-recap !h-8 !w-8 rounded-full flex items-center justify-center"
-						onClick={onSessionRecapRequest}
-						disabled={!selectedCampaignId}
-						tooltip={
-							selectedCampaignId
-								? "Record session recap"
-								: "Select a campaign to record a session recap"
-						}
-						aria-label={
-							selectedCampaignId
-								? "Record session recap"
-								: "Select a campaign to record a session recap"
-						}
-					>
-						<NotePencil size={18} />
-					</Button>
 				)}
 			</div>
 		);
@@ -94,31 +68,6 @@ export function AppHeader({
 							<SidebarSimple size={18} />
 						</Button>
 					</div>
-				)}
-			</div>
-
-			<div className="flex flex-wrap items-center gap-2">
-				{onSessionRecapRequest && (
-					<Button
-						variant="ghost"
-						size="md"
-						shape="square"
-						className="tour-session-recap !h-8 !w-8 rounded-full flex items-center justify-center"
-						onClick={onSessionRecapRequest}
-						disabled={!selectedCampaignId}
-						tooltip={
-							selectedCampaignId
-								? "Record session recap"
-								: "Select a campaign to record a session recap"
-						}
-						aria-label={
-							selectedCampaignId
-								? "Record session recap"
-								: "Select a campaign to record a session recap"
-						}
-					>
-						<NotePencil size={18} />
-					</Button>
 				)}
 			</div>
 		</div>

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -130,6 +130,7 @@ export function AppShell() {
 								agentStatus={ctx.agentStatus}
 								chatError={ctx.chatError}
 								onRegenerate={ctx.onRegenerate}
+								onSessionRecapRequest={ctx.handleSessionRecapRequest}
 							/>
 						</div>
 					</div>

--- a/src/components/app/ChatArea.tsx
+++ b/src/components/app/ChatArea.tsx
@@ -1,6 +1,14 @@
-import { List, MapTrifold, PaperPlaneRight, Stop } from "@phosphor-icons/react";
+import {
+	Lightbulb,
+	List,
+	MapTrifold,
+	NotePencil,
+	PaperPlaneRight,
+	Stop,
+} from "@phosphor-icons/react";
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
+import { UI_INITIATED_PROMPTS } from "@/app-constants";
 import { Button } from "@/components/button/Button";
 import {
 	type PlayerCharacterOption,
@@ -47,8 +55,8 @@ interface ChatAreaProps {
 	agentStatus?: string | null;
 	/** Error from chat request; when set, show error banner with retry */
 	chatError?: Error | undefined;
-	/** Retry failed request (e.g. after error) */
-	onRegenerate?: () => Promise<void>;
+	/** Retry failed request (e.g. after error), or regenerate a specific message. */
+	onRegenerate?: (messageId?: string) => Promise<void>;
 	/** When provided, "Work on this" buttons are shown for next steps in agent messages; called with the step label. */
 	onWorkOnNextStep?: (stepLabel: string) => void;
 	/** When provided, used as step labels for "Work on this" buttons (e.g. from planning-tasks API). */
@@ -58,6 +66,8 @@ interface ChatAreaProps {
 	/** Opens/closes the mobile off-canvas sidebar; button only renders when provided. */
 	onToggleSidebar?: () => void;
 	isSidebarOpen?: boolean;
+	/** Records a session recap for the selected campaign; button only renders when provided. */
+	onSessionRecapRequest?: () => void;
 }
 
 /**
@@ -91,6 +101,7 @@ export function ChatArea({
 	onContinueGeneration,
 	onToggleSidebar,
 	isSidebarOpen = false,
+	onSessionRecapRequest,
 }: ChatAreaProps) {
 	const [claimOptions, setClaimOptions] = useState<PlayerCharacterOption[]>([]);
 	const [canCreateNewCharacter, setCanCreateNewCharacter] = useState(false);
@@ -109,6 +120,10 @@ export function ChatArea({
 					) ?? null)
 				: null,
 		[campaigns, selectedCampaignId]
+	);
+
+	const isPlayerRole = !!(
+		selectedCampaign?.role && PLAYER_ROLES.has(selectedCampaign.role)
 	);
 
 	useEffect(() => {
@@ -338,7 +353,55 @@ export function ChatArea({
 						</option>
 					))}
 				</select>
+				<div className="flex items-center gap-1 ml-1 shrink-0">
+					<button
+						type="button"
+						onClick={() =>
+							onSuggestionSubmit(
+								isPlayerRole
+									? UI_INITIATED_PROMPTS.NEXT_STEPS_PLAYER
+									: UI_INITIATED_PROMPTS.NEXT_STEPS_GM
+							)
+						}
+						disabled={!selectedCampaignId}
+						title={
+							selectedCampaignId
+								? "Idea"
+								: "Select a campaign to get next-step suggestions"
+						}
+						aria-label="Idea"
+						className="shrink-0 p-1.5 rounded-md text-primary hover:bg-primary/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+					>
+						<Lightbulb size={20} weight="fill" aria-hidden />
+					</button>
+					{onSessionRecapRequest && (
+						<button
+							type="button"
+							onClick={onSessionRecapRequest}
+							disabled={!selectedCampaignId || messages.length === 0}
+							title={
+								!selectedCampaignId
+									? "Select a campaign to record a session recap"
+									: messages.length === 0
+										? "Start a session before recording a recap"
+										: "Record session recap"
+							}
+							aria-label="Record session recap"
+							className="tour-session-recap shrink-0 p-1.5 rounded-md text-primary hover:bg-primary/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+						>
+							<NotePencil size={20} weight="fill" aria-hidden />
+						</button>
+					)}
+				</div>
 			</div>
+
+			{!selectedCampaignId && (
+				<div className="px-4 md:px-8 pb-2 flex-shrink-0 -mt-2">
+					<p className="text-xs text-neutral-500 dark:text-neutral-400">
+						Select a campaign for a more targeted experience
+					</p>
+				</div>
+			)}
 
 			{selectedCampaign?.hasProcessingDocuments && (
 				<div className="px-4 md:px-8 pt-0 pb-2 flex-shrink-0">
@@ -393,6 +456,7 @@ export function ChatArea({
 					openPlanningTaskTitles={openPlanningTaskTitles}
 					onContinueGeneration={onContinueGeneration}
 					isStreaming={isLoading}
+					onRegenerate={onRegenerate}
 				/>
 
 				{/* Thinking Spinner - shown when agent is processing */}

--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -3,6 +3,7 @@ import { Card } from "@/components/card/Card";
 import { CopyAsMarkdownButton } from "@/components/chat/CopyAsMarkdownButton";
 import { ExplainabilitySection } from "@/components/chat/ExplainabilitySection";
 import { InterruptedNotice } from "@/components/chat/InterruptedNotice";
+import { MessageFeedback } from "@/components/chat/MessageFeedback";
 import { ToolReceiptsSection } from "@/components/chat/ToolReceiptsSection";
 import { MemoizedMarkdown } from "@/components/MemoizedMarkdown";
 import { buildToolReceiptsFromParts } from "@/lib/tool-receipt-builder";
@@ -22,6 +23,27 @@ interface ChatMessageListProps {
 	onContinueGeneration?: () => void;
 	/** Suppresses the Continue button while a turn is already in flight. */
 	isStreaming?: boolean;
+	/** When provided, each assistant response gets a regenerate button. */
+	onRegenerate?: (messageId?: string) => void | Promise<void>;
+}
+
+/**
+ * Wraps the show/hide condition for MessageFeedback so the big per-part render
+ * closure below (already large) doesn't pick up more branches for it.
+ */
+function AssistantMessageFeedback({
+	isLastTextPart,
+	isUser,
+	messageId,
+	onRegenerate,
+}: {
+	isLastTextPart: boolean;
+	isUser: boolean;
+	messageId: string | undefined;
+	onRegenerate?: (messageId?: string) => void | Promise<void>;
+}) {
+	if (!isLastTextPart || isUser || !messageId) return null;
+	return <MessageFeedback messageId={messageId} onRegenerate={onRegenerate} />;
 }
 
 /**
@@ -193,6 +215,7 @@ export function ChatMessageList({
 	openPlanningTaskTitles,
 	onContinueGeneration,
 	isStreaming,
+	onRegenerate,
 }: ChatMessageListProps) {
 	const visibleMessages = messages.filter((m: Message) => {
 		if (m.role === "system") return false;
@@ -268,7 +291,7 @@ export function ChatMessageList({
 																className={`p-4 rounded-xl bg-neutral-100/80 dark:bg-neutral-900/80 backdrop-blur-sm min-w-0 ${
 																	isUser
 																		? "rounded-br-none"
-																		: "rounded-bl-none border-assistant-border"
+																		: "border-assistant-border"
 																} ${
 																	part.text.startsWith("scheduled message")
 																		? "border-accent/50"
@@ -467,6 +490,12 @@ export function ChatMessageList({
 																		collapsedByDefault
 																	/>
 																)}
+															<AssistantMessageFeedback
+																isLastTextPart={isLastTextPart}
+																isUser={isUser}
+																messageId={m.id}
+																onRegenerate={onRegenerate}
+															/>
 															<InterruptedNotice
 																interrupted={isInterrupted}
 																isLastTextPart={isLastTextPart}

--- a/src/components/chat/MessageFeedback.tsx
+++ b/src/components/chat/MessageFeedback.tsx
@@ -1,0 +1,78 @@
+import { ArrowClockwise, ThumbsDown, ThumbsUp } from "@phosphor-icons/react";
+import { useState } from "react";
+
+interface MessageFeedbackProps {
+	messageId: string;
+	onRegenerate?: (messageId?: string) => void | Promise<void>;
+}
+
+type Vote = "up" | "down" | null;
+
+const buttonClass =
+	"p-1.5 rounded-md transition-colors text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-500 focus:ring-offset-2 focus:ring-offset-neutral-100 dark:focus:ring-offset-neutral-900";
+
+/**
+ * Thumbs up/down + regenerate footer shown under each assistant response.
+ *
+ * TODO(telemetry): the vote is currently local UI state only - nothing is
+ * persisted or sent anywhere. Wire `onVote` to a real feedback/telemetry
+ * endpoint once one exists, keyed by messageId.
+ */
+export function MessageFeedback({
+	messageId,
+	onRegenerate,
+}: MessageFeedbackProps) {
+	const [vote, setVote] = useState<Vote>(null);
+
+	const toggleVote = (next: Vote) => {
+		setVote((prev) => (prev === next ? null : next));
+	};
+
+	return (
+		<div className="mt-2 flex items-center gap-1">
+			<button
+				type="button"
+				onClick={() => toggleVote("up")}
+				aria-pressed={vote === "up"}
+				aria-label="Good response"
+				title="Good response"
+				className={vote === "up" ? `${buttonClass} !text-primary` : buttonClass}
+			>
+				<ThumbsUp
+					size={16}
+					weight={vote === "up" ? "fill" : "regular"}
+					aria-hidden
+				/>
+			</button>
+			<button
+				type="button"
+				onClick={() => toggleVote("down")}
+				aria-pressed={vote === "down"}
+				aria-label="Bad response"
+				title="Bad response"
+				className={
+					vote === "down"
+						? `${buttonClass} !text-red-600 dark:!text-red-400`
+						: buttonClass
+				}
+			>
+				<ThumbsDown
+					size={16}
+					weight={vote === "down" ? "fill" : "regular"}
+					aria-hidden
+				/>
+			</button>
+			{onRegenerate && (
+				<button
+					type="button"
+					onClick={() => void onRegenerate(messageId)}
+					aria-label="Regenerate response"
+					title="Regenerate response"
+					className={buttonClass}
+				>
+					<ArrowClockwise size={16} aria-hidden />
+				</button>
+			)}
+		</div>
+	);
+}

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -101,11 +101,7 @@ export function NotificationBell({
 					}
 				>
 					<span className="relative w-8 h-8 flex items-center justify-center shrink-0">
-						<Bell
-							size={20}
-							weight="light"
-							className="text-purple-600 dark:text-purple-400"
-						/>
+						<Bell size={20} weight="light" className="text-primary" />
 						{isCollapsed && notifications.length > 0 && (
 							<span
 								className="absolute top-0 right-0 w-2 h-2 rounded-full bg-red-500"

--- a/src/components/resource-side-panel/ResourceSidePanel.tsx
+++ b/src/components/resource-side-panel/ResourceSidePanel.tsx
@@ -21,7 +21,6 @@ interface ResourceSidePanelProps {
 	/** Used when rendered outside AppShellProvider (e.g. tests) */
 	isAuthenticated?: boolean;
 	campaigns?: Campaign[];
-	selectedCampaignId?: string;
 	onLogout?: () => Promise<void>;
 	showUserMenu?: boolean;
 	setShowUserMenu?: (show: boolean) => void;
@@ -37,7 +36,6 @@ interface ResourceSidePanelProps {
 	addLocalNotification?: (type: string, title: string, message: string) => void;
 	onShowUsageLimits?: () => void;
 	/** Header controls (used when rendered outside AppShellProvider, e.g. tests) */
-	onSessionRecapRequest?: () => void;
 	onAdminDashboardOpen?: () => void;
 }
 
@@ -61,9 +59,7 @@ export function ResourceSidePanel(props: ResourceSidePanelProps) {
 		isAddingToCampaigns,
 		addLocalNotification,
 		onShowUsageLimits,
-		onSessionRecapRequest,
 		onAdminDashboardOpen,
-		selectedCampaignId,
 		billingTier,
 		notifications,
 		dismissNotification,
@@ -173,8 +169,6 @@ export function ResourceSidePanel(props: ResourceSidePanelProps) {
 			className={`tour-sidebar h-full bg-neutral-50/80 dark:bg-neutral-900/80 border-r border-neutral-200 dark:border-neutral-700 flex flex-col backdrop-blur-sm ${isDesktopSidebarCollapsed ? "w-16" : "w-full md:w-72"} ${className}`}
 		>
 			<AppHeader
-				onSessionRecapRequest={onSessionRecapRequest}
-				selectedCampaignId={selectedCampaignId}
 				onToggleSidebarCollapse={onToggleDesktopSidebarCollapse}
 				isCollapsed={isDesktopSidebarCollapsed}
 			/>
@@ -188,6 +182,16 @@ export function ResourceSidePanel(props: ResourceSidePanelProps) {
 							: "flex flex-col gap-2 pt-4 pr-4 pb-4 pl-2"
 					}
 				>
+					{/* Notifications */}
+					<div className="flex-shrink-0 w-full">
+						<TopBarNotifications
+							notifications={notifications}
+							onDismiss={dismissNotification}
+							onDismissAll={clearAllNotifications}
+							isCollapsed={isDesktopSidebarCollapsed}
+						/>
+					</div>
+
 					{/* Campaigns Section */}
 					<div className="flex-shrink-0 w-full">
 						<CampaignsSection
@@ -215,16 +219,6 @@ export function ResourceSidePanel(props: ResourceSidePanelProps) {
 							isAddingToCampaigns={isAddingToCampaigns}
 							addLocalNotification={addLocalNotification}
 							onShowUsageLimits={onShowUsageLimits}
-							isCollapsed={isDesktopSidebarCollapsed}
-						/>
-					</div>
-
-					{/* Notifications */}
-					<div className="flex-shrink-0 w-full">
-						<TopBarNotifications
-							notifications={notifications}
-							onDismiss={dismissNotification}
-							onDismissAll={clearAllNotifications}
 							isCollapsed={isDesktopSidebarCollapsed}
 						/>
 					</div>

--- a/src/components/resource-side-panel/ShardsSection.tsx
+++ b/src/components/resource-side-panel/ShardsSection.tsx
@@ -50,11 +50,7 @@ export function ShardsSection({
 					}
 				>
 					<span className="relative w-8 h-8 flex items-center justify-center shrink-0">
-						<PuzzlePiece
-							size={20}
-							weight="light"
-							className="text-purple-600 dark:text-purple-400"
-						/>
+						<PuzzlePiece size={20} weight="light" className="text-primary" />
 						{isCollapsed && totalShards > 0 && (
 							<span
 								className="absolute top-0 right-0 w-2 h-2 rounded-full bg-red-500"

--- a/src/components/resource-side-panel/TelemetrySection.tsx
+++ b/src/components/resource-side-panel/TelemetrySection.tsx
@@ -24,11 +24,7 @@ export function TelemetrySection({
 				}
 			>
 				<span className="w-8 h-8 flex items-center justify-center shrink-0">
-					<ChartBar
-						size={20}
-						weight="light"
-						className="text-purple-600 dark:text-purple-400"
-					/>
+					<ChartBar size={20} weight="light" className="text-primary" />
 				</span>
 				{!isCollapsed && <span className="font-medium text-sm">Telemetry</span>}
 			</button>

--- a/src/contexts/AppShellContext.tsx
+++ b/src/contexts/AppShellContext.tsx
@@ -111,7 +111,7 @@ export interface AppShellContextValue {
 	invisibleUserContentsVersion: number;
 	handleSessionRecapRequest?: () => void;
 	chatError: Error | undefined;
-	onRegenerate: () => Promise<void>;
+	onRegenerate: (messageId?: string) => Promise<void>;
 
 	// Shard overlay
 	visibleShardGroups: StagedShardGroup[];
@@ -411,7 +411,8 @@ export function AppShellProvider({ children }: AppShellProviderProps) {
 					? handleSessionRecapRequest
 					: undefined,
 			chatError,
-			onRegenerate: () => regenerate(),
+			onRegenerate: (messageId?: string) =>
+				regenerate(messageId ? { messageId } : undefined),
 			visibleShardGroups,
 			shardsLoading,
 			onShardsProcessed: removeProcessedShards,

--- a/src/hooks/useResourceSidePanelState.ts
+++ b/src/hooks/useResourceSidePanelState.ts
@@ -20,8 +20,6 @@ export interface ResourceSidePanelStateProps {
 	isAddingToCampaigns?: boolean;
 	addLocalNotification?: (type: string, title: string, message: string) => void;
 	onShowUsageLimits?: () => void;
-	selectedCampaignId?: string;
-	onSessionRecapRequest?: () => void;
 	onAdminDashboardOpen?: () => void;
 }
 
@@ -57,9 +55,7 @@ function resolveFromContext(ctx: AppShellContextValue) {
 		isAddingToCampaigns: ctx.isAddingToCampaigns,
 		addLocalNotification: ctx.addLocalNotification,
 		onShowUsageLimits: ctx.onShowUsageLimits,
-		onSessionRecapRequest: ctx.handleSessionRecapRequest,
 		onAdminDashboardOpen: ctx.modalState.handleAdminDashboardOpen,
-		selectedCampaignId: ctx.selectedCampaignId ?? null,
 		billingTier: ctx.billingStatus?.tier ?? null,
 		notifications: ctx.allNotifications.map(withFallbackMessage),
 		dismissNotification: ctx.dismissNotification,
@@ -97,9 +93,7 @@ function resolveFromProps(
 		isAddingToCampaigns: props.isAddingToCampaigns ?? false,
 		addLocalNotification: props.addLocalNotification,
 		onShowUsageLimits: props.onShowUsageLimits,
-		onSessionRecapRequest: props.onSessionRecapRequest,
 		onAdminDashboardOpen: props.onAdminDashboardOpen,
-		selectedCampaignId: props.selectedCampaignId ?? null,
 		billingTier: null,
 		notifications,
 		dismissNotification: noop,

--- a/tests/components/AppHeader.test.tsx
+++ b/tests/components/AppHeader.test.tsx
@@ -25,9 +25,7 @@ beforeEach(() => {
 
 describe("AppHeader", () => {
 	const baseProps = {
-		onGuidanceRequest: vi.fn(),
-		onSessionRecapRequest: vi.fn(),
-		selectedCampaignId: null,
+		onToggleSidebarCollapse: vi.fn(),
 	};
 
 	it("renders the LoreSmith logo and title", () => {

--- a/tests/components/MessageFeedback.test.tsx
+++ b/tests/components/MessageFeedback.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MessageFeedback } from "@/components/chat/MessageFeedback";
+
+describe("MessageFeedback", () => {
+	it("toggles the thumbs-up button as pressed, and clears it when clicked again", () => {
+		render(<MessageFeedback messageId="msg-1" />);
+
+		const up = screen.getByRole("button", { name: "Good response" });
+		expect(up.getAttribute("aria-pressed")).toBe("false");
+
+		fireEvent.click(up);
+		expect(up.getAttribute("aria-pressed")).toBe("true");
+
+		fireEvent.click(up);
+		expect(up.getAttribute("aria-pressed")).toBe("false");
+	});
+
+	it("selecting thumbs-down clears a previously selected thumbs-up", () => {
+		render(<MessageFeedback messageId="msg-1" />);
+
+		const up = screen.getByRole("button", { name: "Good response" });
+		const down = screen.getByRole("button", { name: "Bad response" });
+
+		fireEvent.click(up);
+		expect(up.getAttribute("aria-pressed")).toBe("true");
+
+		fireEvent.click(down);
+		expect(down.getAttribute("aria-pressed")).toBe("true");
+		expect(up.getAttribute("aria-pressed")).toBe("false");
+	});
+
+	it("does not render a regenerate button when onRegenerate is not provided", () => {
+		render(<MessageFeedback messageId="msg-1" />);
+
+		expect(
+			screen.queryByRole("button", { name: "Regenerate response" })
+		).not.toBeInTheDocument();
+	});
+
+	it("calls onRegenerate with the message id when the regenerate button is clicked", () => {
+		const onRegenerate = vi.fn();
+		render(<MessageFeedback messageId="msg-1" onRegenerate={onRegenerate} />);
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "Regenerate response" })
+		);
+
+		expect(onRegenerate).toHaveBeenCalledWith("msg-1");
+	});
+});


### PR DESCRIPTION
## Summary
- Add thumbs up/down + regenerate controls under each assistant response (`MessageFeedback`), with a TODO to wire real telemetry later
- Fix the assistant response card's bottom-left corner radius, now more visible with the new feedback row
- Bring back the "next steps" prompt as an icon-only Idea (lightbulb) button next to the campaign selector, in the app's primary lavender
- Move the session recap button out of the sidebar header and into the chat header next to the Idea button, disabled until a campaign is selected and the session has messages
- Match icon colors across the sidebar (Notifications, Shards, Telemetry) to the same primary lavender
- Show a hint under the campaign selector when no campaign is chosen

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx @biomejs/biome check`
- [x] `node scripts/check/check-complexity.mjs`
- [x] `node scripts/check/check-import-paths.mjs`
- [x] `npx vitest run` (2068 tests passing)
- [x] Manually verified against local dev servers (backend :8787, frontend :5173)

🤖 Generated with [Claude Code](https://claude.com/claude-code)