### PR TITLE
feat(ui): make campaign details always-editable, fix disabled-button cursor

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -40,7 +40,7 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 
 const formBaseClass =
 	"inline-flex max-w-full shrink-0 items-center gap-2 rounded-md border-0 bg-transparent px-1.5 py-1 font-semibold text-sm shadow-none transition-colors select-none " +
-	"disabled:cursor-not-allowed disabled:opacity-50 " +
+	"disabled:pointer-events-none disabled:cursor-default disabled:opacity-50 " +
 	"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:ring-offset-2 " +
 	"focus-visible:ring-offset-white dark:focus-visible:ring-neutral-500 dark:focus-visible:ring-offset-neutral-900";
 

--- a/src/components/resource-side-panel/CampaignDetailsModal.tsx
+++ b/src/components/resource-side-panel/CampaignDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { FloppyDisk, PencilSimple, ShareNetwork } from "@phosphor-icons/react";
+import { FloppyDisk, ShareNetwork } from "@phosphor-icons/react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/button/Button";
 import { PendingProposalsSection } from "@/components/campaign/PendingProposalsSection";
@@ -11,7 +11,6 @@ import { Modal } from "@/components/modal/Modal";
 import { RunsheetPanel } from "@/components/session/RunsheetPanel";
 import { SessionDigestBulkImport } from "@/components/session/SessionDigestBulkImport";
 import { SessionDigestModal } from "@/components/session/SessionDigestModal";
-import { Tooltip } from "@/components/tooltip/Tooltip";
 import { CAMPAIGN_ROLES, PLAYER_ROLES } from "@/constants/campaign-roles";
 import { NOTIFICATION_TYPES } from "@/constants/notification-types";
 import { useAuthenticatedRequest } from "@/hooks/useAuthenticatedRequest";
@@ -175,6 +174,75 @@ function AudioTabPanel({
 	);
 }
 
+function campaignFieldsChanged(
+	campaign: Campaign,
+	editedName: string,
+	editedDescription: string
+): boolean {
+	if (editedName !== campaign.name) return true;
+	return editedDescription !== (campaign.description || "");
+}
+
+interface CampaignDetailsActionsProps {
+	canShare: boolean;
+	isOwner: boolean;
+	isUpdating: boolean;
+	canSave: boolean;
+	onShare: () => void;
+	onSave: () => void;
+	onDelete: () => Promise<void>;
+}
+
+/**
+ * Footer actions for the details tab: Share, Save, Delete — always on the
+ * right, in that order. Extracted so the modal's own render body doesn't
+ * absorb these branches (keeps the complexity gate happy on this file).
+ */
+function CampaignDetailsActions({
+	canShare,
+	isOwner,
+	isUpdating,
+	canSave,
+	onShare,
+	onSave,
+	onDelete,
+}: CampaignDetailsActionsProps) {
+	return (
+		<div className="flex items-center justify-end gap-2 mt-4 md:mt-6 pt-4 md:pt-6 border-t border-neutral-200 dark:border-neutral-700">
+			{canShare && (
+				<Button
+					appearance="form"
+					onClick={onShare}
+					icon={<ShareNetwork size={16} />}
+					variant="secondary"
+				>
+					Share
+				</Button>
+			)}
+			{isOwner && (
+				<Button
+					appearance="form"
+					onClick={onSave}
+					disabled={isUpdating || !canSave}
+					loading={isUpdating}
+					icon={<FloppyDisk size={16} />}
+					data-testid="campaign-details-save"
+				>
+					{isUpdating ? "Saving…" : "Save"}
+				</Button>
+			)}
+			{isOwner && (
+				<ConfirmDeleteButton
+					label="Delete campaign"
+					confirmLabel="Confirm delete"
+					onConfirm={onDelete}
+					disabled={isUpdating}
+				/>
+			)}
+		</div>
+	);
+}
+
 export function CampaignDetailsModal({
 	campaign,
 	isOpen,
@@ -189,7 +257,6 @@ export function CampaignDetailsModal({
 }: CampaignDetailsModalProps) {
 	const nameId = useId();
 	const descriptionId = useId();
-	const [isEditing, setIsEditing] = useState(false);
 	const [editedName, setEditedName] = useState(campaign?.name || "");
 	const [editedDescription, setEditedDescription] = useState(
 		campaign?.description || ""
@@ -625,7 +692,6 @@ export function CampaignDetailsModal({
 				name: editedName,
 				description: editedDescription,
 			});
-			setIsEditing(false);
 		} catch (_error) {
 		} finally {
 			setIsUpdating(false);
@@ -636,12 +702,6 @@ export function CampaignDetailsModal({
 		if (!campaign) return;
 		await onDelete(campaign.campaignId);
 		onClose();
-	};
-
-	const handleCancel = () => {
-		setEditedName(campaign?.name || "");
-		setEditedDescription(campaign?.description || "");
-		setIsEditing(false);
 	};
 
 	const handleCreateDigest = () => {
@@ -689,6 +749,11 @@ export function CampaignDetailsModal({
 	const role = campaign.role ?? null;
 	const isPlayerRole = role !== null && PLAYER_ROLES.has(role);
 	const isOwner = role === CAMPAIGN_ROLES.OWNER;
+	const hasChanges = campaignFieldsChanged(
+		campaign,
+		editedName,
+		editedDescription
+	);
 
 	return (
 		<>
@@ -830,7 +895,7 @@ export function CampaignDetailsModal({
 							>
 								<CampaignDetailsTab
 									campaign={campaign}
-									isEditing={isEditing}
+									canEdit={isOwner}
 									editedName={editedName}
 									editedDescription={editedDescription}
 									nameId={nameId}
@@ -941,80 +1006,15 @@ export function CampaignDetailsModal({
 
 					{/* Actions */}
 					{activeTab === "details" && (
-						<div className="flex items-center justify-between gap-2 mt-4 md:mt-6 pt-4 md:pt-6 border-t border-neutral-200 dark:border-neutral-700">
-							<div className="flex items-center gap-2">
-								{isEditing ? (
-									<>
-										<Button
-											appearance="form"
-											onClick={handleSave}
-											disabled={isUpdating || !editedName.trim()}
-											loading={isUpdating}
-											icon={<FloppyDisk size={16} />}
-											data-testid="campaign-details-save"
-										>
-											{isUpdating ? "Saving…" : "Save changes"}
-										</Button>
-										<Button
-											appearance="form"
-											onClick={handleCancel}
-											disabled={isUpdating}
-											variant="secondary"
-										>
-											Cancel
-										</Button>
-									</>
-								) : (
-									<>
-										{isOwner ? (
-											<Button
-												appearance="form"
-												onClick={() => setIsEditing(true)}
-												icon={<PencilSimple size={16} />}
-												data-testid="campaign-details-edit"
-											>
-												Edit
-											</Button>
-										) : (
-											<Tooltip
-												content="Only the campaign owner can edit campaign details"
-												contentClassName="left-4"
-											>
-												<span className="inline-flex">
-													<Button
-														appearance="form"
-														disabled
-														icon={<PencilSimple size={16} />}
-														className="opacity-50 cursor-not-allowed"
-													>
-														Edit
-													</Button>
-												</span>
-											</Tooltip>
-										)}
-										{canShare && (
-											<Button
-												appearance="form"
-												onClick={() => setIsShareModalOpen(true)}
-												icon={<ShareNetwork size={16} />}
-												variant="secondary"
-											>
-												Share
-											</Button>
-										)}
-									</>
-								)}
-							</div>
-
-							{!isEditing && isOwner && (
-								<ConfirmDeleteButton
-									label="Delete campaign"
-									confirmLabel="Confirm delete"
-									onConfirm={handleDeleteCampaign}
-									disabled={isUpdating}
-								/>
-							)}
-						</div>
+						<CampaignDetailsActions
+							canShare={canShare}
+							isOwner={isOwner}
+							isUpdating={isUpdating}
+							canSave={hasChanges && editedName.trim().length > 0}
+							onShare={() => setIsShareModalOpen(true)}
+							onSave={handleSave}
+							onDelete={handleDeleteCampaign}
+						/>
 					)}
 				</div>
 			</Modal>

--- a/src/components/resource-side-panel/CampaignDetailsTab.tsx
+++ b/src/components/resource-side-panel/CampaignDetailsTab.tsx
@@ -3,7 +3,8 @@ import type { Campaign } from "@/types/campaign";
 
 interface CampaignDetailsTabProps {
 	campaign: Campaign;
-	isEditing: boolean;
+	/** Whether the current user (campaign owner) can edit these fields. */
+	canEdit: boolean;
 	editedName: string;
 	editedDescription: string;
 	nameId: string;
@@ -14,11 +15,12 @@ interface CampaignDetailsTabProps {
 
 /**
  * Details tab content: campaign name, description, and metadata.
- * Edit/save/cancel and view graph actions stay in the modal footer.
+ * Fields are always editable for the owner (save/delete/share actions stay
+ * in the modal footer); other roles see a read-only view.
  */
 export function CampaignDetailsTab({
 	campaign,
-	isEditing,
+	canEdit,
 	editedName,
 	editedDescription,
 	nameId,
@@ -28,7 +30,7 @@ export function CampaignDetailsTab({
 }: CampaignDetailsTabProps) {
 	return (
 		<div className="space-y-4">
-			{isEditing ? (
+			{canEdit ? (
 				<FormField
 					id={nameId}
 					label="Campaign name"
@@ -49,7 +51,7 @@ export function CampaignDetailsTab({
 				</div>
 			)}
 
-			{isEditing ? (
+			{canEdit ? (
 				<FormField
 					id={descriptionId}
 					label="Description"

--- a/src/styles.css
+++ b/src/styles.css
@@ -774,7 +774,8 @@ html {
 
 .add-disable:disabled {
 	color: var(--text-color-ob-base-100);
-	cursor: not-allowed;
+	cursor: default;
+	pointer-events: none;
 }
 
 .add-size-sm {

--- a/tests/e2e/campaign.spec.ts
+++ b/tests/e2e/campaign.spec.ts
@@ -46,7 +46,6 @@ test.describe("campaign management", () => {
 		// Opening a campaign closes the campaigns dialog and opens its details.
 		await appShell.getCampaignButton(originalName).click();
 
-		await campaignDetails.editButton.click();
 		await createModal.fillName(editedName);
 		await campaignDetails.saveButton.click();
 

--- a/tests/e2e/pages/campaign-details.page.ts
+++ b/tests/e2e/pages/campaign-details.page.ts
@@ -4,10 +4,6 @@ import type { Page } from "@playwright/test";
 export class CampaignDetailsPage {
 	constructor(readonly page: Page) {}
 
-	get editButton() {
-		return this.page.getByTestId("campaign-details-edit");
-	}
-
 	get saveButton() {
 		return this.page.getByTestId("campaign-details-save");
 	}


### PR DESCRIPTION
## Summary
- Campaign details fields (name, description) are now always editable for the owner instead of behind an Edit/Cancel toggle; a Save button replaces Edit, enabled only when there are unsaved changes.
- Footer actions consolidated to three buttons, right-aligned, fixed order: Share, Save, Delete.
- Extracted `CampaignDetailsActions` and a standalone `campaignFieldsChanged()` helper to keep the modal's complexity within the repo's CCN gate.
- Fixed disabled buttons app-wide showing an oversized OS "blocked" cursor and still visually reacting to hover: disabled buttons now use `pointer-events-none` + `cursor-default` instead of `cursor-not-allowed`, in both `Button.tsx`'s form-appearance path and the shared `.add-disable` CSS class.
- Updated the campaign e2e test/page-object for the removed Edit button.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run check` (biome + import-paths + tsc)
- [x] `node scripts/check/check-complexity.mjs`
- [x] `npx vitest run` (2359 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)