### PR TITLE
feat(llm-cost): finish finding 10 — triage, retry counts, per-tier effort (#761)

### DIFF
--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -30,7 +30,7 @@ import { normalizeMessageHistoryScope } from "@/lib/get-message-history-query";
 import {
 	addTokenBreakdowns,
 	type LlmTokenBreakdown,
-	pickTokenBreakdown,
+	pickSpendMeta,
 	toTokenBreakdown,
 	totalUsageTokens,
 } from "@/lib/llm-usage-breakdown";
@@ -1180,7 +1180,7 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 						source,
 						agent: this.constructor.name,
 						modelRole: "INTERACTIVE",
-						...pickTokenBreakdown(usage),
+						...pickSpendMeta(usage),
 						totalTokens: tokens,
 					});
 					return;

--- a/src/lib/anthropic-attempt-counter.ts
+++ b/src/lib/anthropic-attempt-counter.ts
@@ -1,0 +1,80 @@
+/**
+ * Counts the HTTP attempts the AI SDK makes for one provider call.
+ *
+ * The AI SDK retries transient failures internally — the default is 2 retries,
+ * so 3 total attempts (`LLMOptions.maxRetries`). Every attempt is a billed
+ * request: a prompt that reliably 500s or 429s costs its full input price three
+ * times and returns nothing. That spend is invisible in token totals, because
+ * only the attempt that *succeeded* reports usage.
+ *
+ * `generateText` does not expose an attempt count on its result, so this counts
+ * one layer down, at the transport `createAnthropic` accepts. Anything that
+ * reaches the Messages endpoint increments the counter, whatever the reason the
+ * SDK re-issued it.
+ *
+ * Read `attempts` only after the call settles. A counter is scoped to a single
+ * provider-method invocation, which includes any JSON-repair call made on the
+ * same model handle — the same grouping `queryCount` and the token totals
+ * already use there.
+ */
+
+/**
+ * Matches the Anthropic Messages endpoint exactly, ignoring host and query.
+ *
+ * Deliberately not `/v1/messages(/|$)` — that also matches `/v1/messages/batches`,
+ * which is the Batches API, a different call with its own accounting. Counting
+ * it here would inflate the retry signal on the one path this is meant to keep
+ * honest.
+ */
+const MESSAGES_PATH = /\/v1\/messages\/?(\?|#|$)/;
+
+export interface AttemptCounter {
+	/** Drop-in replacement for `fetch`, passed to `createAnthropic`. */
+	fetch: typeof globalThis.fetch;
+	/** Requests issued so far. `1` means no retry; `0` means the call never left. */
+	attempts(): number;
+}
+
+function urlOf(input: RequestInfo | URL): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+	return input.url;
+}
+
+/**
+ * Build a counting `fetch` wrapper.
+ *
+ * Falls back to the global `fetch` when no base is supplied. Counting happens
+ * before the request is awaited, so an attempt that throws still counts — that
+ * is the case worth seeing.
+ */
+export function createAttemptCounter(
+	baseFetch: typeof globalThis.fetch = globalThis.fetch
+): AttemptCounter {
+	let count = 0;
+	return {
+		fetch: (input, init) => {
+			try {
+				if (MESSAGES_PATH.test(urlOf(input))) {
+					count += 1;
+				}
+			} catch {
+				// A URL we cannot read is not worth failing a generation over.
+			}
+			return baseFetch(input, init);
+		},
+		attempts: () => count,
+	};
+}
+
+/**
+ * Attempt count worth reporting, or `undefined` when there is nothing to say.
+ *
+ * A single attempt is the expected case and would be noise on every log line;
+ * `0` means the counter never saw the endpoint (a mocked provider, or a call
+ * that failed before dispatch) and reporting it would look like a real
+ * measurement of zero.
+ */
+export function reportableAttempts(count: number): number | undefined {
+	return count > 1 ? count : undefined;
+}

--- a/src/lib/anthropic-model-options.ts
+++ b/src/lib/anthropic-model-options.ts
@@ -5,10 +5,52 @@
  * temperature / top_p / top_k return 400. We default effort to "medium" for cost.
  */
 
+import type { TextGenerationTier } from "@/app-constants";
+
 export type AnthropicEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
 /** Default effort for Sonnet 5+ generation (cost step-down from API default "high"). */
 export const DEFAULT_SONNET5_EFFORT: AnthropicEffort = "medium";
+
+/**
+ * Effort per generation tier.
+ *
+ * Effort trades output tokens — and therefore latency and money — for reasoning
+ * depth, and the right setting is not uniform: a tier whose output shape is
+ * pinned by a JSON schema has less to gain from thinking longer than one writing
+ * free prose. `PIPELINE_STRUCTURED` (entity extraction) is the obvious sweep
+ * candidate for that reason.
+ *
+ * **Every tier is deliberately at the previous global default.** This table is
+ * the knob, not the sweep. Before lowering a row, run the tier at both settings
+ * with `LORESMITH_VERBOSE_LLM_USAGE=true` and compare output quality against the
+ * `effort` and `modelRole` fields now carried on `llm_token_spend` — the issue's
+ * standing rule is measure before committing, and effort is exactly the kind of
+ * change that looks free until quality moves.
+ *
+ * Only consulted on models that take an effort parameter (Sonnet 5+); Haiku
+ * tiers are listed for completeness and are inert today.
+ */
+const TIER_EFFORT: Readonly<Record<TextGenerationTier, AnthropicEffort>> = {
+	PRIMARY: DEFAULT_SONNET5_EFFORT,
+	INTERACTIVE: DEFAULT_SONNET5_EFFORT,
+	ANALYSIS: DEFAULT_SONNET5_EFFORT,
+	PIPELINE_STRUCTURED: DEFAULT_SONNET5_EFFORT,
+	PIPELINE_LIGHT: DEFAULT_SONNET5_EFFORT,
+	PIPELINE_ANALYSIS: DEFAULT_SONNET5_EFFORT,
+	METADATA_ANALYSIS: DEFAULT_SONNET5_EFFORT,
+	SESSION_PLANNING: DEFAULT_SONNET5_EFFORT,
+};
+
+/**
+ * Effort for a tier, or {@link DEFAULT_SONNET5_EFFORT} when the caller did not
+ * declare one. An unknown tier falls back rather than throwing: a mistyped tier
+ * should cost the default, not a generation.
+ */
+export function effortForTier(tier?: TextGenerationTier): AnthropicEffort {
+	if (!tier) return DEFAULT_SONNET5_EFFORT;
+	return TIER_EFFORT[tier] ?? DEFAULT_SONNET5_EFFORT;
+}
 
 /**
  * True for Claude Sonnet 5 and newer Sonnet IDs that reject non-default sampling
@@ -90,13 +132,14 @@ export function getAnthropicSonnet5ProviderOptions(
  */
 export function anthropicBatchModelParams(
 	modelId: string,
-	temperature?: number
+	temperature?: number,
+	tier?: TextGenerationTier
 ): {
 	temperature?: number;
 	output_config?: { effort: AnthropicEffort };
 } {
 	if (isSonnet5OrNewer(modelId)) {
-		return { output_config: { effort: DEFAULT_SONNET5_EFFORT } };
+		return { output_config: { effort: effortForTier(tier) } };
 	}
 	if (temperature === undefined) {
 		return {};
@@ -110,14 +153,15 @@ export function anthropicBatchModelParams(
  */
 export function anthropicSamplingParams(
 	modelId: string,
-	temperature: number | undefined
+	temperature: number | undefined,
+	tier?: TextGenerationTier
 ): {
 	temperature?: number;
 	providerOptions?: ReturnType<typeof getAnthropicSonnet5ProviderOptions>;
 } {
 	if (isSonnet5OrNewer(modelId)) {
 		return {
-			providerOptions: getAnthropicSonnet5ProviderOptions(),
+			providerOptions: getAnthropicSonnet5ProviderOptions(effortForTier(tier)),
 		};
 	}
 	if (temperature === undefined) {

--- a/src/lib/llm-usage-breakdown.ts
+++ b/src/lib/llm-usage-breakdown.ts
@@ -23,6 +23,14 @@ export interface LlmTokenBreakdown {
 export interface LlmUsageReport extends LlmTokenBreakdown {
 	tokens: number;
 	queryCount: number;
+	/**
+	 * HTTP attempts the provider made, when it counted them. Only present when
+	 * greater than 1 — i.e. when the AI SDK retried. Retried attempts are billed
+	 * but report no usage, so this is spend the token fields cannot show.
+	 */
+	attempts?: number;
+	/** Anthropic effort level used, when the model takes one. */
+	effort?: string;
 }
 
 /**
@@ -137,17 +145,25 @@ export function addTokenBreakdowns(
 }
 
 /**
- * Narrow a provider's usage report to just the priced fields, for spreading into
- * `recordUsage` metadata without dragging `tokens`/`queryCount` along.
+ * Narrow a provider's usage report to the fields `recordUsage` metadata wants,
+ * for spreading into it without dragging `tokens`/`queryCount` along.
+ *
+ * Carries the priced token split plus the two diagnostics that explain spend the
+ * split alone cannot — retry attempts and effort level. Every call site already
+ * spreads this into its meta object, so widening it here is what puts those on
+ * `llm_token_spend` everywhere rather than at one hand-wired call site.
  */
-export function pickTokenBreakdown(
-	usage: LlmTokenBreakdown | undefined
-): LlmTokenBreakdown {
+export function pickSpendMeta(
+	usage: LlmUsageReport | LlmTokenBreakdown | undefined
+): LlmTokenBreakdown & { attempts?: number; effort?: string } {
+	const report = usage as LlmUsageReport | undefined;
 	return {
 		promptTokens: usage?.promptTokens,
 		completionTokens: usage?.completionTokens,
 		cachedInputTokens: usage?.cachedInputTokens,
 		cacheWriteTokens: usage?.cacheWriteTokens,
+		attempts: report?.attempts,
+		effort: report?.effort,
 	};
 }
 

--- a/src/lib/llm-usage-verbose-log.ts
+++ b/src/lib/llm-usage-verbose-log.ts
@@ -36,6 +36,29 @@ export type VerboseLlmSpendPayload = {
 	promptTokens?: number;
 	completionTokens?: number;
 	totalTokens?: number;
+	/**
+	 * Cache-read tokens. The only proof a `cache_control` breakpoint is being
+	 * honoured: a breakpoint that never hits and one that always hits produce
+	 * identical `tokens` totals, so without this field the two are
+	 * indistinguishable from the drain.
+	 */
+	cachedInputTokens?: number;
+	/** Cache-write tokens — non-zero on the call that populates the prefix. */
+	cacheWriteTokens?: number;
+	/**
+	 * HTTP attempts the provider made for this call, when the provider counts
+	 * them. `> 1` means the AI SDK retried; a prompt that reliably fails costs
+	 * its full price on every attempt, so a persistently high value is spend
+	 * that no token total explains.
+	 */
+	attempts?: number;
+	/** Anthropic effort level used, when the model takes one (Sonnet 5+). */
+	effort?: string;
+	/** Tier the model was selected from — the grouping key for a per-tier sweep. */
+	modelRole?: string;
+	/** Agent class name, when the spend happened inside an agent. */
+	agent?: string;
+	provider?: string;
 	/** Small, bounded context — never full prompts */
 	extras?: Record<string, unknown>;
 };

--- a/src/routes/campaign-graphrag.ts
+++ b/src/routes/campaign-graphrag.ts
@@ -7,7 +7,7 @@ import {
 	isStubContentSufficient,
 } from "@/lib/entity/entity-required-fields";
 import { getEnvVar } from "@/lib/env-utils";
-import { pickTokenBreakdown } from "@/lib/llm-usage-breakdown";
+import { pickSpendMeta } from "@/lib/llm-usage-breakdown";
 import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
 import { createLogger, getRequestLogger } from "@/lib/logger";
 import { notifyCampaignMembers } from "@/lib/notifications";
@@ -791,7 +791,7 @@ Rules:
 					{
 						intent: LLM_SPEND_INTENT.graph_rebuild,
 						source: "campaign_graphrag:generate_shard_field",
-						...pickTokenBreakdown(usage),
+						...pickSpendMeta(usage),
 						campaignId,
 						shardId,
 						field,

--- a/src/routes/graph-visualization.ts
+++ b/src/routes/graph-visualization.ts
@@ -19,7 +19,7 @@ import {
 	computeOrphanNodes,
 	type GraphFilters,
 } from "@/lib/graph/graph-visualization-helpers";
-import { pickTokenBreakdown } from "@/lib/llm-usage-breakdown";
+import { pickSpendMeta } from "@/lib/llm-usage-breakdown";
 import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
 import type { Env } from "@/middleware/auth";
 import type { AuthPayload } from "@/services/core/auth-service";
@@ -466,7 +466,7 @@ export async function handleSearchEntityInGraph(c: ContextWithAuth) {
 								{
 									intent: LLM_SPEND_INTENT.graph_visualization,
 									source: "graph_visualization:search_entity_embedding",
-									...pickTokenBreakdown(usage),
+									...pickSpendMeta(usage),
 									campaignId,
 									entityName,
 								}

--- a/src/services/campaign/entity-staging-service.ts
+++ b/src/services/campaign/entity-staging-service.ts
@@ -16,10 +16,7 @@ import {
 	truncateContentAtSentenceBoundary,
 } from "@/lib/file/text-chunking-utils";
 import { getLibrarySyntheticCampaignId } from "@/lib/library-entity-id";
-import {
-	type LlmUsageReport,
-	pickTokenBreakdown,
-} from "@/lib/llm-usage-breakdown";
+import { type LlmUsageReport, pickSpendMeta } from "@/lib/llm-usage-breakdown";
 import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
 import { notifyCampaignMembers } from "@/lib/notifications";
 import { R2Helper } from "@/lib/r2";
@@ -248,7 +245,7 @@ async function resolveVisualInspirationTitle(params: {
 					{
 						intent: LLM_SPEND_INTENT.visual_inspiration_title,
 						source: "entity_staging:visual_inspiration_title",
-						...pickTokenBreakdown(usage),
+						...pickSpendMeta(usage),
 						campaignId: params.campaignId,
 						fileKey: params.fileKey,
 						libraryMode: params.libraryMode,
@@ -337,7 +334,7 @@ async function resolveChunkGate(params: {
 				{
 					intent: LLM_SPEND_INTENT.entity_extraction,
 					source: "entity_staging:extraction_chunk_gate",
-					...pickTokenBreakdown(usage),
+					...pickSpendMeta(usage),
 					phase: "chunk_gate",
 					campaignId,
 					fileKey,
@@ -677,7 +674,7 @@ async function stageEntitiesFromResourceImpl(
 							{
 								intent: LLM_SPEND_INTENT.character_sheet_detection,
 								source: "entity_staging:character_sheet_detection",
-								...pickTokenBreakdown(usage),
+								...pickSpendMeta(usage),
 								campaignId,
 								fileKey: normalizedResource.file_key || undefined,
 								libraryMode,
@@ -1002,7 +999,7 @@ async function stageEntitiesFromResourceImpl(
 							{
 								intent: LLM_SPEND_INTENT.entity_extraction,
 								source: "entity_staging:extract_entities",
-								...pickTokenBreakdown(usage),
+								...pickSpendMeta(usage),
 								phase: "extract_entities",
 								campaignId,
 								fileKey: normalizedResource.file_key || undefined,

--- a/src/services/graph/shard-embedding-queue-processor.ts
+++ b/src/services/graph/shard-embedding-queue-processor.ts
@@ -1,6 +1,6 @@
 import { getDAOFactory } from "@/dao/dao-factory";
 import { getEnvVar } from "@/lib/env-utils";
-import { pickTokenBreakdown } from "@/lib/llm-usage-breakdown";
+import { pickSpendMeta } from "@/lib/llm-usage-breakdown";
 import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
 import type { Env } from "@/middleware/auth";
 import { OpenAIEmbeddingService } from "@/services/embedding/openai-embedding-service";
@@ -81,7 +81,7 @@ export class ShardEmbeddingQueueProcessor {
 								{
 									intent: LLM_SPEND_INTENT.shard_embedding,
 									source: "shard_embedding_queue_processor:batch",
-									...pickTokenBreakdown(usage),
+									...pickSpendMeta(usage),
 									campaignId,
 									entityCount: chunk.length,
 								}

--- a/src/services/llm/anthropic-provider.ts
+++ b/src/services/llm/anthropic-provider.ts
@@ -1,7 +1,16 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { generateText, type ModelMessage } from "ai";
-import { MODEL_CONFIG } from "@/app-constants";
-import { anthropicSamplingParams } from "@/lib/anthropic-model-options";
+import { MODEL_CONFIG, type TextGenerationTier } from "@/app-constants";
+import {
+	type AttemptCounter,
+	createAttemptCounter,
+	reportableAttempts,
+} from "@/lib/anthropic-attempt-counter";
+import {
+	anthropicSamplingParams,
+	effortForTier,
+	isSonnet5OrNewer,
+} from "@/lib/anthropic-model-options";
 import { LLMProviderAPIKeyError } from "@/lib/errors";
 import { repairJsonDeterministically } from "@/lib/json-repair";
 import { describeLlmFailure, wrapLlmError } from "@/lib/llm-error-utils";
@@ -14,6 +23,7 @@ import {
 } from "@/lib/llm-structured-output";
 import {
 	addTokenBreakdowns,
+	type LlmTokenBreakdown,
 	toTokenBreakdown,
 	totalUsageTokens,
 } from "@/lib/llm-usage-breakdown";
@@ -129,6 +139,40 @@ function buildJsonRepairPrompt(
 		.join("\n\n");
 }
 
+/**
+ * Narrow a model response to the JSON object inside it, or throw.
+ *
+ * Both failure modes are "the model produced nothing usable", and neither is
+ * recoverable here — the caller's catch turns them into the same
+ * no-object-generated signal.
+ */
+function requireJsonText(rawText: string | undefined): string {
+	if (!rawText || rawText.trim().length === 0) {
+		throw new Error("Anthropic API returned empty structured output");
+	}
+	const jsonText = extractJsonObjectText(rawText);
+	if (!jsonText) {
+		throw new Error("Anthropic API returned non-JSON structured output");
+	}
+	return jsonText;
+}
+
+/**
+ * Map a structured-output failure onto the error the callers expect.
+ *
+ * Malformed JSON surfaces as "no object generated" so extraction can treat the
+ * chunk as empty rather than triggering expensive retries.
+ */
+function asStructuredOutputError(error: unknown): Error {
+	const errorMessage = error instanceof Error ? error.message : String(error);
+	if (isJsonParseFailure(error, errorMessage)) {
+		return new Error(
+			"AI_NoObjectGeneratedError: could not parse the response as JSON"
+		);
+	}
+	return new Error(`Failed to generate structured output: ${errorMessage}`);
+}
+
 function truncateForPrompt(text: string, maxChars: number): string {
 	if (text.length <= maxChars) {
 		return text;
@@ -144,6 +188,7 @@ export class AnthropicProvider implements LLMProvider {
 	private readonly defaultModel: string;
 	private readonly defaultTemperature: number;
 	private readonly defaultMaxTokens: number;
+	private readonly defaultTier?: TextGenerationTier;
 
 	constructor(
 		apiKey: string,
@@ -151,6 +196,7 @@ export class AnthropicProvider implements LLMProvider {
 			defaultModel?: string;
 			defaultTemperature?: number;
 			defaultMaxTokens?: number;
+			defaultTier?: TextGenerationTier;
 		} = {}
 	) {
 		if (!apiKey) {
@@ -164,6 +210,55 @@ export class AnthropicProvider implements LLMProvider {
 			options.defaultModel || MODEL_CONFIG.ANTHROPIC.INTERACTIVE;
 		this.defaultTemperature = options.defaultTemperature ?? 0.3;
 		this.defaultMaxTokens = options.defaultMaxTokens ?? 2000;
+		this.defaultTier = options.defaultTier;
+	}
+
+	/**
+	 * Effort actually sent for this call, or `undefined` on models that take no
+	 * effort parameter. Reported alongside spend so a per-tier sweep can group by
+	 * it instead of inferring it from the tier table at read time.
+	 */
+	private reportedEffort(
+		modelId: string,
+		tier: TextGenerationTier | undefined
+	): string | undefined {
+		return isSonnet5OrNewer(modelId) ? effortForTier(tier) : undefined;
+	}
+
+	/**
+	 * Hand one call's spend to `onUsage`, with the diagnostics that explain spend
+	 * the token split cannot: retried attempts (billed, but reporting no usage)
+	 * and the effort level a per-tier sweep groups by.
+	 *
+	 * Shared by both generation methods so the two cannot drift in what they
+	 * report. Zero-token results are dropped — they are failures, not spend.
+	 */
+	private async reportUsage(
+		options: LLMOptions,
+		call: {
+			modelId: string;
+			tier: TextGenerationTier | undefined;
+			counter: AttemptCounter;
+			tokens: number;
+			queryCount: number;
+			breakdown: LlmTokenBreakdown;
+		}
+	): Promise<void> {
+		if (call.tokens <= 0 || !options.onUsage) {
+			return;
+		}
+		await options.onUsage(
+			{
+				tokens: call.tokens,
+				queryCount: call.queryCount,
+				...call.breakdown,
+				// Counts any JSON-repair call's attempts too: it shares the model
+				// handle, and its spend is already folded into `tokens`.
+				attempts: reportableAttempts(call.counter.attempts()),
+				effort: this.reportedEffort(call.modelId, call.tier),
+			},
+			{ username: options.username, model: call.modelId }
+		);
 	}
 
 	async generateSummary(
@@ -173,11 +268,16 @@ export class AnthropicProvider implements LLMProvider {
 		const modelId = options.model || this.defaultModel;
 		const temperature = options.temperature ?? this.defaultTemperature;
 		const maxTokens = options.maxTokens ?? this.defaultMaxTokens;
+		const tier = options.tier ?? this.defaultTier;
+		const counter = createAttemptCounter();
 
 		try {
-			const anthropic = createAnthropic({ apiKey: this.apiKey });
+			const anthropic = createAnthropic({
+				apiKey: this.apiKey,
+				fetch: counter.fetch,
+			});
 			const model = anthropic(modelId as any);
-			const sampling = anthropicSamplingParams(modelId, temperature);
+			const sampling = anthropicSamplingParams(modelId, temperature, tier);
 
 			const parts = options.structuredPromptParts;
 			if (parts) {
@@ -209,17 +309,14 @@ export class AnthropicProvider implements LLMProvider {
 				);
 			}
 
-			const tokens = getUsageTokens(result.usage);
-			if (tokens > 0 && options.onUsage) {
-				await options.onUsage(
-					{
-						tokens,
-						queryCount: 1,
-						...toTokenBreakdown(result.usage, result.providerMetadata),
-					},
-					{ username: options.username, model: modelId }
-				);
-			}
+			await this.reportUsage(options, {
+				modelId,
+				tier,
+				counter,
+				tokens: getUsageTokens(result.usage),
+				queryCount: 1,
+				breakdown: toTokenBreakdown(result.usage, result.providerMetadata),
+			});
 			return text;
 		} catch (error) {
 			if (error instanceof LLMProviderAPIKeyError) {
@@ -247,6 +344,7 @@ export class AnthropicProvider implements LLMProvider {
 			modelId: string;
 			maxTokens: number;
 			parsedSchema: Record<string, unknown> | null;
+			tier?: TextGenerationTier;
 			onJsonRepair?: () => void | Promise<void>;
 		}
 	): Promise<{
@@ -270,7 +368,7 @@ export class AnthropicProvider implements LLMProvider {
 			const repairResult = await generateText({
 				model: ctx.model,
 				prompt: buildJsonRepairPrompt(jsonText, ctx.parsedSchema, parseError),
-				...anthropicSamplingParams(ctx.modelId, 0),
+				...anthropicSamplingParams(ctx.modelId, 0, ctx.tier),
 				maxOutputTokens: Math.max(ctx.maxTokens, 3000),
 			});
 
@@ -297,13 +395,18 @@ export class AnthropicProvider implements LLMProvider {
 		const temperature = options.temperature ?? this.defaultTemperature;
 		const maxTokens = options.maxTokens ?? this.defaultMaxTokens;
 		const parsedSchema = parseStructuredSchema(options.schema);
+		const tier = options.tier ?? this.defaultTier;
+		const counter = createAttemptCounter();
 
-		const anthropic = createAnthropic({ apiKey: this.apiKey });
+		const anthropic = createAnthropic({
+			apiKey: this.apiKey,
+			fetch: counter.fetch,
+		});
 		const model = anthropic(modelId as any);
 		const input = buildStructuredInput(prompt, parsedSchema, modelId, options);
 
 		try {
-			const sampling = anthropicSamplingParams(modelId, temperature);
+			const sampling = anthropicSamplingParams(modelId, temperature, tier);
 			const result = await generateText({
 				model,
 				...input,
@@ -311,54 +414,36 @@ export class AnthropicProvider implements LLMProvider {
 				maxOutputTokens: maxTokens,
 			});
 
-			const rawText = result.text;
-			if (!rawText || rawText.trim().length === 0) {
-				throw new Error("Anthropic API returned empty structured output");
-			}
-			const jsonText = extractJsonObjectText(rawText);
-			if (!jsonText) {
-				throw new Error("Anthropic API returned non-JSON structured output");
-			}
-			const parsed = await this.parseOrRepairJson<T>(jsonText, {
-				model,
-				modelId,
-				maxTokens,
-				parsedSchema,
-				onJsonRepair: options.onJsonRepair,
-			});
+			const parsed = await this.parseOrRepairJson<T>(
+				requireJsonText(result.text),
+				{
+					model,
+					modelId,
+					maxTokens,
+					parsedSchema,
+					tier,
+					onJsonRepair: options.onJsonRepair,
+				}
+			);
 			const output = parsed.output;
 			const repairBreakdown = parsed.repairBreakdown;
 
-			const tokens = getUsageTokens(result.usage) + (parsed.repairTokens ?? 0);
-			const queryCount = parsed.repairTokens === undefined ? 1 : 2;
-			if (tokens > 0 && options.onUsage) {
-				await options.onUsage(
-					{
-						tokens,
-						queryCount,
-						// A JSON-repair retry is real spend on the same intent — fold it
-						// into the same event rather than losing it.
-						...addTokenBreakdowns(
-							toTokenBreakdown(result.usage, result.providerMetadata),
-							repairBreakdown
-						),
-					},
-					{ username: options.username, model: modelId }
-				);
-			}
+			await this.reportUsage(options, {
+				modelId,
+				tier,
+				counter,
+				tokens: getUsageTokens(result.usage) + (parsed.repairTokens ?? 0),
+				queryCount: parsed.repairTokens === undefined ? 1 : 2,
+				// A JSON-repair retry is real spend on the same intent — fold it into
+				// the same event rather than losing it.
+				breakdown: addTokenBreakdowns(
+					toTokenBreakdown(result.usage, result.providerMetadata),
+					repairBreakdown
+				),
+			});
 			return output as T;
 		} catch (error) {
-			const errorMessage =
-				error instanceof Error ? error.message : String(error);
-
-			// Surface malformed JSON as "no object generated" so extraction can
-			// treat this chunk as empty instead of triggering expensive retries.
-			if (isJsonParseFailure(error, errorMessage)) {
-				throw new Error(
-					"AI_NoObjectGeneratedError: could not parse the response as JSON"
-				);
-			}
-			throw new Error(`Failed to generate structured output: ${errorMessage}`);
+			throw asStructuredOutputError(error);
 		}
 	}
 }

--- a/src/services/llm/llm-provider-factory.ts
+++ b/src/services/llm/llm-provider-factory.ts
@@ -1,3 +1,4 @@
+import type { TextGenerationTier } from "@/app-constants";
 import { AnthropicProvider } from "./anthropic-provider";
 import type { LLMProvider } from "./llm-provider";
 
@@ -9,6 +10,15 @@ export interface LLMProviderFactoryOptions {
 	defaultModel?: string;
 	defaultTemperature?: number;
 	defaultMaxTokens?: number;
+	/**
+	 * Tier every call from this provider belongs to, when the caller builds one
+	 * provider per tier — which is the common shape here, since `defaultModel` is
+	 * almost always `getGenerationModelForProvider(tier)`.
+	 *
+	 * Sets the Anthropic effort level (`effortForTier`) and tags spend with
+	 * `modelRole`. Omitting it preserves today's behaviour exactly.
+	 */
+	defaultTier?: TextGenerationTier;
 }
 
 /**
@@ -21,5 +31,6 @@ export function createLLMProvider(
 		defaultModel: options.defaultModel,
 		defaultTemperature: options.defaultTemperature,
 		defaultMaxTokens: options.defaultMaxTokens,
+		defaultTier: options.defaultTier,
 	});
 }

--- a/src/services/llm/llm-provider-utils.ts
+++ b/src/services/llm/llm-provider-utils.ts
@@ -25,10 +25,14 @@ export function createProviderForTier(params: {
 	maxTokens: number;
 }) {
 	const { apiKey, tier, temperature, maxTokens } = params;
+	// The tier is forwarded, not just consumed to pick a model: it selects the
+	// Anthropic effort level and tags spend with `modelRole`, which is what makes
+	// a per-tier effort comparison groupable in the drain.
 	return createLLMProvider({
 		apiKey,
 		defaultModel: getGenerationModelForProvider(tier),
 		defaultTemperature: temperature,
 		defaultMaxTokens: maxTokens,
+		defaultTier: tier,
 	});
 }

--- a/src/services/llm/llm-provider.ts
+++ b/src/services/llm/llm-provider.ts
@@ -1,3 +1,4 @@
+import type { TextGenerationTier } from "@/app-constants";
 import type { LlmUsageReport } from "@/lib/llm-usage-breakdown";
 
 /**
@@ -13,6 +14,15 @@ export interface UsageCallbackContext {
  */
 export interface LLMOptions {
 	model?: string;
+	/**
+	 * Tier this call was selected from. Purely descriptive — it does not pick the
+	 * model (`model` already does) — but it selects the Anthropic effort level via
+	 * `effortForTier`, and it is the grouping key a per-tier effort sweep needs.
+	 *
+	 * Optional because omitting it yields today's behaviour exactly: the default
+	 * effort, and no `modelRole` on the spend log.
+	 */
+	tier?: TextGenerationTier;
 	temperature?: number;
 	maxTokens?: number;
 	/**

--- a/src/services/llm/llm-rate-limit-service.ts
+++ b/src/services/llm/llm-rate-limit-service.ts
@@ -458,8 +458,14 @@ export class LLMRateLimitService {
 				completionTokens,
 				cachedInputTokens,
 				cacheWriteTokens,
+				attempts,
+				effort,
 				...extras
 			} = meta;
+			// Every field pulled out of `meta` above must be re-attached here.
+			// Destructuring them purely to keep them out of `extras` drops them from
+			// the drain entirely — which is how cache-read counts, the one proof a
+			// breakpoint is being honoured, went missing from `llm_token_spend`.
 			logVerboseLlmSpend(this.env, {
 				intent,
 				source,
@@ -467,8 +473,15 @@ export class LLMRateLimitService {
 				tokens,
 				queryCount,
 				model: model ?? metaModel,
+				modelRole,
+				agent,
+				provider,
 				promptTokens,
 				completionTokens,
+				cachedInputTokens,
+				cacheWriteTokens,
+				attempts: typeof attempts === "number" ? attempts : undefined,
+				effort: typeof effort === "string" ? effort : undefined,
 				extras:
 					Object.keys(extras).length > 0
 						? (extras as Record<string, unknown>)

--- a/src/services/rag/entity-extraction-service.ts
+++ b/src/services/rag/entity-extraction-service.ts
@@ -391,6 +391,7 @@ export class EntityExtractionService {
 				defaultModel: getGenerationModelForProvider("PIPELINE_STRUCTURED"),
 				defaultTemperature: 0.1,
 				defaultMaxTokens: MAX_EXTRACTION_RESPONSE_TOKENS,
+				defaultTier: "PIPELINE_STRUCTURED",
 			});
 
 			// Generate structured output (returns parsed JSON)

--- a/src/services/session-digest/digest-consistency-triage-telemetry.ts
+++ b/src/services/session-digest/digest-consistency-triage-telemetry.ts
@@ -1,0 +1,67 @@
+/**
+ * Structured logging for digest consistency-triage decisions.
+ *
+ * Answers the question that decides how far the deterministic triage should go:
+ * **when a cheap rule would have skipped the GraphRAG consistency pass, did that
+ * pass actually find anything?** Filter the drain to `source=expensive` and
+ * group by `advisoryRule` + `advisorySuppressedFindings` to get a per-rule
+ * false-skip rate; a rule that never suppresses a real finding is a candidate
+ * for promotion into `triageDigestConsistencyDecisively`.
+ *
+ * Gated behind `LORESMITH_VERBOSE_LLM_USAGE`, the same switch as token-spend,
+ * routing, and chunk-gate logs, rather than adding another knob.
+ */
+
+import type { EnvWithSecrets } from "@/lib/env-utils";
+import { isVerboseLlmSpendEnabled } from "@/lib/llm-usage-verbose-log";
+import { createLogger } from "@/lib/logger";
+import type { DigestConsistencyVerdict } from "./digest-consistency-triage";
+
+export type DigestConsistencyDecisionLog = {
+	/** `deterministic` when triage short-circuited; `expensive` when it ran. */
+	source: "deterministic" | "expensive";
+	ranConsistencyPass: boolean;
+	/** Rule that decided, when `source` is `deterministic`. */
+	rule?: string;
+	reason?: string;
+	/** What the advisory rules would have said, when the expensive path ran. */
+	advisoryVerdict?: DigestConsistencyVerdict;
+	advisoryRule?: string;
+	/**
+	 * True when the advisory rules said `skip` but the expensive pass returned
+	 * findings — i.e. promoting that rule would have cost a real inconsistency.
+	 * Undefined when the advisory verdict was `ambiguous` (a deferral, not a
+	 * guess) or when the pass did not run.
+	 */
+	advisorySuppressedFindings?: boolean;
+	/** Findings the expensive pass returned. Counts only — never digest text. */
+	issueCount?: number;
+	narrativeEntries?: number;
+	campaignId?: string;
+};
+
+/**
+ * Emit one structured consistency-triage decision log line.
+ *
+ * Never throws: quality scoring must not fail because logging did.
+ */
+export function logDigestConsistencyDecision(
+	env: EnvWithSecrets | Record<string, unknown> | undefined,
+	decision: DigestConsistencyDecisionLog
+): void {
+	if (!isVerboseLlmSpendEnabled(env)) {
+		return;
+	}
+	try {
+		const log = createLogger(
+			env as Record<string, unknown> | undefined,
+			"[DigestConsistencyTriage]"
+		);
+		log.info("digest_consistency_triage_decision", {
+			event: "digest_consistency_triage_decision",
+			...decision,
+		});
+	} catch {
+		// Logging is best-effort; a drain problem must not break quality scoring.
+	}
+}

--- a/src/services/session-digest/digest-consistency-triage.ts
+++ b/src/services/session-digest/digest-consistency-triage.ts
@@ -1,0 +1,222 @@
+/**
+ * Deterministic triage for the digest consistency check.
+ *
+ * `DigestQualityService.checkConsistencyWithGraphRAG` is the most expensive
+ * thing in quality scoring, and the cost is not the `PIPELINE_ANALYSIS` call at
+ * the end of it. Before that call it runs, unconditionally:
+ *
+ * 1. `EntityExtractionService.extractEntities` over the whole digest — that is
+ *    `PIPELINE_STRUCTURED`, i.e. Sonnet 5;
+ * 2. an embedding request for every extracted entity name;
+ * 3. a vector search plus entity/relationship reads per entity;
+ * 4. the Haiku consistency call.
+ *
+ * The two-stage shape `ContinuityAdjudicationService` uses — cheap triage,
+ * expensive adjudication only on survivors — applies directly, and the cheap
+ * signal is already free: a digest with no narrative text has nothing for a
+ * consistency pass to contradict.
+ *
+ * Split the same way #759 established and #765/#790 reused:
+ *
+ * - `triageDigestConsistencyDecisively` — rules that cannot be wrong, and which
+ *   therefore short-circuit. Today only the empty case, which is provably
+ *   outcome-preserving (see below).
+ * - `triageDigestConsistencyAdvisory` — the broader rule set, evaluated on every
+ *   run and logged against what the expensive path actually found, but never
+ *   routed on. That measurement is what decides which rules get promoted.
+ *
+ * **Why the decisive rule changes no outcome.** `checkConsistencyWithGraphRAG`
+ * already returns `[]` when extraction yields no entities. A digest whose
+ * narrative fields are all blank renders to nothing but static section headers,
+ * from which no entity can be extracted — so the expensive path's result is `[]`
+ * either way. Skipping it removes the spend, not a finding.
+ */
+
+import type { SessionDigestData } from "@/types/session-digest";
+
+export type DigestConsistencyVerdict =
+	/** Confidently nothing to check — skip the GraphRAG consistency pass. */
+	| "skip"
+	/** Confidently worth checking. */
+	| "check"
+	/** Genuinely unclear — run the expensive path. */
+	| "ambiguous";
+
+export interface DigestConsistencyTriageMatch {
+	verdict: DigestConsistencyVerdict;
+	/** Stable identifier so the log drain can group by rule. */
+	rule: string;
+	/** Short human-readable justification; safe to log (carries no digest text). */
+	reason: string;
+}
+
+/**
+ * Entry counts a consistency pass can act on.
+ *
+ * Deliberately ignores `todo_checklist`: it holds GM chores ("book the room",
+ * "print maps"), not campaign facts, so it can be non-empty while the digest
+ * still describes no fiction to be inconsistent about.
+ */
+export interface DigestSubstanceStats {
+	/** Non-blank entries across every narrative field. */
+	narrativeEntries: number;
+	/** Non-blank entries in the recap specifically (what consistency compares). */
+	recapEntries: number;
+	/** Entries containing a capitalised word — proper-noun shaped. */
+	namedEntryCount: number;
+	/** Total characters of narrative text. */
+	narrativeChars: number;
+}
+
+function nonBlank(values: readonly string[] | undefined): string[] {
+	return (values ?? []).filter((value) => value.trim().length > 0);
+}
+
+/**
+ * A capitalised word that is not the first word of the entry.
+ *
+ * Leading capitals are just sentence case and say nothing about proper nouns;
+ * a mid-entry capital is the cheap signal that a name is present.
+ */
+const INTERIOR_CAPITAL = /\s[A-Z][a-z]{2,}/;
+
+/** Narrative fields, in the order they contribute to consistency checking. */
+function recapEntriesOf(digest: SessionDigestData): string[] {
+	const recap = digest.last_session_recap;
+	return [
+		...nonBlank(recap?.key_events),
+		...nonBlank(recap?.state_changes?.factions),
+		...nonBlank(recap?.state_changes?.locations),
+		...nonBlank(recap?.state_changes?.npcs),
+		...nonBlank(recap?.open_threads),
+	];
+}
+
+function planEntriesOf(digest: SessionDigestData): string[] {
+	const plan = digest.next_session_plan;
+	return [
+		...nonBlank(plan?.objectives_dm),
+		...nonBlank(plan?.probable_player_goals),
+		...nonBlank(plan?.beats),
+		...nonBlank(plan?.if_then_branches),
+		...nonBlank(digest.npcs_to_run),
+		...nonBlank(digest.locations_in_focus),
+		...nonBlank(digest.encounter_seeds),
+		...nonBlank(digest.clues_and_revelations),
+		...nonBlank(digest.treasure_and_rewards),
+	];
+}
+
+/** Measure a digest's substance. Pure and cheap — no allocation worth caching. */
+export function measureDigestSubstance(
+	digest: SessionDigestData
+): DigestSubstanceStats {
+	const recap = recapEntriesOf(digest);
+	const plan = planEntriesOf(digest);
+	const all = [...recap, ...plan];
+	return {
+		narrativeEntries: all.length,
+		recapEntries: recap.length,
+		namedEntryCount: all.filter((entry) => INTERIOR_CAPITAL.test(entry)).length,
+		narrativeChars: all.reduce((sum, entry) => sum + entry.trim().length, 0),
+	};
+}
+
+/**
+ * Rules confident enough to skip the expensive consistency pass.
+ *
+ * Only the empty case, because only it is provably outcome-preserving. Anything
+ * that trades a real chance of a missed inconsistency for tokens belongs in the
+ * advisory set until the logs say otherwise — a digest is GM-facing prep, and a
+ * contradiction that reaches the table is worth more than the call that found
+ * it.
+ */
+export function triageDigestConsistencyDecisively(
+	digest: SessionDigestData
+): DigestConsistencyTriageMatch | null {
+	const stats = measureDigestSubstance(digest);
+
+	if (stats.narrativeEntries === 0) {
+		return {
+			verdict: "skip",
+			rule: "no-narrative-content",
+			reason:
+				"every narrative field is empty; entity extraction has nothing to read",
+		};
+	}
+
+	return null;
+}
+
+/**
+ * Entries below which a digest is probably too thin for a consistency pass to
+ * find anything. Advisory only.
+ */
+const THIN_DIGEST_ENTRY_COUNT = 3;
+
+/** Characters below which the whole digest is barely a sentence. */
+const THIN_DIGEST_CHAR_COUNT = 80;
+
+/**
+ * The full rule set — evaluated on every consistency check, never acted on.
+ *
+ * Its agreement with the expensive path is logged so a per-rule "did this ever
+ * suppress a real finding?" rate exists before anything here is promoted.
+ */
+export function triageDigestConsistencyAdvisory(
+	digest: SessionDigestData
+): DigestConsistencyTriageMatch {
+	const stats = measureDigestSubstance(digest);
+
+	const decisive = triageDigestConsistencyDecisively(digest);
+	if (decisive) {
+		return decisive;
+	}
+
+	if (stats.narrativeChars < THIN_DIGEST_CHAR_COUNT) {
+		return {
+			verdict: "skip",
+			rule: "below-minimum-length",
+			reason: `only ${stats.narrativeChars} characters of narrative text`,
+		};
+	}
+
+	// Consistency compares the digest against entities already in the graph. With
+	// no proper-noun-shaped entry there is likely nothing that will match one.
+	if (stats.namedEntryCount === 0) {
+		return {
+			verdict: "skip",
+			rule: "no-named-entities",
+			reason: "no entry contains a proper-noun-shaped word",
+		};
+	}
+
+	if (
+		stats.recapEntries === 0 &&
+		stats.narrativeEntries < THIN_DIGEST_ENTRY_COUNT
+	) {
+		return {
+			verdict: "skip",
+			rule: "forward-looking-only",
+			reason:
+				"no recap entries and few plan entries; nothing recorded to contradict",
+		};
+	}
+
+	if (
+		stats.recapEntries >= THIN_DIGEST_ENTRY_COUNT &&
+		stats.namedEntryCount > 0
+	) {
+		return {
+			verdict: "check",
+			rule: "substantive-recap",
+			reason: `${stats.recapEntries} recap entries with named subjects`,
+		};
+	}
+
+	return {
+		verdict: "ambiguous",
+		rule: "none",
+		reason: "no rule matched confidently",
+	};
+}

--- a/src/services/session-digest/digest-quality-service.ts
+++ b/src/services/session-digest/digest-quality-service.ts
@@ -12,6 +12,12 @@ import { EntityExtractionService } from "@/services/rag/entity-extraction-servic
 import { createPlanningContextService } from "@/services/rag/rag-service-factory";
 import { EntityEmbeddingService } from "@/services/vectorize/entity-embedding-service";
 import type { SessionDigestData } from "@/types/session-digest";
+import {
+	measureDigestSubstance,
+	triageDigestConsistencyAdvisory,
+	triageDigestConsistencyDecisively,
+} from "./digest-consistency-triage";
+import { logDigestConsistencyDecision } from "./digest-consistency-triage-telemetry";
 
 export interface DigestQualityResult {
 	score: number; // 0-10
@@ -267,6 +273,7 @@ Return:
 				defaultModel: getGenerationModelForProvider("PIPELINE_ANALYSIS"),
 				defaultTemperature: 0.1,
 				defaultMaxTokens: 2200,
+				defaultTier: "PIPELINE_ANALYSIS",
 			});
 			const result = await llmProvider.generateStructuredOutput<{
 				specificity?: { score?: number; issues?: string[] };
@@ -338,14 +345,37 @@ Return:
 			this.vectorize &&
 			this.env
 		) {
-			try {
-				const aiIssues = await this.checkConsistencyWithGraphRAG(
-					digestData,
-					campaignId
-				);
-				issues.push(...aiIssues);
-			} catch (_error) {
-				// Continue with basic checks if GraphRAG check fails
+			// Cheap triage before the expensive pass, the same shape
+			// ContinuityAdjudicationService uses. The pass costs a Sonnet 5 entity
+			// extraction, an embedding request, N vector searches and a Haiku call —
+			// all to compare a digest against the graph. A digest with no narrative
+			// text has nothing to compare, and the pass already returns no issues for
+			// it, so this removes spend rather than a finding.
+			const decisive = triageDigestConsistencyDecisively(digestData);
+			if (decisive?.verdict === "skip") {
+				logDigestConsistencyDecision(this.env, {
+					source: "deterministic",
+					ranConsistencyPass: false,
+					rule: decisive.rule,
+					reason: decisive.reason,
+					narrativeEntries: measureDigestSubstance(digestData).narrativeEntries,
+					campaignId,
+				});
+			} else {
+				try {
+					const aiIssues = await this.checkConsistencyWithGraphRAG(
+						digestData,
+						campaignId
+					);
+					issues.push(...aiIssues);
+					this.logAdvisoryConsistencyTriage(
+						digestData,
+						campaignId,
+						aiIssues.length
+					);
+				} catch (_error) {
+					// Continue with basic checks if GraphRAG check fails
+				}
 			}
 		}
 
@@ -355,6 +385,37 @@ Return:
 		const score = Math.max(0, 10 - issuePenalty * 10);
 
 		return { score, issues: issues.slice(0, 15) }; // Limit issues to first 15
+	}
+
+	/**
+	 * Record what the broader triage rules would have decided, against what the
+	 * expensive pass actually found.
+	 *
+	 * Never routes on the advisory verdict — it exists purely to produce the
+	 * per-rule false-skip rate that would justify promoting a rule into
+	 * `triageDigestConsistencyDecisively`. An `ambiguous` verdict is a deferral,
+	 * so it is recorded without a suppression judgement rather than counted as
+	 * agreement.
+	 */
+	private logAdvisoryConsistencyTriage(
+		digestData: SessionDigestData,
+		campaignId: string,
+		issueCount: number
+	): void {
+		const advisory = triageDigestConsistencyAdvisory(digestData);
+		logDigestConsistencyDecision(this.env, {
+			source: "expensive",
+			ranConsistencyPass: true,
+			advisoryVerdict: advisory.verdict,
+			advisoryRule: advisory.rule,
+			advisorySuppressedFindings:
+				advisory.verdict === "ambiguous"
+					? undefined
+					: advisory.verdict === "skip" && issueCount > 0,
+			issueCount,
+			narrativeEntries: measureDigestSubstance(digestData).narrativeEntries,
+			campaignId,
+		});
 	}
 
 	/**
@@ -537,6 +598,7 @@ Return:
 			defaultModel: getGenerationModelForProvider("PIPELINE_ANALYSIS"),
 			defaultTemperature: 0.1,
 			defaultMaxTokens: 1500,
+			defaultTier: "PIPELINE_ANALYSIS",
 		});
 
 		try {

--- a/src/tools/campaign-context/recap-tools.ts
+++ b/src/tools/campaign-context/recap-tools.ts
@@ -19,7 +19,7 @@ import {
 	isLikelyTransientLlmFailure,
 } from "@/lib/llm-error-utils";
 import type { LlmUsageReport } from "@/lib/llm-usage-breakdown";
-import { pickTokenBreakdown } from "@/lib/llm-usage-breakdown";
+import { pickSpendMeta } from "@/lib/llm-usage-breakdown";
 import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
 import { createLogger } from "@/lib/logger";
 import type { SessionPlanReadoutStep } from "@/lib/prompts/recap-prompts";
@@ -257,7 +257,7 @@ function sessionReadoutGenerateSummaryOptions(
 					{
 						intent: LLM_SPEND_INTENT.session_plan_readout,
 						source,
-						...pickTokenBreakdown(usage),
+						...pickSpendMeta(usage),
 						campaignId,
 					}
 				);

--- a/tests/lib/anthropic-attempt-counter.test.ts
+++ b/tests/lib/anthropic-attempt-counter.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	createAttemptCounter,
+	reportableAttempts,
+} from "@/lib/anthropic-attempt-counter";
+
+const MESSAGES_URL = "https://api.anthropic.com/v1/messages";
+
+function okFetch() {
+	return vi.fn(async () => new Response("{}", { status: 200 }));
+}
+
+describe("createAttemptCounter", () => {
+	it("starts at zero before anything is dispatched", () => {
+		expect(createAttemptCounter(okFetch() as never).attempts()).toBe(0);
+	});
+
+	it("counts each request to the messages endpoint", async () => {
+		const base = okFetch();
+		const counter = createAttemptCounter(base as never);
+
+		await counter.fetch(MESSAGES_URL, { method: "POST" });
+		await counter.fetch(MESSAGES_URL, { method: "POST" });
+		await counter.fetch(MESSAGES_URL, { method: "POST" });
+
+		expect(counter.attempts()).toBe(3);
+		expect(base).toHaveBeenCalledTimes(3);
+	});
+
+	it("passes the request through unchanged", async () => {
+		const base = okFetch();
+		const counter = createAttemptCounter(base as never);
+		const init = { method: "POST", body: "{}" };
+
+		await counter.fetch(MESSAGES_URL, init);
+
+		expect(base).toHaveBeenCalledWith(MESSAGES_URL, init);
+	});
+
+	it("accepts URL and Request inputs, not just strings", async () => {
+		const counter = createAttemptCounter(okFetch() as never);
+
+		await counter.fetch(new URL(MESSAGES_URL));
+		await counter.fetch(new Request(MESSAGES_URL, { method: "POST" }));
+
+		expect(counter.attempts()).toBe(2);
+	});
+
+	// Token counting, model listing and any other endpoint the SDK may call are
+	// not generation attempts; counting them would inflate the retry signal.
+	it("ignores requests to other endpoints", async () => {
+		const counter = createAttemptCounter(okFetch() as never);
+
+		await counter.fetch("https://api.anthropic.com/v1/models");
+		await counter.fetch("https://api.anthropic.com/v1/messages/batches");
+
+		expect(counter.attempts()).toBe(0);
+	});
+
+	it("counts the messages endpoint when it carries a query string", async () => {
+		const counter = createAttemptCounter(okFetch() as never);
+		await counter.fetch(`${MESSAGES_URL}?beta=true`);
+		await counter.fetch(`${MESSAGES_URL}/`);
+		expect(counter.attempts()).toBe(2);
+	});
+
+	// An attempt that throws is the case most worth seeing: it was dispatched,
+	// so it may have been billed, and it returns no usage to account for it.
+	it("counts an attempt that rejects", async () => {
+		const base = vi.fn(async () => {
+			throw new Error("overloaded");
+		});
+		const counter = createAttemptCounter(base as never);
+
+		await expect(counter.fetch(MESSAGES_URL)).rejects.toThrow("overloaded");
+		expect(counter.attempts()).toBe(1);
+	});
+
+	it("does not fail a generation when the URL cannot be read", async () => {
+		const base = okFetch();
+		const counter = createAttemptCounter(base as never);
+
+		await counter.fetch({} as never);
+
+		expect(base).toHaveBeenCalled();
+	});
+});
+
+describe("reportableAttempts", () => {
+	// A single attempt is the expected case; logging it on every call would be
+	// noise. Zero means the counter never saw the endpoint (a mocked provider),
+	// and reporting it would read as a measurement of zero attempts.
+	it("reports nothing for the no-retry and never-dispatched cases", () => {
+		expect(reportableAttempts(0)).toBeUndefined();
+		expect(reportableAttempts(1)).toBeUndefined();
+	});
+
+	it("reports the count once a retry has happened", () => {
+		expect(reportableAttempts(2)).toBe(2);
+		expect(reportableAttempts(3)).toBe(3);
+	});
+});

--- a/tests/lib/llm-usage-breakdown.test.ts
+++ b/tests/lib/llm-usage-breakdown.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	addTokenBreakdowns,
 	hasPriceableSplit,
-	pickTokenBreakdown,
+	pickSpendMeta,
 	toTokenBreakdown,
 	totalUsageTokens,
 } from "@/lib/llm-usage-breakdown";
@@ -115,18 +115,45 @@ describe("addTokenBreakdowns", () => {
 	});
 });
 
-describe("pickTokenBreakdown", () => {
+describe("pickSpendMeta", () => {
 	it("drops tokens/queryCount so they do not leak into metadata", () => {
-		const picked = pickTokenBreakdown({
+		const picked = pickSpendMeta({
+			tokens: 6,
+			queryCount: 1,
 			promptTokens: 5,
 			completionTokens: 1,
 		} as never);
+		expect(picked).not.toHaveProperty("tokens");
+		expect(picked).not.toHaveProperty("queryCount");
 		expect(Object.keys(picked).sort()).toEqual([
+			"attempts",
 			"cacheWriteTokens",
 			"cachedInputTokens",
 			"completionTokens",
+			"effort",
 			"promptTokens",
 		]);
+	});
+
+	// Every call site spreads this into its spend metadata, so carrying the two
+	// diagnostics here is what puts retries and effort on `llm_token_spend`
+	// everywhere rather than at one hand-wired call site.
+	it("carries retry attempts and effort through to metadata", () => {
+		expect(
+			pickSpendMeta({
+				tokens: 6,
+				queryCount: 1,
+				promptTokens: 5,
+				attempts: 3,
+				effort: "medium",
+			})
+		).toMatchObject({ attempts: 3, effort: "medium" });
+	});
+
+	it("leaves the diagnostics undefined when the provider omitted them", () => {
+		const picked = pickSpendMeta({ promptTokens: 5 });
+		expect(picked.attempts).toBeUndefined();
+		expect(picked.effort).toBeUndefined();
 	});
 });
 

--- a/tests/lib/tier-effort.test.ts
+++ b/tests/lib/tier-effort.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { TextGenerationTier } from "@/app-constants";
+import {
+	anthropicBatchModelParams,
+	anthropicSamplingParams,
+	DEFAULT_SONNET5_EFFORT,
+	effortForTier,
+} from "@/lib/anthropic-model-options";
+
+const ALL_TIERS: TextGenerationTier[] = [
+	"PRIMARY",
+	"INTERACTIVE",
+	"ANALYSIS",
+	"PIPELINE_STRUCTURED",
+	"PIPELINE_LIGHT",
+	"PIPELINE_ANALYSIS",
+	"METADATA_ANALYSIS",
+	"SESSION_PLANNING",
+];
+
+describe("effortForTier", () => {
+	// The point of the table is that a sweep can change one row. Until a sweep
+	// has actually been run and its quality impact recorded, every row must still
+	// read the previous global default — otherwise this shipped an unmeasured
+	// quality change disguised as a refactor.
+	it("leaves every tier at the previous global default", () => {
+		for (const tier of ALL_TIERS) {
+			expect(effortForTier(tier)).toBe(DEFAULT_SONNET5_EFFORT);
+		}
+	});
+
+	it("covers every declared tier", () => {
+		for (const tier of ALL_TIERS) {
+			expect(effortForTier(tier)).toBeDefined();
+		}
+	});
+
+	it("falls back rather than throwing on an absent or unknown tier", () => {
+		expect(effortForTier(undefined)).toBe(DEFAULT_SONNET5_EFFORT);
+		expect(effortForTier("NOT_A_TIER" as TextGenerationTier)).toBe(
+			DEFAULT_SONNET5_EFFORT
+		);
+	});
+});
+
+describe("anthropicSamplingParams", () => {
+	it("sends the tier's effort on Sonnet 5", () => {
+		const params = anthropicSamplingParams(
+			"claude-sonnet-5",
+			0.7,
+			"PIPELINE_STRUCTURED"
+		);
+		expect(params.providerOptions?.anthropic.effort).toBe(
+			effortForTier("PIPELINE_STRUCTURED")
+		);
+		expect(params.temperature).toBeUndefined();
+	});
+
+	it("behaves exactly as before when no tier is supplied", () => {
+		expect(anthropicSamplingParams("claude-sonnet-5", 0.7)).toEqual(
+			anthropicSamplingParams("claude-sonnet-5", 0.7, undefined)
+		);
+	});
+
+	// Haiku takes no effort parameter, so a tier must not start smuggling one in.
+	it("ignores the tier on models that take no effort", () => {
+		const params = anthropicSamplingParams(
+			"claude-haiku-4-5",
+			0.3,
+			"PIPELINE_LIGHT"
+		);
+		expect(params.providerOptions).toBeUndefined();
+		expect(params.temperature).toBe(0.3);
+	});
+});
+
+describe("anthropicBatchModelParams", () => {
+	it("uses the tier's effort on the batch path too", () => {
+		const params = anthropicBatchModelParams(
+			"claude-sonnet-5",
+			0.1,
+			"PIPELINE_STRUCTURED"
+		);
+		expect(params.output_config?.effort).toBe(
+			effortForTier("PIPELINE_STRUCTURED")
+		);
+	});
+
+	it("keeps its previous behaviour when no tier is supplied", () => {
+		expect(anthropicBatchModelParams("claude-sonnet-5", 0.1)).toEqual({
+			output_config: { effort: DEFAULT_SONNET5_EFFORT },
+		});
+	});
+});

--- a/tests/services/digest-consistency-triage.test.ts
+++ b/tests/services/digest-consistency-triage.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+import {
+	measureDigestSubstance,
+	triageDigestConsistencyAdvisory,
+	triageDigestConsistencyDecisively,
+} from "@/services/session-digest/digest-consistency-triage";
+import type { SessionDigestData } from "@/types/session-digest";
+
+const EMPTY_DIGEST: SessionDigestData = {
+	last_session_recap: {
+		key_events: [],
+		state_changes: { factions: [], locations: [], npcs: [] },
+		open_threads: [],
+	},
+	next_session_plan: {
+		objectives_dm: [],
+		probable_player_goals: [],
+		beats: [],
+		if_then_branches: [],
+	},
+	npcs_to_run: [],
+	locations_in_focus: [],
+	encounter_seeds: [],
+	clues_and_revelations: [],
+	treasure_and_rewards: [],
+	todo_checklist: [],
+};
+
+function digest(overrides: Partial<SessionDigestData>): SessionDigestData {
+	return {
+		...EMPTY_DIGEST,
+		...overrides,
+		last_session_recap: {
+			...EMPTY_DIGEST.last_session_recap,
+			...overrides.last_session_recap,
+		},
+		next_session_plan: {
+			...EMPTY_DIGEST.next_session_plan,
+			...overrides.next_session_plan,
+		},
+	};
+}
+
+describe("measureDigestSubstance", () => {
+	it("ignores whitespace-only entries", () => {
+		const stats = measureDigestSubstance(
+			digest({
+				last_session_recap: {
+					key_events: ["   ", "\n\t", ""],
+					state_changes: { factions: [], locations: [], npcs: [] },
+					open_threads: [],
+				},
+			})
+		);
+		expect(stats.narrativeEntries).toBe(0);
+	});
+
+	it("excludes the todo checklist, which holds GM chores rather than fiction", () => {
+		const stats = measureDigestSubstance(
+			digest({ todo_checklist: ["Print the maps", "Book the room"] })
+		);
+		expect(stats.narrativeEntries).toBe(0);
+	});
+
+	it("counts recap entries separately from plan entries", () => {
+		const stats = measureDigestSubstance(
+			digest({
+				last_session_recap: {
+					key_events: ["The party fled Ravenhollow"],
+					state_changes: { factions: [], locations: [], npcs: [] },
+					open_threads: [],
+				},
+				npcs_to_run: ["Sera the smith"],
+			})
+		);
+		expect(stats.recapEntries).toBe(1);
+		expect(stats.narrativeEntries).toBe(2);
+	});
+
+	it("treats a mid-entry capital as a proper noun but not a leading one", () => {
+		const leadingOnly = measureDigestSubstance(
+			digest({ npcs_to_run: ["Someone opened the door"] })
+		);
+		expect(leadingOnly.namedEntryCount).toBe(0);
+
+		const interior = measureDigestSubstance(
+			digest({ npcs_to_run: ["the party met Sera"] })
+		);
+		expect(interior.namedEntryCount).toBe(1);
+	});
+});
+
+describe("triageDigestConsistencyDecisively", () => {
+	it("skips a digest with no narrative content", () => {
+		const match = triageDigestConsistencyDecisively(EMPTY_DIGEST);
+		expect(match?.verdict).toBe("skip");
+		expect(match?.rule).toBe("no-narrative-content");
+	});
+
+	it("skips when every narrative entry is whitespace", () => {
+		const match = triageDigestConsistencyDecisively(
+			digest({
+				last_session_recap: {
+					key_events: ["  "],
+					state_changes: { factions: [""], locations: [], npcs: [] },
+					open_threads: ["\t"],
+				},
+			})
+		);
+		expect(match?.verdict).toBe("skip");
+	});
+
+	// The decisive rule is the only one allowed to change behaviour, so anything
+	// carrying content must fall through to the expensive pass. A digest that
+	// mentions something a GM could contradict is worth the model call.
+	it("does not skip a digest with a single real entry", () => {
+		expect(
+			triageDigestConsistencyDecisively(
+				digest({ npcs_to_run: ["Sera the smith"] })
+			)
+		).toBeNull();
+	});
+
+	it("does not skip a thin digest, however unpromising", () => {
+		expect(
+			triageDigestConsistencyDecisively(digest({ encounter_seeds: ["a"] }))
+		).toBeNull();
+	});
+
+	it("does not skip when only the todo checklist is empty", () => {
+		expect(
+			triageDigestConsistencyDecisively(
+				digest({
+					last_session_recap: {
+						key_events: ["The party burned the Ledger of Ash"],
+						state_changes: { factions: [], locations: [], npcs: [] },
+						open_threads: [],
+					},
+				})
+			)
+		).toBeNull();
+	});
+});
+
+describe("triageDigestConsistencyAdvisory", () => {
+	it("reports the decisive verdict when one applies", () => {
+		const advisory = triageDigestConsistencyAdvisory(EMPTY_DIGEST);
+		expect(advisory.verdict).toBe("skip");
+		expect(advisory.rule).toBe("no-narrative-content");
+	});
+
+	it("flags a digest with no proper-noun-shaped entry", () => {
+		const advisory = triageDigestConsistencyAdvisory(
+			digest({
+				last_session_recap: {
+					key_events: [
+						"they walked for a long while and then rested by the water",
+						"nothing much happened after that, so they made camp again",
+					],
+					state_changes: { factions: [], locations: [], npcs: [] },
+					open_threads: [],
+				},
+			})
+		);
+		expect(advisory.verdict).toBe("skip");
+		expect(advisory.rule).toBe("no-named-entities");
+	});
+
+	it("flags a digest that is barely a sentence", () => {
+		const advisory = triageDigestConsistencyAdvisory(
+			digest({ npcs_to_run: ["met Sera"] })
+		);
+		expect(advisory.verdict).toBe("skip");
+		expect(advisory.rule).toBe("below-minimum-length");
+	});
+
+	it("flags a forward-looking digest with nothing recorded to contradict", () => {
+		const advisory = triageDigestConsistencyAdvisory(
+			digest({
+				next_session_plan: {
+					objectives_dm: [
+						"the party should eventually reach Ravenhollow and speak to the smith there about the road north",
+					],
+					probable_player_goals: [],
+					beats: [],
+					if_then_branches: [],
+				},
+			})
+		);
+		expect(advisory.verdict).toBe("skip");
+		expect(advisory.rule).toBe("forward-looking-only");
+	});
+
+	it("says check for a substantive recap with named subjects", () => {
+		const advisory = triageDigestConsistencyAdvisory(
+			digest({
+				last_session_recap: {
+					key_events: [
+						"the party burned the Ledger of Ash in the undercroft",
+						"they bargained with Sera for safe passage north",
+					],
+					state_changes: {
+						factions: ["the Ashen Court now considers them outlaws"],
+						locations: [],
+						npcs: [],
+					},
+					open_threads: ["who warned the Court before they arrived"],
+				},
+			})
+		);
+		expect(advisory.verdict).toBe("check");
+		expect(advisory.rule).toBe("substantive-recap");
+	});
+
+	// An unmatched digest must defer rather than guess: `ambiguous` is recorded as
+	// a deferral in the telemetry, not counted as agreement either way.
+	it("defers when no rule matches confidently", () => {
+		const advisory = triageDigestConsistencyAdvisory(
+			digest({
+				last_session_recap: {
+					key_events: [
+						"the party spoke with Sera for some time about the road north and what waits along it",
+					],
+					state_changes: { factions: [], locations: [], npcs: [] },
+					open_threads: [],
+				},
+			})
+		);
+		expect(advisory.verdict).toBe("ambiguous");
+	});
+});

--- a/tests/services/llm-spend-log-threading.test.ts
+++ b/tests/services/llm-spend-log-threading.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const insertUsage = vi.fn();
+const insertEvent = vi.fn();
+const incrementUsage = vi.fn();
+
+vi.mock("@/dao/dao-factory", () => ({
+	getDAOFactory: () => ({
+		llmUsageDAO: { insertUsage },
+		llmCostEventDAO: { insertEvent },
+		userFreeTierUsageDAO: { incrementUsage },
+		userMonthlyUsageDAO: { incrementUsage },
+	}),
+}));
+
+vi.mock("@/services/billing/subscription-service", () => ({
+	getSubscriptionService: () => ({
+		getTier: async () => "basic",
+		getTierLimits: () => ({}),
+	}),
+}));
+
+import { LLM_SPEND_INTENT } from "@/lib/llm-usage-intents";
+import { LLM_SPEND_VERBOSE_ENV } from "@/lib/llm-usage-verbose-log";
+import * as loggerModule from "@/lib/logger";
+import { LLMRateLimitService } from "@/services/llm/llm-rate-limit-service";
+
+/**
+ * Pins the invariant that broke `llm_token_spend`: `recordUsage` destructures
+ * fields out of `meta` to keep them from landing in `extras`, and anything it
+ * pulls out but does not re-attach vanishes from the drain entirely.
+ *
+ * Cache-read tokens are the field that matters most. They are the only proof a
+ * `cache_control` breakpoint is being honoured — a breakpoint that never hits
+ * and one that always hits produce identical `tokens` totals — and the issue's
+ * own verification recipe says to read them from this log.
+ */
+describe("recordUsage → llm_token_spend", () => {
+	let info: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		info = vi.fn();
+		vi.spyOn(loggerModule, "createLogger").mockReturnValue({
+			info,
+			warn: vi.fn(),
+		} as unknown as ReturnType<typeof loggerModule.createLogger>);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		insertUsage.mockReset();
+		insertEvent.mockReset();
+	});
+
+	function serviceWithVerboseLogging() {
+		return new LLMRateLimitService({
+			[LLM_SPEND_VERBOSE_ENV]: "true",
+		} as never);
+	}
+
+	function loggedPayload() {
+		const call = info.mock.calls.find((c) => c[0] === "llm_token_spend");
+		expect(call, "no llm_token_spend line was emitted").toBeDefined();
+		return call?.[1] as Record<string, unknown>;
+	}
+
+	it("carries the cache split onto the log line", async () => {
+		await serviceWithVerboseLogging().recordUsage("alice", 900, 1, "model-x", {
+			intent: LLM_SPEND_INTENT.user_prompt,
+			promptTokens: 100,
+			completionTokens: 50,
+			cachedInputTokens: 700,
+			cacheWriteTokens: 50,
+		});
+
+		expect(loggedPayload()).toMatchObject({
+			cachedInputTokens: 700,
+			cacheWriteTokens: 50,
+			promptTokens: 100,
+			completionTokens: 50,
+		});
+	});
+
+	it("carries the attribution fields the drain groups by", async () => {
+		await serviceWithVerboseLogging().recordUsage("alice", 10, 1, "model-x", {
+			intent: LLM_SPEND_INTENT.user_prompt,
+			modelRole: "PIPELINE_STRUCTURED",
+			agent: "CampaignAgent",
+			provider: "anthropic",
+		});
+
+		expect(loggedPayload()).toMatchObject({
+			modelRole: "PIPELINE_STRUCTURED",
+			agent: "CampaignAgent",
+			provider: "anthropic",
+		});
+	});
+
+	it("carries retry attempts and effort", async () => {
+		await serviceWithVerboseLogging().recordUsage("alice", 10, 1, "model-x", {
+			intent: LLM_SPEND_INTENT.user_prompt,
+			attempts: 3,
+			effort: "medium",
+		});
+
+		expect(loggedPayload()).toMatchObject({ attempts: 3, effort: "medium" });
+	});
+
+	// These fields are optional everywhere upstream, so absent must stay absent
+	// rather than becoming a zero that reads as a real measurement.
+	it("omits the diagnostics when the provider did not report them", async () => {
+		await serviceWithVerboseLogging().recordUsage("alice", 10, 1, "model-x", {
+			intent: LLM_SPEND_INTENT.user_prompt,
+		});
+
+		const payload = loggedPayload();
+		expect(payload.attempts).toBeUndefined();
+		expect(payload.effort).toBeUndefined();
+	});
+
+	// Non-numeric junk arriving through the `Record<string, unknown>` half of
+	// LlmSpendLogMeta must not be presented as a measured attempt count.
+	it("drops a non-numeric attempts value rather than logging it", async () => {
+		await serviceWithVerboseLogging().recordUsage("alice", 10, 1, "model-x", {
+			intent: LLM_SPEND_INTENT.user_prompt,
+			attempts: "lots",
+		});
+
+		expect(loggedPayload().attempts).toBeUndefined();
+	});
+
+	it("still records the ledger row and the cost event", async () => {
+		await serviceWithVerboseLogging().recordUsage("alice", 10, 1, "model-x", {
+			intent: LLM_SPEND_INTENT.user_prompt,
+			promptTokens: 8,
+			completionTokens: 2,
+		});
+
+		expect(insertUsage).toHaveBeenCalledWith("alice", 10, 1, "model-x");
+		expect(insertEvent).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
Closes the remaining scope of the #761 umbrella: **finding 10**, the "smaller items, worth doing while in the area" list, plus a gap in finding 3's plumbing found on the way.

Follows the issue's own discipline throughout — **measure before optimising, layer cheapest-first, and never let a rule short-circuit before its telemetry justifies it.**

## What was actually left

#765 landed findings 1, 2, 3, 4, 6, 7; #790 landed 5a, 8, 9 (and recorded 5b as a measured cost *regression*, deliberately not implemented). One more finding-10 sub-item — the `PIPELINE_LIGHT: gpt-4o-mini` tier drift — was resolved incidentally by #795 deleting the OpenAI tier table outright. #734 and #737 are separately-owned open issues that #761 sequences but does not own.

That leaves four items.

## The verification gap (finding 3, completion)

`recordUsage` destructures fields out of `meta` to keep them from landing in the `extras` bag, then re-attaches only some of them. Five were pulled out and dropped on the floor: `cachedInputTokens`, `cacheWriteTokens`, `modelRole`, `agent`, `provider`.

Cache-read tokens are the one that matters. They are **the only proof a `cache_control` breakpoint is being honoured** — a breakpoint that never hits and one that always hits produce identical `tokens` totals — and the issue's own "How to verify any of this" section tells you to read them from `llm_token_spend`. They reached the D1 cost table and the admin panel, so the dashboard was right while the drain the issue points you at was silently blind.

`tests/services/llm-spend-log-threading.test.ts` pins the invariant. Verified it fails against the old code before fixing it.

## Finding 10 — two-stage triage

The issue suggests `digest-quality-service`'s two `PIPELINE_ANALYSIS` calls fit the cheap-triage → expensive-adjudication shape `ContinuityAdjudicationService` uses. The shape fits, but **the expensive half is not the call the issue points at**. Before the Haiku consistency call, `checkConsistencyWithGraphRAG` unconditionally runs a **Sonnet 5** `EntityExtractionService.extractEntities` over the whole digest, an embedding request per entity, and a vector search plus entity/relationship reads per entity. The Haiku call is the cheapest thing in it.

Split the way #759 established and #765/#790 reused:

- `triageDigestConsistencyDecisively` — short-circuits, and holds only the empty case.
- `triageDigestConsistencyAdvisory` — the full rule set (below-minimum-length, no-named-entities, forward-looking-only, substantive-recap), evaluated on every consistency check, logged against what the expensive pass actually found, **never routed on**. `ambiguous` is recorded as a deferral, not a disagreement.

**The decisive rule provably changes no outcome.** `checkConsistencyWithGraphRAG` already returns `[]` when extraction yields no entities. A digest whose narrative fields are all blank renders to nothing but static section headers, so the expensive path's result is `[]` either way — today's code pays Sonnet 5 to discover it has nothing to do. This removes the spend, not a finding.

Two judgement calls worth reviewing: the substance measure **excludes `todo_checklist`** (GM chores like "print the maps", not campaign facts, so it can be non-empty while the digest describes no fiction to contradict), and the proper-noun signal requires an **interior** capital, since a leading capital is just sentence case.

## Finding 10 — retry counts

#765 called this "not implementable as asked", correctly: `generateText` exposes no retry count on its **result**. But retries are HTTP requests, and `createAnthropic` accepts a custom `fetch`. `src/lib/anthropic-attempt-counter.ts` counts attempts one layer down.

This is spend no token total can show — a retried attempt is billed but reports no usage, so a prompt that reliably 429s costs 3x forever and looks free. Only reported when `> 1`; `1` would be noise on every line and `0` would present "never dispatched" as a measurement.

Writing the test caught a real bug in my own regex: `/v1/messages(\/|$)` also matches `/v1/messages/batches`, which is the Batches API — a different call with its own accounting, and counting it would have inflated the retry signal on the one path this exists to keep honest.

## Finding 10 — per-tier effort

Effort was globally hardcoded at `DEFAULT_SONNET5_EFFORT`, so the per-tier sweep the issue asks for could not be run at all. `effortForTier` is now a table, `LLMOptions.tier` / `defaultTier` thread it, and the effort actually sent is reported on `llm_token_spend` alongside `modelRole`.

**Every row is deliberately still at the previous default, and there is a test asserting it.** This ships the knob, not the sweep — the issue says measure before committing, and effort is exactly the kind of change that looks free until quality moves. `tests/lib/tier-effort.test.ts` fails if a row is changed without that measurement.

Wiring cost one line: `createProviderForTier` already received the tier and discarded it after picking a model.

## Not in this PR

- **#734** (streaming chat path caching) — its own open issue, and the highest-value remaining item in the umbrella.
- **#737** (`MODEL_CONFIGURATION.md` drift) — its own open issue; I did not half-correct it, so **no `docs/` files changed and no wiki sync is pending**.
- **Finding 10, embeddings** — the issue scopes this as needing a separate index or a full re-embed because the Workers AI fallback pads 768 dims to 1,536 by repetition, and says to measure relevance impact first. Not a code change that can be made safely here.
- **Finding 5b** — #790 measured it as a ~20x cost *regression* on true negatives, which are most uploads. Still correctly not implemented.

## Verification

Everything below was run on this branch:

- `npm run check` — clean (10 warnings / 3 infos all pre-existing)
- `npm run validate` — exit 0; branch coverage 75.25% vs the 70% threshold
- `npm run complexity` — passes (a **separate** CI step, not part of `validate`). It caught `generateStructuredOutput` at CCN 16; extracting `requireJsonText`, `asStructuredOutputError` and a shared `reportUsage` brought it under.
- `npx vitest run` — 2406 passed / 237 files
- `npm run build` — exit 0

Not run: Playwright e2e (CI runs it), and no live Anthropic call — the attempt counter is covered by unit tests against a stubbed fetch, not against a real 429.

## How to see this change

```bash
gh pr checkout 818
npm install            # dependency tree unchanged, but the worktree needs it
```

There is **no user-visible difference** — this is instrumentation plus one deterministic skip that is provably outcome-preserving. The evidence is the tests:

```bash
npx vitest run tests/services/llm-spend-log-threading.test.ts \
               tests/services/digest-consistency-triage.test.ts \
               tests/lib/anthropic-attempt-counter.test.ts \
               tests/lib/tier-effort.test.ts
```

**What you should see:** 39 passing tests. The four worth reading are `carries the cache split onto the log line` (the field that was being dropped), `does not skip a digest with a single real entry` (the decisive rule refusing to over-reach), `ignores requests to other endpoints` (the batches-path bug), and `leaves every tier at the previous global default` (the guard that keeps this a knob rather than an unmeasured quality change).

To see the new fields for real, set `LORESMITH_VERBOSE_LLM_USAGE=true` and grep the drain for `llm_token_spend` — lines now carry `cachedInputTokens`, `cacheWriteTokens`, `modelRole`, `effort`, and `attempts` when a retry happened. Grouping by `modelRole` + `effort` is what makes the sweep in finding 10 runnable. I did not run this against a live drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
