### PR TITLE
feat(agents): add the agent activity log primitive (#739)

### DIFF
--- a/docs/AGENT_ACTIVITY.md
+++ b/docs/AGENT_ACTIVITY.md
@@ -1,0 +1,167 @@
+# Agent activity log
+
+An append-only record of what agents did: one row per tool call, with lifecycle
+state, timing, attribution, and parent/child linkage.
+
+It exists because five separate features each needed the same thing and none of
+them had it. Issues #273 (agent dashboard), #276 (autonomy levels), #277
+(interrupt controls), #279 (guided flows) and #281 (multi-agent visualization)
+are all views over, or hooks into, one durable trace of agent actions — so each
+was individually large and none was individually startable. This is that trace
+(issue #739).
+
+## Why nothing recorded this before
+
+Agents run in Durable Objects, and `BaseAgent` executes tools inside
+`streamText`. Tool results flow back into the response stream and are then gone.
+The only surviving evidence that a tool ran was the chat transcript and whatever
+the tool itself happened to write to D1. Nothing said which agent ran it, what
+it touched, how long it took, or whether it succeeded.
+
+## Where rows come from
+
+`BaseAgent.createEnhancedTools` already rewraps every tool's `execute` for every
+agent — it is where JWT injection, campaign-id override, the infinite-loop guard
+and the stale-command block live. The activity log is written from that same
+wrapper, so **every agent is logged with no per-agent instrumentation**, and an
+agent added tomorrow is logged the day it is added.
+
+```
+BaseAgent.createEnhancedTools
+  └─ withActivityRecording(recorder, toolName, …)   ← src/services/agent-activity
+       ├─ recorder.begin()   → status: running
+       ├─ the tool's actual execute
+       └─ recorder.finish()  → status: succeeded | failed
+```
+
+Recording wraps the *whole* wrapper, not just the tool, so calls the wrapper
+blocks itself — a loop-limited tool, a mutating tool blocked as stale — appear
+as failures rather than silently succeeding. Those return a failure envelope
+instead of throwing, so status is read from `result.success`, not from whether
+an exception escaped.
+
+## Multi-agent turns form a tree
+
+`askAnotherAgent` is itself a tool, so it gets a row like any other — typed
+`delegation` rather than `tool_call`. The delegate's tools are then built
+through the same wrapper with a child context, so everything the delegate does
+is recorded under *its* `agent_type` with the delegating call as `parent_id`.
+
+Every row also carries `root_id`, set to its own id when it is a root. One
+indexed equality therefore fetches a whole multi-agent turn — no recursive
+query — which is what `GET /api/agent-activity/tree/:rootId` serves.
+
+## Schema
+
+`migrations/0036_agent_activity.sql`. The columns that are not self-evident:
+
+| Column | Notes |
+|---|---|
+| `username` | Denormalized from the JWT. This is the **entire** authorization check on the table — every read is scoped to it, and no read joins to prove ownership. |
+| `session_id` | The Durable Object id, i.e. one chat thread. |
+| `action_type` | `tool_call` or `delegation`. Coarser than `tool_name` so a future generation or indexing step lands without a migration. |
+| `status` | `running`, `succeeded`, `failed`, plus `cancelled` and `awaiting_approval`, which nothing writes yet — see below. |
+| `root_id` | Set even on roots (to their own id). |
+| `duration_ms` | Measured in the Worker: D1 stores timestamps at second resolution and most tool calls finish inside one. |
+| `summary` | JSON. Redacted, size-capped view of the arguments and of what was touched. |
+
+### The summary is never raw tool input
+
+The wrapper injects the caller's JWT into arguments before calling `execute`, so
+a verbatim copy of the input would persist a live credential in a table built to
+be displayed. `src/lib/agent-activity-summary.ts` therefore:
+
+- redacts by key — an explicit list plus a substring pass for the `*Token`,
+  `*Secret`, `*Password` and `*ApiKey` families, so a tool added later is
+  covered without being added to a list;
+- keeps redacted keys as `[redacted]` rather than dropping them, because "this
+  call carried a JWT" is worth knowing and a missing key makes an authenticated
+  action look anonymous;
+- truncates every value, caps the key count, and caps the serialized payload,
+  shedding the input map entirely rather than emitting oversized JSON.
+
+Touched ids (entities, files, campaigns, shards) are collected by a bounded,
+depth-limited walk over the tool's result, keyed on field name. That is a
+heuristic on purpose: a per-tool output contract would be exactly the per-agent
+instrumentation this primitive exists to avoid. Missing an id costs a dimmer
+badge in the UI; making 200 tools declare their outputs would cost the feature.
+
+## Write cost
+
+A D1 round-trip per tool call — twice, for start and finish — on the path a user
+is waiting on would be a real regression. Nothing on the hot path is awaited:
+
+- `begin` and `finish` mutate an in-memory map and mark the row dirty.
+- Flushes chain onto a single promise, so enqueues during an in-flight flush
+  coalesce into the next one, and each flush drains everything dirty in one
+  `db.batch()`.
+- A tool that starts and finishes between two flushes — the common case — is
+  written **once**, with its final state, because the DAO upserts on `id`.
+
+Losing a row is acceptable; losing a turn is not. Every failure path logs and
+continues.
+
+## Degradation
+
+Merging to `main` deploys the Worker automatically but does **not** apply D1
+migrations (`docs/DEPLOYMENT.md`). Because this table is written from inside
+every agent's tool path, throwing during that window would not lose a log line —
+it would break every agent in production. So `AgentActivityDAO` checks
+`isSchemaReady()` and degrades every method to a no-op or an empty result.
+
+Logging is also skipped entirely when:
+
+- there is no `DB` binding (the normal state in unit tests);
+- the turn is unauthenticated — a row with no owner could never be read back;
+- `LORESMITH_AGENT_ACTIVITY_LOG` is set to a falsy value. Unset means enabled;
+  the variable exists as a kill switch that needs no deploy.
+
+## Retention
+
+14 days, swept on the fast cron (`*/5`) alongside the other prunes. Shorter than
+the 90-day cost ledger because this table gains a row per tool call rather than
+per turn, and its readers care about the last few days. Anything needing a
+longer horizon should aggregate into telemetry rather than lengthen this window.
+
+The same sweep closes out rows left `running` by a Worker that died mid-call.
+The finish write is best-effort by design, so without it a dashboard would show
+work that never ends. Those rows are marked `failed`, not `cancelled` — nobody
+asked for them to stop, they simply never came back.
+
+## API
+
+All read-only, all scoped to the authenticated caller. There is deliberately no
+write endpoint: rows come from the agents, and an endpoint that accepted them
+would be a way to forge a record of work that never happened.
+
+| Endpoint | Returns |
+|---|---|
+| `GET /api/agent-activity` | The caller's actions, newest first. Filters: `campaignId`, `sessionId`, `agentType`, `status`, `since`, `limit`, `offset`. |
+| `GET /api/agent-activity/summary` | Counts over the same filters, minus paging — totals by status and by agent type. |
+| `GET /api/agent-activity/tree/:rootId` | One turn's actions, oldest first, including a delegate's work. |
+
+A `username` in the query string is ignored. The caller's own username is taken
+from the JWT and pinned, because the row's username is the only thing standing
+between one user's dashboard and everyone else's campaigns.
+
+## What this unblocks
+
+| Issue | What is left to build |
+|---|---|
+| #273 Agent dashboard | A view over `GET /api/agent-activity` and its summary. |
+| #281 Multi-agent visualization | A join on `agent_type` and `root_id`, rendered as badges on existing chat and entity UI. |
+| #277 Interrupt controls | Write `cancelled`, plus a cancellation check in the agent loop — `stopWhen: stepCountIs(MAX_AGENT_STEPS)` in `src/agents/base-agent.ts` is the natural interception point. |
+| #276 Autonomy levels | Write `awaiting_approval` as a gate on write-capable tools; the status already exists. |
+| #279 Guided flows | Parent/child linkage plus a flow definition. |
+
+## Files
+
+| Path | Role |
+|---|---|
+| `migrations/0036_agent_activity.sql` | Table and indexes. |
+| `src/types/agent-activity.ts` | Statuses, action types, record and query shapes. |
+| `src/lib/agent-activity-summary.ts` | Redaction, truncation, touched-id collection. |
+| `src/dao/agent-activity-dao.ts` | Upsert, queries, counts, retention, stale-row sweep. |
+| `src/services/agent-activity/agent-activity-recorder.ts` | Buffered writer and the `withActivityRecording` decorator. |
+| `src/agents/base-agent.ts` | The one call site that makes every agent report. |
+| `src/routes/agent-activity.ts` | Read API. |

--- a/docs/AGENT_DESIGN.md
+++ b/docs/AGENT_DESIGN.md
@@ -137,6 +137,7 @@ Details that matter when changing this:
 - **Chat flow**: `onChatMessage` builds a minimal message context (current user message, last assistant message, essential system context), then calls `streamText` with the agent’s tools. JWT and `campaignId` are taken from the last user message’s `data`.
 - **Rules-aware injection**: For targeted agents (`campaign`, `campaign-context`, `campaign-analysis`, `recap`, `session-digest`), `onChatMessage` resolves campaign rules from multiple sources (`house_rule`, source `rules`, and rule-tagged context) and injects normalized rules plus conflict warnings before generation.
 - **Tool execution**: Tools receive a `context` object that includes `env` when running inside the DO, so they can use the database directly. When `context.env` is missing (e.g. in tests or external calls), tools fall back to HTTP API with `authenticatedFetch`. See [TOOL_PATTERNS.md](./TOOL_PATTERNS.md).
+- **Activity logging**: The same `createEnhancedTools` wrapper records every tool call to the `agent_activity` table — agent, campaign, timing, status, and delegation linkage — with no per-agent instrumentation. See [AGENT_ACTIVITY.md](./AGENT_ACTIVITY.md).
 
 ## Token handling
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,11 @@ Welcome to the LoreSmith AI documentation! This directory contains comprehensive
   - BaseAgent behavior
   - Tool invocation lifecycle
 
+- **[Agent Activity Log](AGENT_ACTIVITY.md)** - Durable record of what agents did
+  - Written from the shared tool wrapper, so every agent is logged
+  - Delegation trees, redaction, and buffered writes
+  - The read API behind the agent dashboard
+
 - **[Tool System](TOOL_SYSTEM.md)** - Tool architecture and how to add a new tool
   - Tool anatomy and result envelope
   - Context object and auto-injected parameters

--- a/migrations/0036_agent_activity.sql
+++ b/migrations/0036_agent_activity.sql
@@ -1,0 +1,78 @@
+-- Append-only record of agent actions (issue #739).
+--
+-- Five stalled issues — #273 (agent dashboard), #276 (autonomy levels), #277
+-- (interrupt controls), #279 (guided flows), #281 (multi-agent visualization) —
+-- each need the same thing and none of them had it: a durable, queryable trace
+-- of what an agent did. Tool results flow back through `streamText` into the
+-- response stream and are then gone; the only surviving evidence that a tool
+-- ran was the chat transcript and whatever the tool itself wrote.
+--
+-- Rows are written from `BaseAgent.createEnhancedTools`, the one wrapper every
+-- agent's every tool call already passes through, so agents get this with no
+-- per-agent instrumentation.
+CREATE TABLE IF NOT EXISTS agent_activity (
+  id TEXT PRIMARY KEY,
+
+  -- Who acted, and on whose behalf. `username` is denormalized from the JWT
+  -- rather than joined through the session, because every read of this table is
+  -- scoped to one user and a dashboard cannot afford a join to prove ownership.
+  username TEXT NOT NULL,
+  agent_type TEXT NOT NULL,
+  -- Null for actions outside any campaign (library uploads, auth, help).
+  campaign_id TEXT,
+  -- The Durable Object id of the conversation, i.e. one chat thread.
+  session_id TEXT NOT NULL,
+
+  -- 'tool_call' | 'delegation'. Deliberately coarser than the tool name so a
+  -- future non-tool action (a generation step, an indexing pass) has somewhere
+  -- to land without a migration.
+  action_type TEXT NOT NULL,
+  tool_name TEXT,
+
+  -- 'running' | 'succeeded' | 'failed' | 'cancelled' | 'awaiting_approval'.
+  -- The last two are unused by this change and exist because #277 and #276 are
+  -- a status value plus a check, not a schema change, once they are here.
+  status TEXT NOT NULL,
+
+  -- Parent/child linkage. `parent_id` is the delegating action for work a
+  -- delegate did on another agent's behalf; `root_id` is the top of that tree
+  -- and is set even on roots (to their own id) so one indexed equality fetches
+  -- a whole multi-agent turn without a recursive query.
+  parent_id TEXT,
+  root_id TEXT NOT NULL,
+
+  started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ended_at DATETIME,
+  -- Measured in the Worker rather than derived from the two timestamps: D1
+  -- stores these at second resolution, and most tool calls finish inside one.
+  duration_ms INTEGER,
+
+  -- JSON. Redacted, size-capped view of the arguments and of what the call
+  -- touched (entity ids, file keys, campaign ids). Never the raw tool input:
+  -- the wrapper injects the caller's JWT into args before execute, so a
+  -- verbatim copy would persist credentials. See summarizeToolInput().
+  summary TEXT,
+  -- Failure message, already truncated. Null on success.
+  error TEXT
+);
+
+-- The dashboard's primary read: this user's recent activity, newest first.
+CREATE INDEX IF NOT EXISTS idx_agent_activity_user_started
+  ON agent_activity(username, started_at DESC);
+
+-- Per-campaign feed (#273) and per-agent attribution badges (#281).
+CREATE INDEX IF NOT EXISTS idx_agent_activity_campaign_started
+  ON agent_activity(campaign_id, started_at DESC);
+
+-- "What is this conversation doing right now" — the live view for one thread.
+CREATE INDEX IF NOT EXISTS idx_agent_activity_session_started
+  ON agent_activity(session_id, started_at DESC);
+
+-- Fetch a whole delegation tree in one query.
+CREATE INDEX IF NOT EXISTS idx_agent_activity_root
+  ON agent_activity(root_id);
+
+-- The retention sweep deletes by age across all users, so it needs started_at
+-- as a leading column on its own — the composite indexes above cannot serve it.
+CREATE INDEX IF NOT EXISTS idx_agent_activity_started_at
+  ON agent_activity(started_at);

--- a/scripts/d1/d1-bootstrap.sql
+++ b/scripts/d1/d1-bootstrap.sql
@@ -1223,3 +1223,82 @@ CREATE INDEX IF NOT EXISTS idx_llm_result_cache_created
 -- a tier change, both scan by these two columns.
 CREATE INDEX IF NOT EXISTS idx_llm_result_cache_kind_model
   ON llm_result_cache(kind, model);
+
+-- Append-only record of agent actions (issue #739).
+--
+-- Five stalled issues — #273 (agent dashboard), #276 (autonomy levels), #277
+-- (interrupt controls), #279 (guided flows), #281 (multi-agent visualization) —
+-- each need the same thing and none of them had it: a durable, queryable trace
+-- of what an agent did. Tool results flow back through `streamText` into the
+-- response stream and are then gone; the only surviving evidence that a tool
+-- ran was the chat transcript and whatever the tool itself wrote.
+--
+-- Rows are written from `BaseAgent.createEnhancedTools`, the one wrapper every
+-- agent's every tool call already passes through, so agents get this with no
+-- per-agent instrumentation.
+CREATE TABLE IF NOT EXISTS agent_activity (
+  id TEXT PRIMARY KEY,
+
+  -- Who acted, and on whose behalf. `username` is denormalized from the JWT
+  -- rather than joined through the session, because every read of this table is
+  -- scoped to one user and a dashboard cannot afford a join to prove ownership.
+  username TEXT NOT NULL,
+  agent_type TEXT NOT NULL,
+  -- Null for actions outside any campaign (library uploads, auth, help).
+  campaign_id TEXT,
+  -- The Durable Object id of the conversation, i.e. one chat thread.
+  session_id TEXT NOT NULL,
+
+  -- 'tool_call' | 'delegation'. Deliberately coarser than the tool name so a
+  -- future non-tool action (a generation step, an indexing pass) has somewhere
+  -- to land without a migration.
+  action_type TEXT NOT NULL,
+  tool_name TEXT,
+
+  -- 'running' | 'succeeded' | 'failed' | 'cancelled' | 'awaiting_approval'.
+  -- The last two are unused by this change and exist because #277 and #276 are
+  -- a status value plus a check, not a schema change, once they are here.
+  status TEXT NOT NULL,
+
+  -- Parent/child linkage. `parent_id` is the delegating action for work a
+  -- delegate did on another agent's behalf; `root_id` is the top of that tree
+  -- and is set even on roots (to their own id) so one indexed equality fetches
+  -- a whole multi-agent turn without a recursive query.
+  parent_id TEXT,
+  root_id TEXT NOT NULL,
+
+  started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ended_at DATETIME,
+  -- Measured in the Worker rather than derived from the two timestamps: D1
+  -- stores these at second resolution, and most tool calls finish inside one.
+  duration_ms INTEGER,
+
+  -- JSON. Redacted, size-capped view of the arguments and of what the call
+  -- touched (entity ids, file keys, campaign ids). Never the raw tool input:
+  -- the wrapper injects the caller's JWT into args before execute, so a
+  -- verbatim copy would persist credentials. See summarizeToolInput().
+  summary TEXT,
+  -- Failure message, already truncated. Null on success.
+  error TEXT
+);
+
+-- The dashboard's primary read: this user's recent activity, newest first.
+CREATE INDEX IF NOT EXISTS idx_agent_activity_user_started
+  ON agent_activity(username, started_at DESC);
+
+-- Per-campaign feed (#273) and per-agent attribution badges (#281).
+CREATE INDEX IF NOT EXISTS idx_agent_activity_campaign_started
+  ON agent_activity(campaign_id, started_at DESC);
+
+-- "What is this conversation doing right now" — the live view for one thread.
+CREATE INDEX IF NOT EXISTS idx_agent_activity_session_started
+  ON agent_activity(session_id, started_at DESC);
+
+-- Fetch a whole delegation tree in one query.
+CREATE INDEX IF NOT EXISTS idx_agent_activity_root
+  ON agent_activity(root_id);
+
+-- The retention sweep deletes by age across all users, so it needs started_at
+-- as a leading column on its own — the composite indexes above cannot serve it.
+CREATE INDEX IF NOT EXISTS idx_agent_activity_started_at
+  ON agent_activity(started_at);

--- a/scripts/wiki/sync-docs-to-wiki.js
+++ b/scripts/wiki/sync-docs-to-wiki.js
@@ -135,6 +135,11 @@ const FILE_MAPPINGS = [
 		process: true,
 	},
 	{
+		src: "docs/AGENT_ACTIVITY.md",
+		dest: "Technical/Agent-Activity-Log.md",
+		process: true,
+	},
+	{
 		src: "docs/TOOL_SYSTEM.md",
 		dest: "Technical/Tool-System.md",
 		process: true,
@@ -338,6 +343,7 @@ function createSidebar() {
 
 ## Agents & Tools
 - [[Technical/Agent-Design|Agent design]]
+- [[Technical/Agent-Activity-Log|Agent activity log]]
 - [[Technical/Tool-System|Tool system]]
 - [[Technical/Tool-Patterns|Tool patterns]]
 

--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -56,6 +56,11 @@ import {
 } from "@/lib/token-utils";
 import { buildToolReceiptsFromSteps } from "@/lib/tool-receipt-builder";
 import { trimToolResultsByRelevancy } from "@/lib/tool-result-trimming";
+import {
+	type AgentActivityContext,
+	AgentActivityRecorder,
+	withActivityRecording,
+} from "@/services/agent-activity/agent-activity-recorder";
 import { RulesContextService } from "@/services/campaign/rules-context-service";
 import { AuthService } from "@/services/core/auth-service";
 import { EmailService } from "@/services/core/email-service";
@@ -1521,6 +1526,9 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 		clientJwt: string | null;
 		selectedCampaignId: string | null;
 		claimedPlayerContext?: ResolvedClaimedPlayerContext | null;
+		/** The delegating agent's recorder and the row for its `askAnotherAgent` call. */
+		parentRecorder?: AgentActivityRecorder | null;
+		parentActivityId?: string | null;
 	}): Promise<DelegatedAgentResult> {
 		const log = createLogger(
 			this.env as Record<string, unknown>,
@@ -1541,6 +1549,16 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 		}
 
 		const toolsUsed: string[] = [];
+		// The delegate's actions are recorded as the delegate's, not the caller's,
+		// and hang under the `askAnotherAgent` row — which is the join #281 renders
+		// as "which agent did what" without any agent knowing it is being watched.
+		const activityContext =
+			params.parentRecorder && params.parentActivityId
+				? params.parentRecorder.childContext(
+						params.parentActivityId,
+						params.agentType
+					)
+				: null;
 		const enhancedTools = this.createEnhancedTools(
 			params.clientJwt,
 			params.selectedCampaignId,
@@ -1549,6 +1567,7 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 			{
 				onToolStart: (toolName) => toolsUsed.push(toolName),
 				allowDelegation: false,
+				activityContext,
 			},
 			params.claimedPlayerContext
 		);
@@ -1585,6 +1604,8 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 		selectedCampaignId: string | null;
 		campaignRole: CampaignRole | null;
 		claimedPlayerContext?: ResolvedClaimedPlayerContext | null;
+		/** This turn's activity recorder, so the delegate's work links to ours. */
+		recorder?: AgentActivityRecorder | null;
 	}): Record<string, any> {
 		let catalog: Array<{ agent: string; description: string }>;
 		try {
@@ -1602,7 +1623,7 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 		return {
 			askAnotherAgent: createAskAnotherAgentTool({
 				catalog,
-				run: ({ agentType, request }) =>
+				run: ({ agentType, request, parentActivityId }) =>
 					this.runDelegatedAgent({
 						agentType,
 						request,
@@ -1610,6 +1631,8 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 						clientJwt: context.clientJwt,
 						selectedCampaignId: context.selectedCampaignId,
 						claimedPlayerContext: context.claimedPlayerContext,
+						parentRecorder: context.recorder ?? null,
+						parentActivityId: parentActivityId ?? null,
 					}),
 			}),
 		};
@@ -1629,6 +1652,11 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 			/** False while running as someone else's delegate, so handoffs cannot nest. */
 			allowDelegation?: boolean;
 			campaignRole?: CampaignRole | null;
+			/**
+			 * Set only when running as a delegate, to attribute the delegate's
+			 * actions to it and hang them under the delegating call (issue #739).
+			 */
+			activityContext?: AgentActivityContext | null;
 		},
 		claimedPlayerContext?: ResolvedClaimedPlayerContext | null
 	): Record<string, any> {
@@ -1636,6 +1664,20 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 			this.env as Record<string, unknown>,
 			`[${this.constructor.name}]`
 		);
+
+		// One recorder per tool set, so every tool this agent runs this turn is
+		// logged with no per-tool or per-agent instrumentation. Null whenever the
+		// log is off, there is no D1 binding, or the turn is unauthenticated.
+		const recorder = AgentActivityRecorder.create(
+			this.env as unknown as Record<string, unknown>,
+			options?.activityContext ?? {
+				username: parseUsernameFromClientJwt(clientJwt),
+				agentType: this.getAgentType() ?? this.constructor.name,
+				campaignId: selectedCampaignId,
+				sessionId: this.ctx?.id?.toString() ?? "",
+			}
+		);
+
 		const baseTools = toolsOverride ?? this.tools;
 		const tools = {
 			...baseTools,
@@ -1647,6 +1689,7 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 						selectedCampaignId,
 						campaignRole: options?.campaignRole ?? null,
 						claimedPlayerContext,
+						recorder,
 					})),
 		};
 		// Track tool calls to prevent infinite loops
@@ -1658,262 +1701,281 @@ export abstract class BaseAgent extends SimpleChatAgent<Env> {
 					toolName,
 					{
 						...tool,
-						execute: async (args: any, context: any) => {
-							options?.onToolStart?.(toolName);
+						/**
+						 * Wrapped so the activity record covers every exit path —
+						 * including the loop guard and the stale-command block below,
+						 * which return a failure envelope rather than throwing and would
+						 * otherwise look successful in the log (issue #739).
+						 *
+						 * The raw `args` are what get summarized, deliberately: the
+						 * enhancement step below injects the caller's JWT, and the log is
+						 * a display surface.
+						 */
+						execute: withActivityRecording(
+							recorder,
+							toolName,
+							async (args: any, context: any, activityId: string | null) => {
+								options?.onToolStart?.(toolName);
 
-							// Check for infinite loops
-							const callKey = `${toolName}_${JSON.stringify(args)}`;
-							const currentCount = toolCallCounts.get(callKey) || 0;
-							if (currentCount > 2) {
-								log.warn(
-									`Tool ${toolName} called ${currentCount} times, preventing infinite loop`
-								);
-								return {
-									toolCallId: context?.toolCallId || "unknown",
-									result: {
-										success: false,
-										message: `Tool ${toolName} called too many times, stopping to prevent infinite loop`,
-										data: null,
-									},
-								};
-							}
-							toolCallCounts.set(callKey, currentCount + 1);
-
-							// Ensure JWT is always included for operations that require it
-							const enhancedArgs = { ...args };
-
-							// Resolve schema for param checks: AI SDK v5 uses .parameters, v6 uses .inputSchema (Zod has .shape)
-							const schema =
-								(tool as any).inputSchema ?? (tool as any).parameters;
-							const shape =
-								schema &&
-								typeof schema === "object" &&
-								"shape" in schema &&
-								(schema as any).shape;
-
-							const hasJwtParam = !!shape && "jwt" in shape;
-							if (hasJwtParam) {
-								// Always use client JWT when available; never trust LLM-provided jwt (often invalid/placeholder)
-								if (clientJwt) {
-									enhancedArgs.jwt = clientJwt;
-								} else if (!("jwt" in enhancedArgs)) {
-									enhancedArgs.jwt = null;
-								}
-							}
-
-							const hasCampaignIdParam = !!shape && "campaignId" in shape;
-							if (hasCampaignIdParam && selectedCampaignId) {
-								// Always use the selectedCampaignId from the current message, overriding any LLM-provided value
-								const previousCampaignId = enhancedArgs.campaignId;
-								enhancedArgs.campaignId = selectedCampaignId;
-								if (
-									previousCampaignId &&
-									previousCampaignId !== selectedCampaignId
-								) {
-									log.debug(
-										"Overriding inferred campaignId with selected campaign",
-										{
-											toolName,
-										}
+								// Check for infinite loops
+								const callKey = `${toolName}_${JSON.stringify(args)}`;
+								const currentCount = toolCallCounts.get(callKey) || 0;
+								if (currentCount > 2) {
+									log.warn(
+										`Tool ${toolName} called ${currentCount} times, preventing infinite loop`
 									);
-								}
-							}
-
-							const hasSessionIdParam = !!shape && "sessionId" in shape;
-
-							if (hasSessionIdParam) {
-								if (toolName === "getMessageHistory") {
-									const ghArgs = enhancedArgs as {
-										historyScope?: string;
-										sessionId?: string;
-										campaignId?: string | null;
+									return {
+										toolCallId: context?.toolCallId || "unknown",
+										result: {
+											success: false,
+											message: `Tool ${toolName} called too many times, stopping to prevent infinite loop`,
+											data: null,
+										},
 									};
-									let historyScope = normalizeMessageHistoryScope(
-										ghArgs.historyScope
-									);
-									const hasCampaign = Boolean(
-										selectedCampaignId ||
-											(typeof ghArgs.campaignId === "string" &&
-												ghArgs.campaignId.length > 0)
-									);
-									if (historyScope === "campaign" && !hasCampaign) {
-										ghArgs.historyScope = "current_session";
-										historyScope = "current_session";
+								}
+								toolCallCounts.set(callKey, currentCount + 1);
+
+								// Ensure JWT is always included for operations that require it
+								const enhancedArgs = { ...args };
+
+								// Resolve schema for param checks: AI SDK v5 uses .parameters, v6 uses .inputSchema (Zod has .shape)
+								const schema =
+									(tool as any).inputSchema ?? (tool as any).parameters;
+								const shape =
+									schema &&
+									typeof schema === "object" &&
+									"shape" in schema &&
+									(schema as any).shape;
+
+								const hasJwtParam = !!shape && "jwt" in shape;
+								if (hasJwtParam) {
+									// Always use client JWT when available; never trust LLM-provided jwt (often invalid/placeholder)
+									if (clientJwt) {
+										enhancedArgs.jwt = clientJwt;
+									} else if (!("jwt" in enhancedArgs)) {
+										enhancedArgs.jwt = null;
 									}
+								}
+
+								const hasCampaignIdParam = !!shape && "campaignId" in shape;
+								if (hasCampaignIdParam && selectedCampaignId) {
+									// Always use the selectedCampaignId from the current message, overriding any LLM-provided value
+									const previousCampaignId = enhancedArgs.campaignId;
+									enhancedArgs.campaignId = selectedCampaignId;
 									if (
-										historyScope === "current_session" &&
-										!enhancedArgs.sessionId
+										previousCampaignId &&
+										previousCampaignId !== selectedCampaignId
 									) {
+										log.debug(
+											"Overriding inferred campaignId with selected campaign",
+											{
+												toolName,
+											}
+										);
+									}
+								}
+
+								const hasSessionIdParam = !!shape && "sessionId" in shape;
+
+								if (hasSessionIdParam) {
+									if (toolName === "getMessageHistory") {
+										const ghArgs = enhancedArgs as {
+											historyScope?: string;
+											sessionId?: string;
+											campaignId?: string | null;
+										};
+										let historyScope = normalizeMessageHistoryScope(
+											ghArgs.historyScope
+										);
+										const hasCampaign = Boolean(
+											selectedCampaignId ||
+												(typeof ghArgs.campaignId === "string" &&
+													ghArgs.campaignId.length > 0)
+										);
+										if (historyScope === "campaign" && !hasCampaign) {
+											ghArgs.historyScope = "current_session";
+											historyScope = "current_session";
+										}
+										if (
+											historyScope === "current_session" &&
+											!enhancedArgs.sessionId
+										) {
+											enhancedArgs.sessionId = this.ctx.id.toString();
+										}
+										if (
+											historyScope === "campaign" ||
+											historyScope === "account"
+										) {
+											delete enhancedArgs.sessionId;
+										}
+										if (historyScope === "account") {
+											delete enhancedArgs.campaignId;
+										}
+									} else if (!enhancedArgs.sessionId) {
 										enhancedArgs.sessionId = this.ctx.id.toString();
 									}
-									if (
-										historyScope === "campaign" ||
-										historyScope === "account"
-									) {
-										delete enhancedArgs.sessionId;
+								}
+
+								const claimedEntity = claimedPlayerContext?.entity;
+								if (claimedEntity && shape) {
+									if ("playerCharacterEntityId" in shape) {
+										enhancedArgs.playerCharacterEntityId = claimedEntity.id;
 									}
-									if (historyScope === "account") {
-										delete enhancedArgs.campaignId;
+									if ("claimedEntityId" in shape) {
+										enhancedArgs.claimedEntityId = claimedEntity.id;
 									}
-								} else if (!enhancedArgs.sessionId) {
-									enhancedArgs.sessionId = this.ctx.id.toString();
+									if ("playerCharacterName" in shape) {
+										enhancedArgs.playerCharacterName = claimedEntity.name;
+									}
 								}
-							}
 
-							const claimedEntity = claimedPlayerContext?.entity;
-							if (claimedEntity && shape) {
-								if ("playerCharacterEntityId" in shape) {
-									enhancedArgs.playerCharacterEntityId = claimedEntity.id;
-								}
-								if ("claimedEntityId" in shape) {
-									enhancedArgs.claimedEntityId = claimedEntity.id;
-								}
-								if ("playerCharacterName" in shape) {
-									enhancedArgs.playerCharacterName = claimedEntity.name;
-								}
-							}
-
-							// Pass sessionId and env in context for tools that need it (will be merged with existing enhancedContext below)
-							// Handle test environments where ctx.id might not exist
-							const sessionContext = {
-								sessionId: this.ctx?.id?.toString() || `session-${Date.now()}`,
-							};
-
-							if (hasCampaignIdParam && !selectedCampaignId) {
-								// Valid use case: User may not have a campaign selected but wants to interact with a specific campaign.
-								// In this case, we allow the LLM to infer the campaign ID from the user's request.
-								log.debug("No selected campaign ID for tool execution", {
-									toolName,
-								});
-							}
-
-							// Block mutating tools if the last user command is stale
-							// Note: Legacy shard tools removed - entity approval/rejection now handled via API routes
-							const mutatingTools = new Set([
-								"createShardsTool", // Keep for backward compatibility if still used
-							]);
-							if (staleGuard?.isStaleCommand && mutatingTools.has(toolName)) {
-								log.warn(
-									`Blocking mutating tool '${toolName}' due to stale user command`
-								);
-								return {
-									toolCallId: context?.toolCallId || "unknown",
-									result: {
-										success: false,
-										message:
-											"IGNORED_STALE_COMMAND: Mutating action was blocked because the originating user command is stale.",
-										data: null,
-									},
+								// Pass sessionId and env in context for tools that need it (will be merged with existing enhancedContext below)
+								// Handle test environments where ctx.id might not exist
+								const sessionContext = {
+									sessionId:
+										this.ctx?.id?.toString() || `session-${Date.now()}`,
 								};
-							}
 
-							if (!tool.execute) {
-								log.warn(`Tool ${toolName} has no execute function`);
-								return {
-									toolCallId: context?.toolCallId || "unknown",
-									result: {
-										success: false,
-										message: `Tool ${toolName} is not executable`,
-										data: null,
-									},
-								};
-							}
+								if (hasCampaignIdParam && !selectedCampaignId) {
+									// Valid use case: User may not have a campaign selected but wants to interact with a specific campaign.
+									// In this case, we allow the LLM to infer the campaign ID from the user's request.
+									log.debug("No selected campaign ID for tool execution", {
+										toolName,
+									});
+								}
 
-							// Pass environment and sessionId to tools that need it
-							const enhancedContext = {
-								...context,
-								env: this.env,
-								...sessionContext,
-								playerCharacter: claimedPlayerContext
-									? {
-											username: claimedPlayerContext.username,
-											role: claimedPlayerContext.role,
-											claim: claimedPlayerContext.claim,
-											entity: claimedPlayerContext.entity,
-										}
-									: null,
-							};
-							const toolResult = await tool.execute(
-								enhancedArgs,
-								enhancedContext
-							);
-							log.debug("Tool executed", { toolName });
-
-							// Trim tool results by relevancy if they're too large
-							// This prevents token overflow by keeping highest priority items
-							let trimmedResult = toolResult;
-							try {
-								const modelId =
-									this.model?.modelId ||
-									getGenerationModelForProvider("SESSION_PLANNING");
-								const contextLimit = getSafeContextLimit(modelId);
-
-								// Use a conservative limit for tool results: 30% of context limit
-								// This leaves room for system prompt, tools, messages, and response generation
-								const maxToolResultTokens = Math.floor(contextLimit * 0.3);
-
-								if (maxToolResultTokens > 0) {
-									trimmedResult = await trimToolResultsByRelevancy(
-										toolResult,
-										maxToolResultTokens,
-										this.env,
-										selectedCampaignId
+								// Block mutating tools if the last user command is stale
+								// Note: Legacy shard tools removed - entity approval/rejection now handled via API routes
+								const mutatingTools = new Set([
+									"createShardsTool", // Keep for backward compatibility if still used
+								]);
+								if (staleGuard?.isStaleCommand && mutatingTools.has(toolName)) {
+									log.warn(
+										`Blocking mutating tool '${toolName}' due to stale user command`
 									);
-								}
-							} catch (trimError) {
-								log.warn("Failed to trim tool result", trimError);
-								// Continue with original result if trimming fails
-							}
-
-							// Normalize results from ai.tool() to the expected ToolResult envelope
-							const normalized = (() => {
-								// If already in the expected envelope, use trimmed result so LLM gets trimmed content
-								if (
-									trimmedResult &&
-									typeof trimmedResult === "object" &&
-									"toolCallId" in trimmedResult &&
-									"result" in trimmedResult
-								) {
-									return trimmedResult as any;
-								}
-								if (
-									toolResult &&
-									typeof toolResult === "object" &&
-									"toolCallId" in toolResult &&
-									"result" in toolResult
-								) {
-									return toolResult as any;
+									return {
+										toolCallId: context?.toolCallId || "unknown",
+										result: {
+											success: false,
+											message:
+												"IGNORED_STALE_COMMAND: Mutating action was blocked because the originating user command is stale.",
+											data: null,
+										},
+									};
 								}
 
-								// Wrap plain results (use trimmed result)
-								const resultToWrap = trimmedResult;
-								const success =
-									resultToWrap &&
-									typeof resultToWrap === "object" &&
-									"success" in resultToWrap
-										? (resultToWrap as any).success
-										: true;
-								const message =
-									resultToWrap &&
-									typeof resultToWrap === "object" &&
-									"message" in resultToWrap
-										? (resultToWrap as any).message
-										: "ok";
-								const data =
-									resultToWrap &&
-									typeof resultToWrap === "object" &&
-									"data" in resultToWrap
-										? (resultToWrap as any).data
-										: resultToWrap;
+								if (!tool.execute) {
+									log.warn(`Tool ${toolName} has no execute function`);
+									return {
+										toolCallId: context?.toolCallId || "unknown",
+										result: {
+											success: false,
+											message: `Tool ${toolName} is not executable`,
+											data: null,
+										},
+									};
+								}
 
-								return {
-									toolCallId: enhancedContext?.toolCallId || "unknown",
-									result: { success, message, data },
+								// Pass environment and sessionId to tools that need it
+								const enhancedContext = {
+									...context,
+									env: this.env,
+									...sessionContext,
+									// Only `askAnotherAgent` reads this: it is the id of this
+									// call's activity row, which the delegate's own actions hang
+									// under so a multi-agent turn forms a tree (issue #739).
+									agentActivityId: activityId,
+									playerCharacter: claimedPlayerContext
+										? {
+												username: claimedPlayerContext.username,
+												role: claimedPlayerContext.role,
+												claim: claimedPlayerContext.claim,
+												entity: claimedPlayerContext.entity,
+											}
+										: null,
 								};
-							})();
+								const toolResult = await tool.execute(
+									enhancedArgs,
+									enhancedContext
+								);
+								log.debug("Tool executed", { toolName });
 
-							return normalized;
-						},
+								// Trim tool results by relevancy if they're too large
+								// This prevents token overflow by keeping highest priority items
+								let trimmedResult = toolResult;
+								try {
+									const modelId =
+										this.model?.modelId ||
+										getGenerationModelForProvider("SESSION_PLANNING");
+									const contextLimit = getSafeContextLimit(modelId);
+
+									// Use a conservative limit for tool results: 30% of context limit
+									// This leaves room for system prompt, tools, messages, and response generation
+									const maxToolResultTokens = Math.floor(contextLimit * 0.3);
+
+									if (maxToolResultTokens > 0) {
+										trimmedResult = await trimToolResultsByRelevancy(
+											toolResult,
+											maxToolResultTokens,
+											this.env,
+											selectedCampaignId
+										);
+									}
+								} catch (trimError) {
+									log.warn("Failed to trim tool result", trimError);
+									// Continue with original result if trimming fails
+								}
+
+								// Normalize results from ai.tool() to the expected ToolResult envelope
+								const normalized = (() => {
+									// If already in the expected envelope, use trimmed result so LLM gets trimmed content
+									if (
+										trimmedResult &&
+										typeof trimmedResult === "object" &&
+										"toolCallId" in trimmedResult &&
+										"result" in trimmedResult
+									) {
+										return trimmedResult as any;
+									}
+									if (
+										toolResult &&
+										typeof toolResult === "object" &&
+										"toolCallId" in toolResult &&
+										"result" in toolResult
+									) {
+										return toolResult as any;
+									}
+
+									// Wrap plain results (use trimmed result)
+									const resultToWrap = trimmedResult;
+									const success =
+										resultToWrap &&
+										typeof resultToWrap === "object" &&
+										"success" in resultToWrap
+											? (resultToWrap as any).success
+											: true;
+									const message =
+										resultToWrap &&
+										typeof resultToWrap === "object" &&
+										"message" in resultToWrap
+											? (resultToWrap as any).message
+											: "ok";
+									const data =
+										resultToWrap &&
+										typeof resultToWrap === "object" &&
+										"data" in resultToWrap
+											? (resultToWrap as any).data
+											: resultToWrap;
+
+									return {
+										toolCallId: enhancedContext?.toolCallId || "unknown",
+										result: { success, message, data },
+									};
+								})();
+
+								return normalized;
+							}
+						),
 					},
 				];
 			})

--- a/src/dao/agent-activity-dao.ts
+++ b/src/dao/agent-activity-dao.ts
@@ -1,0 +1,309 @@
+import { BaseDAOClass } from "@/dao/base-dao";
+import { parseSummary, serializeSummary } from "@/lib/agent-activity-summary";
+import type {
+	AgentActivityActionType,
+	AgentActivityQuery,
+	AgentActivityRecord,
+	AgentActivityStatus,
+	AgentActivitySummaryCounts,
+	StartAgentActivityInput,
+} from "@/types/agent-activity";
+import { AGENT_ACTIVITY_STATUS } from "@/types/agent-activity";
+import type { SqlParam, SqlParams } from "@/types/utils";
+
+/** Raw row shape, matching migration 0036. */
+export interface AgentActivityRow {
+	id: string;
+	username: string;
+	agent_type: string;
+	campaign_id: string | null;
+	session_id: string;
+	action_type: string;
+	tool_name: string | null;
+	status: string;
+	parent_id: string | null;
+	root_id: string;
+	started_at: string;
+	ended_at: string | null;
+	duration_ms: number | null;
+	summary: string | null;
+	error: string | null;
+}
+
+/**
+ * How long a row lives. Shorter than the 90-day cost ledger on purpose: this
+ * table gains a row per tool call rather than per turn, and its readers — a
+ * live dashboard, a "what did the agent just do" panel — care about the last
+ * few days. Anything needing a longer horizon should aggregate into telemetry.
+ */
+export const AGENT_ACTIVITY_RETENTION_DAYS = 14;
+
+/** Page size when a caller does not ask for one, and the ceiling if it does. */
+const DEFAULT_QUERY_LIMIT = 50;
+const MAX_QUERY_LIMIT = 200;
+
+/** A row queued for persistence, already merged to its latest known state. */
+export interface PendingAgentActivityWrite extends StartAgentActivityInput {
+	status: AgentActivityStatus;
+	endedAt: string | null;
+	durationMs: number | null;
+	error: string | null;
+}
+
+const SELECT_COLUMNS = `id, username, agent_type, campaign_id, session_id,
+       action_type, tool_name, status, parent_id, root_id,
+       started_at, ended_at, duration_ms, summary, error`;
+
+/**
+ * Persistence for the agent activity log (issue #739).
+ *
+ * Every method degrades to a no-op or an empty result when the table is absent.
+ * Merging to `main` deploys the Worker automatically but does not apply D1
+ * migrations, and this table is written from inside the tool-execution path —
+ * throwing during that window would not lose a log line, it would break every
+ * agent in production.
+ */
+export class AgentActivityDAO extends BaseDAOClass {
+	async isSchemaReady(): Promise<boolean> {
+		return this.hasTable("agent_activity");
+	}
+
+	/**
+	 * Write a batch of rows, inserting or updating each by id.
+	 *
+	 * An upsert rather than separate insert-on-start and update-on-finish calls,
+	 * because the recorder merges a row's start and finish in memory whenever
+	 * both happen before a flush — the common case for a fast tool. One
+	 * statement shape then covers "first write" and "second write" identically,
+	 * and replaying a batch is harmless.
+	 *
+	 * `started_at` and the identity columns are deliberately not updated on
+	 * conflict: a later write only ever learns how an action ended.
+	 */
+	async saveMany(rows: PendingAgentActivityWrite[]): Promise<void> {
+		if (rows.length === 0) return;
+		if (!(await this.isSchemaReady())) return;
+
+		const sql = `INSERT INTO agent_activity (
+        id, username, agent_type, campaign_id, session_id,
+        action_type, tool_name, status, parent_id, root_id,
+        started_at, ended_at, duration_ms, summary, error
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        status = excluded.status,
+        ended_at = excluded.ended_at,
+        duration_ms = excluded.duration_ms,
+        summary = COALESCE(excluded.summary, agent_activity.summary),
+        error = excluded.error`;
+
+		const statements = rows.map((row) =>
+			this.db
+				.prepare(sql)
+				.bind(
+					row.id,
+					row.username,
+					row.agentType,
+					row.campaignId,
+					row.sessionId,
+					row.actionType,
+					row.toolName,
+					row.status,
+					row.parentId,
+					row.rootId,
+					row.startedAt,
+					row.endedAt,
+					row.durationMs,
+					serializeSummary(row.summary),
+					row.error
+				)
+		);
+
+		await this.db.batch(statements);
+	}
+
+	/**
+	 * Read one user's activity, newest first.
+	 *
+	 * `username` is not optional on the query type, so there is no way to call
+	 * this without scoping to a caller — the row's denormalized username is the
+	 * whole authorization check, and losing it silently would leak other users'
+	 * campaigns.
+	 */
+	async query(options: AgentActivityQuery): Promise<AgentActivityRecord[]> {
+		if (!(await this.isSchemaReady())) return [];
+
+		const { where, params } = this.buildFilters(options);
+		const limit = Math.min(
+			Math.max(options.limit ?? DEFAULT_QUERY_LIMIT, 1),
+			MAX_QUERY_LIMIT
+		);
+		const offset = Math.max(options.offset ?? 0, 0);
+
+		const rows = await this.queryAll<AgentActivityRow>(
+			`SELECT ${SELECT_COLUMNS}
+         FROM agent_activity
+        ${where}
+        ORDER BY started_at DESC, rowid DESC
+        LIMIT ? OFFSET ?`,
+			[...params, limit, offset]
+		);
+
+		return rows.map(mapRowToRecord);
+	}
+
+	/**
+	 * Every action in one delegation tree, oldest first.
+	 *
+	 * Ordered ascending because a tree is read as a narrative — the delegating
+	 * call, then what the delegate did — unlike the reverse-chronological feed.
+	 */
+	async getTree(
+		rootId: string,
+		username: string
+	): Promise<AgentActivityRecord[]> {
+		if (!(await this.isSchemaReady())) return [];
+
+		const rows = await this.queryAll<AgentActivityRow>(
+			`SELECT ${SELECT_COLUMNS}
+         FROM agent_activity
+        WHERE root_id = ? AND username = ?
+        ORDER BY started_at ASC, rowid ASC`,
+			[rootId, username]
+		);
+
+		return rows.map(mapRowToRecord);
+	}
+
+	/**
+	 * Header counts over the same filters as `query`, minus paging.
+	 *
+	 * Two aggregate queries rather than counting the returned page: the page is
+	 * capped at 200 rows, so counting it would silently understate any window
+	 * busier than that.
+	 */
+	async getSummaryCounts(
+		options: AgentActivityQuery
+	): Promise<AgentActivitySummaryCounts> {
+		const empty: AgentActivitySummaryCounts = {
+			total: 0,
+			running: 0,
+			succeeded: 0,
+			failed: 0,
+			byAgentType: {},
+		};
+		if (!(await this.isSchemaReady())) return empty;
+
+		const { where, params } = this.buildFilters(options);
+
+		const [byStatus, byAgent] = await Promise.all([
+			this.queryAll<{ status: string; count: number }>(
+				`SELECT status, COUNT(*) AS count FROM agent_activity ${where} GROUP BY status`,
+				params
+			),
+			this.queryAll<{ agent_type: string; count: number }>(
+				`SELECT agent_type, COUNT(*) AS count FROM agent_activity ${where} GROUP BY agent_type`,
+				params
+			),
+		]);
+
+		const counts = { ...empty, byAgentType: {} as Record<string, number> };
+		for (const row of byStatus) {
+			const count = Number(row.count) || 0;
+			counts.total += count;
+			if (row.status === AGENT_ACTIVITY_STATUS.RUNNING) counts.running += count;
+			if (row.status === AGENT_ACTIVITY_STATUS.SUCCEEDED)
+				counts.succeeded += count;
+			if (row.status === AGENT_ACTIVITY_STATUS.FAILED) counts.failed += count;
+		}
+		for (const row of byAgent) {
+			counts.byAgentType[row.agent_type] = Number(row.count) || 0;
+		}
+		return counts;
+	}
+
+	/** Age-based eviction, run from the fast cron alongside the other sweeps. */
+	async pruneOldRows(
+		retentionDays: number = AGENT_ACTIVITY_RETENTION_DAYS
+	): Promise<number> {
+		if (!(await this.isSchemaReady())) return 0;
+		return this.executeReturningChanges(
+			`DELETE FROM agent_activity WHERE started_at < datetime('now', ?)`,
+			[`-${retentionDays} days`]
+		);
+	}
+
+	/**
+	 * Close out rows left `running` by a Worker that died mid-tool-call.
+	 *
+	 * Without this the dashboard shows perpetual in-flight work: the finish
+	 * write is best-effort by design, so an eviction or an unhandled crash
+	 * strands the row. Marked `failed`, not `cancelled` — nobody asked for it to
+	 * stop, it simply never came back.
+	 */
+	async failStaleRunningRows(olderThanMinutes = 30): Promise<number> {
+		if (!(await this.isSchemaReady())) return 0;
+		return this.executeReturningChanges(
+			`UPDATE agent_activity
+          SET status = ?, ended_at = datetime('now'), error = ?
+        WHERE status = ? AND started_at < datetime('now', ?)`,
+			[
+				AGENT_ACTIVITY_STATUS.FAILED,
+				"Abandoned: no completion recorded",
+				AGENT_ACTIVITY_STATUS.RUNNING,
+				`-${olderThanMinutes} minutes`,
+			]
+		);
+	}
+
+	/** Shared WHERE builder so the list and its counts can never drift apart. */
+	private buildFilters(options: AgentActivityQuery): {
+		where: string;
+		params: SqlParams;
+	} {
+		const conditions: string[] = ["username = ?"];
+		const params: SqlParam[] = [options.username];
+
+		if (options.campaignId) {
+			conditions.push("campaign_id = ?");
+			params.push(options.campaignId);
+		}
+		if (options.sessionId) {
+			conditions.push("session_id = ?");
+			params.push(options.sessionId);
+		}
+		if (options.agentType) {
+			conditions.push("agent_type = ?");
+			params.push(options.agentType);
+		}
+		if (options.status) {
+			conditions.push("status = ?");
+			params.push(options.status);
+		}
+		if (options.since) {
+			conditions.push("started_at >= ?");
+			params.push(options.since);
+		}
+
+		return { where: `WHERE ${conditions.join(" AND ")}`, params };
+	}
+}
+
+export function mapRowToRecord(row: AgentActivityRow): AgentActivityRecord {
+	return {
+		id: row.id,
+		username: row.username,
+		agentType: row.agent_type,
+		campaignId: row.campaign_id,
+		sessionId: row.session_id,
+		actionType: row.action_type as AgentActivityActionType,
+		toolName: row.tool_name,
+		status: row.status as AgentActivityStatus,
+		parentId: row.parent_id,
+		rootId: row.root_id,
+		startedAt: row.started_at,
+		endedAt: row.ended_at,
+		durationMs: row.duration_ms,
+		summary: parseSummary(row.summary),
+		error: row.error,
+	};
+}

--- a/src/dao/dao-factory.ts
+++ b/src/dao/dao-factory.ts
@@ -9,6 +9,7 @@ import { EntityGraphService } from "@/services/graph/entity-graph-service";
 import { EntityImportanceService } from "@/services/graph/entity-importance-service";
 import { RebuildTriggerService } from "@/services/graph/rebuild-trigger-service";
 import { AdminAnalyticsDAO } from "./admin-analytics-dao";
+import { AgentActivityDAO } from "./agent-activity-dao";
 import { AuthUserDAO } from "./auth-user-dao";
 import { CampaignAudioDAO } from "./campaign-audio-dao";
 import { CampaignDAO } from "./campaign-dao";
@@ -58,6 +59,7 @@ export interface EnvWithDb {
 
 export interface DAOFactory {
 	adminAnalyticsDAO: AdminAnalyticsDAO;
+	agentActivityDAO: AgentActivityDAO;
 	authUserDAO: AuthUserDAO;
 	userDAO: UserDAO;
 	campaignDAO: CampaignDAO;
@@ -108,6 +110,7 @@ export interface DAOFactory {
 export class DAOFactoryImpl implements DAOFactory {
 	private readonly db: D1Database;
 	public readonly adminAnalyticsDAO: AdminAnalyticsDAO;
+	public readonly agentActivityDAO: AgentActivityDAO;
 	public readonly authUserDAO: AuthUserDAO;
 	public readonly userDAO: UserDAO;
 	public readonly campaignDAO: CampaignDAO;
@@ -153,6 +156,7 @@ export class DAOFactoryImpl implements DAOFactory {
 	constructor(db: D1Database) {
 		this.db = db;
 		this.adminAnalyticsDAO = new AdminAnalyticsDAO(db);
+		this.agentActivityDAO = new AgentActivityDAO(db);
 		this.authUserDAO = new AuthUserDAO(db);
 		this.userDAO = new UserDAO(db);
 		this.campaignDAO = new CampaignDAO(db);

--- a/src/lib/agent-activity-summary.ts
+++ b/src/lib/agent-activity-summary.ts
@@ -1,0 +1,244 @@
+import type { AgentActivitySummary } from "@/types/agent-activity";
+
+/**
+ * Turning tool arguments and results into something safe and small enough to
+ * keep forever.
+ *
+ * Two constraints drive everything here. First, the arguments reaching a tool
+ * are not the arguments the model produced: `BaseAgent.createEnhancedTools`
+ * injects the caller's JWT before calling `execute`, so a verbatim copy of the
+ * input would write a live credential into a table whose entire purpose is to
+ * be displayed. Second, tool results are routinely tens of kilobytes (search
+ * hits, entity dumps); storing them would make this table larger than the data
+ * it describes.
+ *
+ * So: drop secrets by key, truncate every value, cap the whole payload.
+ */
+
+/**
+ * Argument names never written to the log. Matched case-insensitively against
+ * the whole key, plus a substring pass for the `*Token` / `*Secret` families,
+ * because a tool added tomorrow will not consult this list.
+ */
+const REDACTED_KEYS = new Set([
+	"jwt",
+	"token",
+	"apikey",
+	"api_key",
+	"password",
+	"secret",
+	"authorization",
+	"auth",
+	"credentials",
+	"openaiapikey",
+	"anthropicapikey",
+]);
+
+const REDACTED_SUBSTRINGS = ["token", "secret", "password", "apikey"];
+
+/** Per-value cap. Long enough to identify a call, short enough to be free. */
+const MAX_VALUE_LENGTH = 120;
+/** Number of argument keys kept. Tools with more are already unusual. */
+const MAX_INPUT_KEYS = 12;
+/** Ids kept per kind. A bulk operation's first few are enough to attribute it. */
+const MAX_IDS_PER_KIND = 10;
+/** Hard cap on the serialized summary. Beyond this the row stops being cheap. */
+export const MAX_SUMMARY_BYTES = 2000;
+
+function isRedactedKey(key: string): boolean {
+	const lower = key.toLowerCase();
+	if (REDACTED_KEYS.has(lower)) return true;
+	return REDACTED_SUBSTRINGS.some((fragment) => lower.includes(fragment));
+}
+
+function truncate(value: string): string {
+	return value.length <= MAX_VALUE_LENGTH
+		? value
+		: `${value.slice(0, MAX_VALUE_LENGTH)}…`;
+}
+
+/** Render one argument value as a short string, whatever its type. */
+function stringifyValue(value: unknown): string {
+	if (value === null) return "null";
+	if (value === undefined) return "undefined";
+	if (typeof value === "string") return truncate(value);
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value);
+	}
+	if (Array.isArray(value)) {
+		return truncate(`[${value.length} item${value.length === 1 ? "" : "s"}]`);
+	}
+	try {
+		return truncate(JSON.stringify(value) ?? "");
+	} catch {
+		return "[unserializable]";
+	}
+}
+
+/**
+ * Redacted argument map for the log.
+ *
+ * Redacted keys are kept with a `[redacted]` placeholder rather than dropped:
+ * "this call carried a JWT" is useful when reading the log, and silently
+ * omitting the key would make an audited action look unauthenticated.
+ */
+export function summarizeToolInput(args: unknown): Record<string, string> {
+	if (!args || typeof args !== "object" || Array.isArray(args)) return {};
+
+	const entries = Object.entries(args as Record<string, unknown>).slice(
+		0,
+		MAX_INPUT_KEYS
+	);
+
+	const out: Record<string, string> = {};
+	for (const [key, value] of entries) {
+		out[key] = isRedactedKey(key) ? "[redacted]" : stringifyValue(value);
+	}
+	return out;
+}
+
+/** Keys whose values are collected as touched ids, by kind. */
+const ID_FIELDS: Array<{
+	kind: keyof NonNullable<AgentActivitySummary["touched"]>;
+	keys: string[];
+}> = [
+	{ kind: "entityIds", keys: ["id", "entityId", "entityIds"] },
+	{ kind: "fileKeys", keys: ["fileKey", "fileKeys", "file_key"] },
+	{ kind: "campaignIds", keys: ["campaignId", "campaign_id"] },
+	{ kind: "shardIds", keys: ["shardId", "shardIds", "shard_id"] },
+];
+
+/** How deep into a result object to look for ids before giving up. */
+const MAX_SCAN_DEPTH = 4;
+/** Objects visited per scan. Bounds the cost on a large search result. */
+const MAX_SCAN_NODES = 400;
+
+/**
+ * Walk a tool result collecting the ids it mentions.
+ *
+ * Deliberately a heuristic over field names rather than a per-tool contract:
+ * the point of writing from the shared wrapper is that no tool has to opt in,
+ * and a per-tool mapping would be exactly the per-agent instrumentation this
+ * primitive exists to avoid. Missing an id costs a dimmer badge in the UI;
+ * requiring 200 tools to declare their outputs costs the feature.
+ */
+export function collectTouchedIds(
+	value: unknown
+): AgentActivitySummary["touched"] {
+	const found = new Map<string, Set<string>>();
+	let visited = 0;
+
+	const push = (kind: string, id: unknown) => {
+		if (typeof id !== "string" || !id) return;
+		const set = found.get(kind) ?? new Set<string>();
+		if (set.size >= MAX_IDS_PER_KIND) return;
+		set.add(truncate(id));
+		found.set(kind, set);
+	};
+
+	const walk = (node: unknown, depth: number): void => {
+		if (depth > MAX_SCAN_DEPTH || visited >= MAX_SCAN_NODES) return;
+		if (!node || typeof node !== "object") return;
+		visited += 1;
+
+		if (Array.isArray(node)) {
+			for (const item of node) walk(item, depth + 1);
+			return;
+		}
+
+		const record = node as Record<string, unknown>;
+		for (const { kind, keys } of ID_FIELDS) {
+			for (const key of keys) {
+				const raw = record[key];
+				if (Array.isArray(raw)) {
+					for (const item of raw) push(kind, item);
+				} else {
+					push(kind, raw);
+				}
+			}
+		}
+
+		for (const child of Object.values(record)) walk(child, depth + 1);
+	};
+
+	walk(value, 0);
+
+	if (found.size === 0) return undefined;
+	const touched: Record<string, string[]> = {};
+	for (const [kind, ids] of found) touched[kind] = [...ids];
+	return touched as AgentActivitySummary["touched"];
+}
+
+/** The tool's own message, when its result carries one. */
+function extractMessage(result: unknown): string | undefined {
+	if (!result || typeof result !== "object") return undefined;
+	const envelope = result as Record<string, unknown>;
+	const inner = envelope.result;
+	const source =
+		inner && typeof inner === "object"
+			? (inner as Record<string, unknown>)
+			: envelope;
+	const message = source.message;
+	return typeof message === "string" && message ? truncate(message) : undefined;
+}
+
+/**
+ * Merge the start-time input summary with what the result revealed.
+ *
+ * Applied at finish rather than replacing the start summary, so a row that is
+ * read while still running already says what it was asked to do.
+ */
+export function summarizeToolResult(
+	result: unknown,
+	base?: AgentActivitySummary | null
+): AgentActivitySummary {
+	const summary: AgentActivitySummary = { ...(base ?? {}) };
+
+	const touched = collectTouchedIds(result);
+	if (touched) {
+		summary.touched = { ...(summary.touched ?? {}), ...touched };
+	}
+
+	const message = extractMessage(result);
+	if (message) summary.message = message;
+
+	return summary;
+}
+
+/**
+ * Serialize a summary for storage, shedding detail until it fits.
+ *
+ * The cap has to hold even against a pathological single argument, so the
+ * fallback drops the input map entirely rather than returning something over
+ * budget. A truncated JSON string is not an option — the read path parses it.
+ */
+export function serializeSummary(
+	summary: AgentActivitySummary | null | undefined
+): string | null {
+	if (!summary) return null;
+
+	const attempts: AgentActivitySummary[] = [
+		summary,
+		{ touched: summary.touched, message: summary.message },
+		{ message: summary.message },
+	];
+
+	for (const attempt of attempts) {
+		const json = JSON.stringify(attempt);
+		if (json && json.length <= MAX_SUMMARY_BYTES) return json;
+	}
+	return null;
+}
+
+/** Parse a stored summary, treating anything malformed as absent. */
+export function parseSummary(raw: string | null): AgentActivitySummary | null {
+	if (!raw) return null;
+	try {
+		const parsed = JSON.parse(raw);
+		return parsed && typeof parsed === "object"
+			? (parsed as AgentActivitySummary)
+			: null;
+	} catch {
+		return null;
+	}
+}

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -395,6 +395,21 @@ async function runFastScheduledTasks(
 		log.error("Failed to prune LLM usage log", error);
 	}
 
+	// Agent activity gains a row per tool call, so it is swept on the fast cron
+	// rather than left to grow. The second call closes out rows stranded
+	// `running` by a Worker that died mid-call — the finish write is best-effort
+	// by design, so without this the dashboard shows work that never ends.
+	try {
+		const daoFactory = getDAOFactory(env);
+		await daoFactory.agentActivityDAO.pruneOldRows();
+		const stranded = await daoFactory.agentActivityDAO.failStaleRunningRows();
+		if (stranded > 0) {
+			log.info("agent_activity_stale_rows_closed", { rows: stranded });
+		}
+	} catch (error) {
+		log.error("agent_activity_sweep_failed", error);
+	}
+
 	const processor = new FileProcessingQueue(env);
 	await processor.cleanupStaging();
 

--- a/src/routes/agent-activity.ts
+++ b/src/routes/agent-activity.ts
@@ -1,0 +1,154 @@
+import type { Context } from "hono";
+import { getDAOFactory } from "@/dao/dao-factory";
+import { UserAuthenticationMissingError } from "@/lib/errors";
+import { getRequestLogger } from "@/lib/logger";
+import type { Env } from "@/routes/env";
+import type { AuthPayload } from "@/services/core/auth-service";
+import type { AgentActivityQuery } from "@/types/agent-activity";
+import { isAgentActivityStatus } from "@/types/agent-activity";
+
+/**
+ * Read API over the agent activity log (issue #739).
+ *
+ * Deliberately read-only. Rows are written from `BaseAgent`'s tool wrapper, so
+ * an endpoint that accepted them would be a way to forge a record of work that
+ * never happened — and the dashboard's whole value is that it is trustworthy.
+ */
+
+type ContextWithAuth = Context<{ Bindings: Env }> & {
+	userAuth?: AuthPayload;
+};
+
+function getUserAuth(c: ContextWithAuth): AuthPayload {
+	const userAuth = (c as any).userAuth as AuthPayload | undefined;
+	if (!userAuth) {
+		throw new UserAuthenticationMissingError();
+	}
+	return userAuth;
+}
+
+/**
+ * `requireUserJwt` already rejects anonymous callers, so a missing `userAuth`
+ * here means the handler was mounted or invoked without it. Answering 401
+ * rather than 500 keeps that honest — nothing is broken, the caller is just
+ * not signed in.
+ */
+function errorResponse(c: ContextWithAuth, error: unknown) {
+	if (error instanceof UserAuthenticationMissingError) {
+		return c.json({ error: error.message }, 401);
+	}
+	return c.json(
+		{ error: error instanceof Error ? error.message : "Internal server error" },
+		500
+	);
+}
+
+/**
+ * Build the query from the URL, pinning `username` to the authenticated caller.
+ *
+ * The username is never read from a parameter. It is the only authorization
+ * check on this table — rows carry it denormalized precisely so a read needs no
+ * join to prove ownership — so accepting it as input would make every other
+ * user's campaign activity a query string away.
+ */
+function parseQuery(c: ContextWithAuth, username: string): AgentActivityQuery {
+	const query: AgentActivityQuery = { username };
+
+	const campaignId = c.req.query("campaignId");
+	if (campaignId) query.campaignId = campaignId;
+
+	const sessionId = c.req.query("sessionId");
+	if (sessionId) query.sessionId = sessionId;
+
+	const agentType = c.req.query("agentType");
+	if (agentType) query.agentType = agentType;
+
+	const status = c.req.query("status");
+	if (isAgentActivityStatus(status)) query.status = status;
+
+	const since = c.req.query("since");
+	if (since) query.since = since;
+
+	const limit = Number.parseInt(c.req.query("limit") ?? "", 10);
+	if (Number.isFinite(limit)) query.limit = limit;
+
+	const offset = Number.parseInt(c.req.query("offset") ?? "", 10);
+	if (Number.isFinite(offset)) query.offset = offset;
+
+	return query;
+}
+
+/**
+ * GET /api/agent-activity
+ *
+ * The feed behind #273: this user's agent actions, newest first, filterable by
+ * campaign, session, agent type, and status.
+ */
+export async function handleListAgentActivity(c: ContextWithAuth) {
+	try {
+		const { username } = getUserAuth(c);
+		const dao = getDAOFactory(c.env).agentActivityDAO;
+		const activities = await dao.query(parseQuery(c, username));
+		return c.json({ activities });
+	} catch (error) {
+		getRequestLogger(c).error(
+			"[handleListAgentActivity] Failed to read agent activity",
+			error
+		);
+		return errorResponse(c, error);
+	}
+}
+
+/**
+ * GET /api/agent-activity/summary
+ *
+ * Counts over the same filters as the list, minus paging. Separate from the
+ * list because a dashboard header wants totals for the window, not for the page.
+ */
+export async function handleGetAgentActivitySummary(c: ContextWithAuth) {
+	try {
+		const { username } = getUserAuth(c);
+		const dao = getDAOFactory(c.env).agentActivityDAO;
+		const counts = await dao.getSummaryCounts(parseQuery(c, username));
+		return c.json(counts);
+	} catch (error) {
+		getRequestLogger(c).error(
+			"[handleGetAgentActivitySummary] Failed to summarize agent activity",
+			error
+		);
+		return errorResponse(c, error);
+	}
+}
+
+/**
+ * GET /api/agent-activity/tree/:rootId
+ *
+ * One turn's actions in order, including anything a delegate did on another
+ * agent's behalf — the join #281 renders as per-agent attribution.
+ */
+export async function handleGetAgentActivityTree(c: ContextWithAuth) {
+	try {
+		const { username } = getUserAuth(c);
+		const rootId = c.req.param("rootId");
+		if (!rootId) {
+			return c.json({ error: "rootId is required" }, 400);
+		}
+
+		const dao = getDAOFactory(c.env).agentActivityDAO;
+		const activities = await dao.getTree(rootId, username);
+		if (activities.length === 0) {
+			// Indistinguishable from "belongs to someone else", on purpose: the tree
+			// query is scoped by username, so a 404 here never confirms that an id
+			// exists for another user.
+			return c.json({ error: "Activity tree not found" }, 404);
+		}
+
+		return c.json({ activities });
+	} catch (error) {
+		getRequestLogger(c).error(
+			"[handleGetAgentActivityTree] Failed to read activity tree",
+			error
+		);
+		return errorResponse(c, error);
+	}
+}

--- a/src/routes/agent-activity/index.ts
+++ b/src/routes/agent-activity/index.ts
@@ -1,0 +1,33 @@
+import type { OpenAPIHono } from "@hono/zod-openapi";
+import type { Handler } from "hono";
+import type { RequestLogger } from "@/lib/logger";
+import {
+	handleGetAgentActivitySummary,
+	handleGetAgentActivityTree,
+	handleListAgentActivity,
+} from "@/routes/agent-activity";
+import {
+	routeGetAgentActivitySummary,
+	routeGetAgentActivityTree,
+	routeListAgentActivity,
+} from "@/routes/agent-activity/routes";
+import type { Env } from "@/routes/env";
+
+export function registerAgentActivityRoutes(
+	app: OpenAPIHono<{ Bindings: Env; Variables: { logger: RequestLogger } }>
+) {
+	// `/summary` before the list only for readability; Hono matches on method
+	// plus literal segment, so the three paths cannot collide.
+	app.openapi(
+		routeGetAgentActivitySummary,
+		handleGetAgentActivitySummary as unknown as Handler
+	);
+	app.openapi(
+		routeGetAgentActivityTree,
+		handleGetAgentActivityTree as unknown as Handler
+	);
+	app.openapi(
+		routeListAgentActivity,
+		handleListAgentActivity as unknown as Handler
+	);
+}

--- a/src/routes/agent-activity/routes.ts
+++ b/src/routes/agent-activity/routes.ts
@@ -1,0 +1,72 @@
+import { createRoute, z } from "@hono/zod-openapi";
+import { requireUserJwt } from "@/routes/auth";
+import { toApiRoutePath } from "@/routes/env";
+import { ErrorSchema } from "@/routes/schemas/common";
+import { API_CONFIG } from "@/shared-config";
+
+const E401 = {
+	401: {
+		content: { "application/json": { schema: ErrorSchema } },
+		description: "Unauthorized",
+	},
+} as const;
+const E500 = {
+	500: {
+		content: { "application/json": { schema: ErrorSchema } },
+		description: "Internal server error",
+	},
+} as const;
+const jsonDesc = (d: string) => ({
+	content: { "application/json": { schema: z.any() } } as const,
+	description: d,
+});
+
+/**
+ * Filters shared by the list and its summary. Declared once so the two can
+ * never accept different windows and report inconsistent numbers.
+ */
+const ActivityQuerySchema = z
+	.object({
+		campaignId: z.string().optional(),
+		sessionId: z.string().optional(),
+		agentType: z.string().optional(),
+		status: z.string().optional(),
+		since: z.string().optional(),
+		limit: z.string().optional(),
+		offset: z.string().optional(),
+	})
+	.openapi("AgentActivityQuery");
+
+export const routeListAgentActivity = createRoute({
+	method: "get",
+	path: toApiRoutePath(API_CONFIG.ENDPOINTS.AGENT_ACTIVITY.LIST),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	request: { query: ActivityQuerySchema },
+	responses: { 200: jsonDesc("Agent activity"), ...E401, ...E500 },
+});
+
+export const routeGetAgentActivitySummary = createRoute({
+	method: "get",
+	path: toApiRoutePath(API_CONFIG.ENDPOINTS.AGENT_ACTIVITY.SUMMARY),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	request: { query: ActivityQuerySchema },
+	responses: { 200: jsonDesc("Agent activity counts"), ...E401, ...E500 },
+});
+
+export const routeGetAgentActivityTree = createRoute({
+	method: "get",
+	// The builder takes a concrete id; the OpenAPI path needs Hono's placeholder,
+	// so it is called with the placeholder rather than duplicating the string.
+	path: toApiRoutePath(API_CONFIG.ENDPOINTS.AGENT_ACTIVITY.TREE(":rootId")),
+	middleware: [requireUserJwt],
+	security: [{ bearerAuth: [] }],
+	responses: {
+		200: jsonDesc("Activity tree"),
+		400: jsonDesc("Missing rootId"),
+		404: jsonDesc("Not found"),
+		...E401,
+		...E500,
+	},
+});

--- a/src/routes/endpoints.ts
+++ b/src/routes/endpoints.ts
@@ -371,6 +371,16 @@ export const ENDPOINTS = {
 	EXPERIMENTS: {
 		ASSIGNMENTS: "/experiments/assignments",
 	},
+	/**
+	 * The agent activity log (issue #739). Read-only: rows are written from the
+	 * agents' tool path, never by a client.
+	 */
+	AGENT_ACTIVITY: {
+		LIST: "/agent-activity",
+		SUMMARY: "/agent-activity/summary",
+		/** One delegation tree — an `askAnotherAgent` call and its delegate's work. */
+		TREE: (rootId: string) => `/agent-activity/tree/${rootId}`,
+	},
 	ADMIN: {
 		TELEMETRY: {
 			METRICS: "/admin/telemetry/metrics",

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIHono } from "@hono/zod-openapi";
 import type { RequestLogger } from "@/lib/logger";
+import { registerAgentActivityRoutes } from "@/routes/agent-activity/index";
 import { registerAppRoutes } from "@/routes/app/index";
 import { registerAssessmentRoutes } from "@/routes/assessment/index";
 import { registerAuthRoutes } from "@/routes/auth/index";
@@ -40,5 +41,6 @@ export function registerRoutes(
 	registerNotificationsRoutes(app);
 	registerUploadRoutes(app);
 	registerChatRoutes(app);
+	registerAgentActivityRoutes(app);
 	registerAppRoutes(app);
 }

--- a/src/services/agent-activity/agent-activity-recorder.ts
+++ b/src/services/agent-activity/agent-activity-recorder.ts
@@ -1,0 +1,377 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import {
+	AgentActivityDAO,
+	type PendingAgentActivityWrite,
+} from "@/dao/agent-activity-dao";
+import {
+	summarizeToolInput,
+	summarizeToolResult,
+} from "@/lib/agent-activity-summary";
+import type { EnvWithSecrets } from "@/lib/env-utils";
+import { createLogger } from "@/lib/logger";
+import { nanoid } from "@/lib/nanoid";
+import type {
+	AgentActivityActionType,
+	AgentActivityStatus,
+	AgentActivitySummary,
+} from "@/types/agent-activity";
+import { AGENT_ACTIVITY_STATUS } from "@/types/agent-activity";
+
+/** Env var gate. Unset defaults to enabled; set to a falsy value to turn off. */
+export const AGENT_ACTIVITY_ENV = "LORESMITH_AGENT_ACTIVITY_LOG";
+
+const FALSY_FLAG_VALUES = new Set(["0", "false", "no", "off"]);
+
+/** Longest error message kept on a row. */
+const MAX_ERROR_LENGTH = 500;
+
+/**
+ * Whether the activity log is enabled. Defaults to on; an explicit falsy value
+ * turns it off without a deploy, which matters because this writes from inside
+ * the tool-execution path of every agent.
+ */
+export function isAgentActivityLoggingEnabled(
+	env?: EnvWithSecrets | Record<string, unknown>
+): boolean {
+	const fromEnv = (env as Record<string, unknown> | undefined)?.[
+		AGENT_ACTIVITY_ENV
+	];
+	if (typeof fromEnv === "boolean") return fromEnv;
+
+	const fromProcess =
+		typeof process !== "undefined"
+			? process.env[AGENT_ACTIVITY_ENV]
+			: undefined;
+	const raw =
+		(typeof fromEnv === "string" ? fromEnv : undefined) ??
+		(typeof fromProcess === "string" ? fromProcess : undefined);
+
+	if (raw === undefined || raw.trim() === "") return true;
+	return !FALSY_FLAG_VALUES.has(raw.trim().toLowerCase());
+}
+
+/** Identity of the agent and turn a recorder is writing for. */
+export interface AgentActivityContext {
+	username: string;
+	agentType: string;
+	campaignId: string | null;
+	sessionId: string;
+	/**
+	 * The delegating action, when this recorder belongs to a delegate. Its row
+	 * becomes the parent of everything the delegate does, and carries the tree's
+	 * root forward.
+	 */
+	parentId?: string | null;
+	rootId?: string | null;
+}
+
+export interface BeginActivityInput {
+	actionType: AgentActivityActionType;
+	toolName: string | null;
+	/** Raw tool arguments. Redacted and truncated before anything is stored. */
+	input?: unknown;
+}
+
+export interface FinishActivityInput {
+	status: AgentActivityStatus;
+	/** Raw tool result, mined for touched ids and the tool's own message. */
+	result?: unknown;
+	error?: unknown;
+}
+
+/**
+ * Buffered writer for the agent activity log (issue #739).
+ *
+ * The issue's open question was write cost: a D1 round-trip per tool call, on
+ * the path a user is waiting on, twice (start and finish). The answer here is
+ * that nothing on the hot path is awaited.
+ *
+ * `begin` and `finish` only mutate an in-memory map and mark the row dirty.
+ * Flushes are chained onto a single promise, so any number of enqueues while a
+ * flush is in flight coalesce into the next one, and every flush drains
+ * everything dirty in one `db.batch()`. A tool that starts and finishes between
+ * two flushes — the common case for a fast tool — is written exactly once, with
+ * its final state, because the DAO's upsert makes "first write" and "second
+ * write" the same statement.
+ *
+ * Losing a row is acceptable and losing a turn is not, so every failure path
+ * logs and continues. `settle()` exists for tests and for callers that want the
+ * log durable before they return.
+ */
+export class AgentActivityRecorder {
+	private readonly dao: AgentActivityDAO;
+	private readonly context: AgentActivityContext;
+	private readonly log: ReturnType<typeof createLogger>;
+	private readonly rows = new Map<string, PendingAgentActivityWrite>();
+	private readonly dirty = new Set<string>();
+	private readonly startedAtMs = new Map<string, number>();
+	private flushChain: Promise<void> = Promise.resolve();
+
+	private constructor(
+		db: D1Database,
+		context: AgentActivityContext,
+		env: Record<string, unknown>
+	) {
+		this.dao = new AgentActivityDAO(db);
+		this.context = context;
+		this.log = createLogger(env, "[AgentActivity]");
+	}
+
+	/**
+	 * Build a recorder, or return null when there is nothing useful to write.
+	 *
+	 * A null recorder is the normal state in unit tests (no DB binding) and for
+	 * unauthenticated turns. Returning null rather than a silently inert object
+	 * keeps the "is this on?" check at one call site instead of inside every
+	 * method.
+	 */
+	static create(
+		env: Record<string, unknown> | undefined,
+		context: Omit<Partial<AgentActivityContext>, "username"> & {
+			/** Null on an unauthenticated turn, which is why it is not just optional. */
+			username: string | null;
+		}
+	): AgentActivityRecorder | null {
+		const db = (env as { DB?: D1Database } | undefined)?.DB;
+		if (!db) return null;
+		if (!isAgentActivityLoggingEnabled(env)) return null;
+
+		// A row is authorized by its username; one without an owner could never be
+		// read back, so writing it would only cost storage.
+		if (!context.username) return null;
+		if (!context.agentType || !context.sessionId) return null;
+
+		return new AgentActivityRecorder(
+			db,
+			{
+				username: context.username,
+				agentType: context.agentType,
+				campaignId: context.campaignId ?? null,
+				sessionId: context.sessionId,
+				parentId: context.parentId ?? null,
+				rootId: context.rootId ?? null,
+			},
+			env ?? {}
+		);
+	}
+
+	/** Record that an action started. Returns the row id to pass to `finish`. */
+	begin(input: BeginActivityInput): string {
+		const id = nanoid();
+		const now = new Date();
+
+		const summary: AgentActivitySummary = {};
+		const inputSummary = summarizeToolInput(input.input);
+		if (Object.keys(inputSummary).length > 0) summary.input = inputSummary;
+
+		this.rows.set(id, {
+			id,
+			username: this.context.username,
+			agentType: this.context.agentType,
+			campaignId: this.context.campaignId,
+			sessionId: this.context.sessionId,
+			actionType: input.actionType,
+			toolName: input.toolName,
+			status: AGENT_ACTIVITY_STATUS.RUNNING,
+			parentId: this.context.parentId ?? null,
+			// A root is its own root, so one indexed equality fetches the tree
+			// whether or not delegation happened.
+			rootId: this.context.rootId ?? id,
+			startedAt: now.toISOString(),
+			endedAt: null,
+			durationMs: null,
+			summary: Object.keys(summary).length > 0 ? summary : null,
+			error: null,
+		});
+		this.startedAtMs.set(id, now.getTime());
+		this.markDirty(id);
+		return id;
+	}
+
+	/** Record how an action ended. Unknown ids are ignored, never thrown on. */
+	finish(id: string, input: FinishActivityInput): void {
+		const row = this.rows.get(id);
+		if (!row) return;
+
+		const endedAt = new Date();
+		const startedAtMs = this.startedAtMs.get(id) ?? endedAt.getTime();
+
+		row.status = input.status;
+		row.endedAt = endedAt.toISOString();
+		row.durationMs = Math.max(0, endedAt.getTime() - startedAtMs);
+		row.error = formatError(input.error);
+		if (input.result !== undefined) {
+			row.summary = summarizeToolResult(input.result, row.summary);
+		}
+
+		this.markDirty(id);
+	}
+
+	/**
+	 * The context a delegate should record under: same user and campaign, its own
+	 * agent type, and this action as the parent.
+	 *
+	 * Falls back to treating the parent as the tree root when its row is no
+	 * longer buffered. That fallback is exact rather than approximate today,
+	 * because delegation cannot nest — `allowDelegation: false` is forced on a
+	 * delegate's toolset — so a delegating action is always its own root.
+	 */
+	childContext(parentId: string, agentType: string): AgentActivityContext {
+		const row = this.rows.get(parentId);
+		return {
+			username: this.context.username,
+			agentType,
+			campaignId: this.context.campaignId,
+			sessionId: this.context.sessionId,
+			parentId,
+			rootId: row?.rootId ?? parentId,
+		};
+	}
+
+	/** Wait for every queued write to land. For tests and end-of-turn flushes. */
+	async settle(): Promise<void> {
+		// Two awaits, not one: the first drains what is already queued, and the
+		// second covers anything enqueued while that flush was running.
+		await this.flushChain;
+		await this.flushChain;
+	}
+
+	private markDirty(id: string): void {
+		this.dirty.add(id);
+		this.scheduleFlush();
+	}
+
+	/**
+	 * Chain a flush behind whatever is already running. Not awaited by callers —
+	 * the whole point is that the user's turn never waits on the log.
+	 */
+	private scheduleFlush(): void {
+		this.flushChain = this.flushChain.then(() => this.flush());
+	}
+
+	private async flush(): Promise<void> {
+		if (this.dirty.size === 0) return;
+
+		const ids = [...this.dirty];
+		this.dirty.clear();
+		const batch = ids
+			.map((id) => this.rows.get(id))
+			.filter((row): row is PendingAgentActivityWrite => Boolean(row))
+			// Snapshot each row: `finish` mutates in place, and an in-flight write
+			// must not see half of the next state.
+			.map((row) => ({ ...row }));
+
+		try {
+			await this.dao.saveMany(batch);
+			// Terminal rows will never change again, so nothing needs their state
+			// after a successful write. Dropping them keeps a long turn's memory
+			// bounded by concurrent tool calls rather than total tool calls.
+			for (const row of batch) {
+				if (!this.dirty.has(row.id) && isTerminal(row.status)) {
+					this.rows.delete(row.id);
+					this.startedAtMs.delete(row.id);
+				}
+			}
+		} catch (error) {
+			this.log.warn("Failed to persist agent activity", {
+				rows: batch.length,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+}
+
+function isTerminal(status: AgentActivityStatus): boolean {
+	return status !== AGENT_ACTIVITY_STATUS.RUNNING;
+}
+
+/**
+ * The one tool whose row is a delegation rather than a plain call. Its children
+ * are whatever the delegate then did, which is what #281 renders as attribution.
+ */
+export const DELEGATION_TOOL_NAME = "askAnotherAgent";
+
+/**
+ * A tool reports failure by returning `{ result: { success: false } }`, not by
+ * throwing — the wrapper's own guards do exactly that for loop-limited and
+ * stale-command calls. Reading the envelope keeps those visible as failures in
+ * the log instead of silently succeeding.
+ */
+export function isSuccessfulToolResult(value: unknown): boolean {
+	if (!value || typeof value !== "object") return true;
+	const envelope = value as Record<string, unknown>;
+	const inner = envelope.result;
+	const source =
+		inner && typeof inner === "object"
+			? (inner as Record<string, unknown>)
+			: envelope;
+	return source.success !== false;
+}
+
+/**
+ * Wrap a tool's implementation so every call it serves is logged.
+ *
+ * A decorator rather than a call inside the implementation, because it lets
+ * `BaseAgent`'s tool wrapper stay one anonymous function instead of a named
+ * inner one plus a shim — the wrapper is long-standing grandfathered
+ * complexity, and renaming it would read to the complexity ratchet as brand
+ * new debt rather than the same code with a hat on.
+ *
+ * The `any`s match the AI SDK's untyped tool `execute` signature, which this
+ * has to reproduce exactly.
+ */
+export function withActivityRecording<T>(
+	recorder: AgentActivityRecorder | null,
+	toolName: string,
+	run: (args: any, context: any, activityId: string | null) => Promise<T>
+): (args: any, context: any) => Promise<T> {
+	return (args, context) =>
+		recordAgentActivity(recorder, { toolName, input: args }, (activityId) =>
+			run(args, context, activityId)
+		);
+}
+
+/**
+ * Run one action inside an activity record.
+ *
+ * Lives here rather than inline in the agent so the recording rules — which
+ * result maps to which status, what a thrown error does, that a null recorder
+ * changes nothing — are testable without standing up an agent.
+ */
+export async function recordAgentActivity<T>(
+	recorder: AgentActivityRecorder | null,
+	action: { toolName: string; input: unknown },
+	run: (activityId: string | null) => Promise<T>
+): Promise<T> {
+	if (!recorder) return run(null);
+
+	const activityId = recorder.begin({
+		actionType:
+			action.toolName === DELEGATION_TOOL_NAME ? "delegation" : "tool_call",
+		toolName: action.toolName,
+		input: action.input,
+	});
+
+	try {
+		const result = await run(activityId);
+		recorder.finish(activityId, {
+			status: isSuccessfulToolResult(result)
+				? AGENT_ACTIVITY_STATUS.SUCCEEDED
+				: AGENT_ACTIVITY_STATUS.FAILED,
+			result,
+		});
+		return result;
+	} catch (error) {
+		recorder.finish(activityId, {
+			status: AGENT_ACTIVITY_STATUS.FAILED,
+			error,
+		});
+		throw error;
+	}
+}
+
+function formatError(error: unknown): string | null {
+	if (error === undefined || error === null) return null;
+	const message = error instanceof Error ? error.message : String(error);
+	return message.slice(0, MAX_ERROR_LENGTH) || null;
+}

--- a/src/tools/common/agent-handoff-tools.ts
+++ b/src/tools/common/agent-handoff-tools.ts
@@ -29,6 +29,12 @@ export interface DelegatedAgentResult {
 export type DelegatedAgentRunner = (input: {
 	agentType: string;
 	request: string;
+	/**
+	 * Activity-log row for this delegation, when logging is on (issue #739).
+	 * The delegate's own actions are recorded as children of it, so a turn that
+	 * crossed agents can be read back as one tree.
+	 */
+	parentActivityId?: string | null;
 }) => Promise<DelegatedAgentResult>;
 
 export interface DelegationCatalogEntry {
@@ -113,9 +119,16 @@ export function createAskAnotherAgentTool(params: {
 			}
 
 			try {
+				// Injected by the tool wrapper in BaseAgent, not part of the AI SDK's
+				// options, hence the cast.
+				const parentActivityId =
+					(options as { agentActivityId?: string | null } | undefined)
+						?.agentActivityId ?? null;
+
 				const delegated = await run({
 					agentType: input.agentType,
 					request: input.request,
+					parentActivityId,
 				});
 
 				if (!delegated.answer.trim()) {

--- a/src/types/agent-activity.ts
+++ b/src/types/agent-activity.ts
@@ -1,0 +1,148 @@
+/**
+ * Agent activity log (issue #739).
+ *
+ * One append-only record of what agents did, written from the single tool
+ * wrapper in `BaseAgent`. Five stalled issues are views over or hooks into this
+ * shape: #273 and #281 read it, #276 and #277 add a status transition to it,
+ * #279 walks its parent/child linkage.
+ */
+
+/** Lifecycle of a single agent action. */
+export const AGENT_ACTIVITY_STATUS = {
+	/** Started, not yet resolved. The only non-terminal status today. */
+	RUNNING: "running",
+	SUCCEEDED: "succeeded",
+	FAILED: "failed",
+	/**
+	 * Reserved for #277 (interrupt controls): an action abandoned because the
+	 * user stopped the turn. Nothing writes it yet.
+	 */
+	CANCELLED: "cancelled",
+	/**
+	 * Reserved for #276 (autonomy levels): a write-capable action held at the
+	 * gate pending user approval. Nothing writes it yet.
+	 */
+	AWAITING_APPROVAL: "awaiting_approval",
+} as const;
+
+export type AgentActivityStatus =
+	(typeof AGENT_ACTIVITY_STATUS)[keyof typeof AGENT_ACTIVITY_STATUS];
+
+const STATUS_VALUES = new Set<string>(Object.values(AGENT_ACTIVITY_STATUS));
+
+export function isAgentActivityStatus(
+	value: unknown
+): value is AgentActivityStatus {
+	return typeof value === "string" && STATUS_VALUES.has(value);
+}
+
+/** Terminal statuses — an action in any other status is still in flight. */
+export function isTerminalAgentActivityStatus(
+	status: AgentActivityStatus
+): boolean {
+	return (
+		status === AGENT_ACTIVITY_STATUS.SUCCEEDED ||
+		status === AGENT_ACTIVITY_STATUS.FAILED ||
+		status === AGENT_ACTIVITY_STATUS.CANCELLED
+	);
+}
+
+/**
+ * What kind of action this row describes. Coarser than `toolName` on purpose:
+ * a future generation or indexing step needs a home here, not a migration.
+ */
+export const AGENT_ACTIVITY_ACTION_TYPE = {
+	TOOL_CALL: "tool_call",
+	/** An `askAnotherAgent` call — the parent of whatever the delegate then did. */
+	DELEGATION: "delegation",
+} as const;
+
+export type AgentActivityActionType =
+	(typeof AGENT_ACTIVITY_ACTION_TYPE)[keyof typeof AGENT_ACTIVITY_ACTION_TYPE];
+
+/**
+ * Redacted, size-capped description of one action. Never holds raw tool input:
+ * the tool wrapper injects the caller's JWT into arguments before execution, so
+ * a verbatim copy would persist a credential in a table built to be read by a
+ * dashboard.
+ */
+export interface AgentActivitySummary {
+	/** Argument names and truncated values, with secrets dropped. */
+	input?: Record<string, string>;
+	/** Ids the action read or wrote, by kind, for #281's attribution badges. */
+	touched?: {
+		entityIds?: string[];
+		fileKeys?: string[];
+		campaignIds?: string[];
+		shardIds?: string[];
+	};
+	/** The tool's own one-line message, when it returned one. */
+	message?: string;
+}
+
+/** One row, as the rest of the app sees it. */
+export interface AgentActivityRecord {
+	id: string;
+	username: string;
+	agentType: string;
+	campaignId: string | null;
+	sessionId: string;
+	actionType: AgentActivityActionType;
+	toolName: string | null;
+	status: AgentActivityStatus;
+	parentId: string | null;
+	rootId: string;
+	startedAt: string;
+	endedAt: string | null;
+	durationMs: number | null;
+	summary: AgentActivitySummary | null;
+	error: string | null;
+}
+
+/** Everything known when an action starts. */
+export interface StartAgentActivityInput {
+	id: string;
+	username: string;
+	agentType: string;
+	campaignId: string | null;
+	sessionId: string;
+	actionType: AgentActivityActionType;
+	toolName: string | null;
+	parentId: string | null;
+	rootId: string;
+	startedAt: string;
+	summary: AgentActivitySummary | null;
+}
+
+/** Everything learned when it resolves. */
+export interface FinishAgentActivityInput {
+	status: AgentActivityStatus;
+	endedAt: string;
+	durationMs: number;
+	summary?: AgentActivitySummary | null;
+	error?: string | null;
+}
+
+/** Filters accepted by the read path. */
+export interface AgentActivityQuery {
+	/** Always required: every read is scoped to the caller. */
+	username: string;
+	campaignId?: string;
+	sessionId?: string;
+	agentType?: string;
+	status?: AgentActivityStatus;
+	/** ISO timestamp; rows started strictly before this are excluded. */
+	since?: string;
+	limit?: number;
+	offset?: number;
+}
+
+/** Counts for the dashboard header (#273), over the same window as the list. */
+export interface AgentActivitySummaryCounts {
+	total: number;
+	running: number;
+	succeeded: number;
+	failed: number;
+	/** Action counts keyed by agent type — the raw material for #281. */
+	byAgentType: Record<string, number>;
+}

--- a/tests/agents/base-agent-activity.test.ts
+++ b/tests/agents/base-agent-activity.test.ts
@@ -1,0 +1,306 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PendingAgentActivityWrite } from "@/dao/agent-activity-dao";
+
+/**
+ * The activity log is written from `BaseAgent.createEnhancedTools`, the wrapper
+ * every agent's every tool call already passes through (issue #739). These
+ * tests exercise that path end to end: a tool call, a tool that throws, a tool
+ * blocked by the wrapper's own guards, and a delegation tree.
+ */
+
+const saveMany = vi.fn<(rows: PendingAgentActivityWrite[]) => Promise<void>>();
+
+vi.mock("@/dao/agent-activity-dao", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/dao/agent-activity-dao")>();
+	return {
+		...actual,
+		AgentActivityDAO: class {
+			saveMany(rows: PendingAgentActivityWrite[]) {
+				return saveMany(rows);
+			}
+		},
+	};
+});
+
+const generateTextMock = vi.fn();
+
+vi.mock("ai", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("ai")>();
+	return {
+		...actual,
+		generateText: (...args: unknown[]) => generateTextMock(...args),
+		stepCountIs: vi.fn((n: number) => n),
+	};
+});
+
+const { BaseAgent } = await import("@/agents/base-agent");
+const { AgentRouter } = await import("@/lib/agent-router");
+type AgentType = import("@/lib/agent-router").AgentType;
+
+/** A JWT the agent can read a username out of; only the payload is parsed. */
+function jwtFor(username: string): string {
+	const payload = btoa(JSON.stringify({ username }));
+	return `header.${payload}.signature`;
+}
+
+const mockEnv = { DB: {} } as any;
+const mockCtx = {
+	env: mockEnv,
+	id: { toString: () => "do-session-1" },
+	storage: { get: vi.fn(), put: vi.fn() },
+} as any;
+const mockModel = { modelId: "test-model" };
+
+const searchRulesTool = {
+	description: "Search indexed rulebooks",
+	execute: vi.fn().mockResolvedValue({ success: true, message: "found" }),
+	parameters: { shape: { query: {} } },
+};
+const rulesTools = { searchRules: searchRulesTool };
+
+class RulesStub extends BaseAgent {
+	static readonly agentMetadata = {
+		type: "rules-reference",
+		description: "Answers rules questions.",
+		systemPrompt: "rules prompt",
+		tools: rulesTools,
+	};
+	constructor() {
+		super(mockCtx, mockEnv, mockModel, rulesTools);
+	}
+	async onChatMessage(): Promise<Response> {
+		return new Response("unused");
+	}
+}
+
+const listFilesTool = {
+	description: "List files",
+	execute: vi.fn().mockResolvedValue({ success: true, data: { id: "file-1" } }),
+	parameters: { shape: { campaignId: {}, jwt: {} } },
+};
+const resourceTools = { listFiles: listFilesTool };
+
+class ResourceStub extends BaseAgent {
+	static readonly agentMetadata = {
+		type: "resources",
+		description: "Manages uploaded files.",
+		systemPrompt: "resource prompt",
+		tools: resourceTools,
+	};
+	constructor() {
+		super(mockCtx, mockEnv, mockModel, resourceTools);
+	}
+	async onChatMessage(): Promise<Response> {
+		return new Response("unused");
+	}
+}
+
+function registerAgents() {
+	for (const agentType of AgentRouter.getRegisteredAgentTypes()) {
+		delete (AgentRouter as any).agentRegistry[agentType];
+	}
+	AgentRouter.registerAgent(
+		"rules-reference" as AgentType,
+		RulesStub,
+		rulesTools,
+		"rules prompt",
+		"Answers rules questions."
+	);
+	AgentRouter.registerAgent(
+		"resources" as AgentType,
+		ResourceStub,
+		resourceTools,
+		"resource prompt",
+		"Manages uploaded files."
+	);
+}
+
+/** Every row written across all flushes, latest state per id. */
+function rows(): PendingAgentActivityWrite[] {
+	const byId = new Map<string, PendingAgentActivityWrite>();
+	for (const call of saveMany.mock.calls) {
+		for (const row of call[0]) byId.set(row.id, row);
+	}
+	return [...byId.values()];
+}
+
+function rowFor(toolName: string): PendingAgentActivityWrite | undefined {
+	return rows().find((row) => row.toolName === toolName);
+}
+
+/** Let the recorder's chained flushes drain. */
+async function drain() {
+	for (let i = 0; i < 5; i++) await Promise.resolve();
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("BaseAgent activity logging", () => {
+	let agent: ResourceStub;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		saveMany.mockResolvedValue(undefined);
+		registerAgents();
+		agent = new ResourceStub();
+	});
+
+	it("records a tool call with no per-agent instrumentation", async () => {
+		const tools = (agent as any).createEnhancedTools(
+			jwtFor("gm"),
+			"camp-1",
+			undefined,
+			resourceTools,
+			{ allowDelegation: false }
+		);
+
+		await tools.listFiles.execute({ campaignId: "camp-1" }, {});
+		await drain();
+
+		const row = rowFor("listFiles");
+		expect(row).toBeDefined();
+		expect(row?.username).toBe("gm");
+		expect(row?.agentType).toBe("resources");
+		expect(row?.campaignId).toBe("camp-1");
+		expect(row?.sessionId).toBe("do-session-1");
+		expect(row?.status).toBe("succeeded");
+		expect(row?.actionType).toBe("tool_call");
+	});
+
+	it("never persists the JWT the wrapper injects into arguments", async () => {
+		const tools = (agent as any).createEnhancedTools(
+			jwtFor("gm"),
+			"camp-1",
+			undefined,
+			resourceTools,
+			{ allowDelegation: false }
+		);
+
+		await tools.listFiles.execute({ campaignId: "camp-1" }, {});
+		await drain();
+
+		// The tool really did receive the JWT...
+		expect(listFilesTool.execute).toHaveBeenCalledWith(
+			expect.objectContaining({ jwt: jwtFor("gm") }),
+			expect.anything()
+		);
+		// ...and the log really did not.
+		expect(JSON.stringify(rowFor("listFiles")?.summary)).not.toContain(
+			jwtFor("gm")
+		);
+	});
+
+	it("records a thrown tool error as failed and still rethrows", async () => {
+		listFilesTool.execute.mockRejectedValueOnce(new Error("R2 unavailable"));
+		const tools = (agent as any).createEnhancedTools(
+			jwtFor("gm"),
+			"camp-1",
+			undefined,
+			resourceTools,
+			{ allowDelegation: false }
+		);
+
+		await expect(tools.listFiles.execute({}, {})).rejects.toThrow(
+			"R2 unavailable"
+		);
+		await drain();
+
+		const row = rowFor("listFiles");
+		expect(row?.status).toBe("failed");
+		expect(row?.error).toBe("R2 unavailable");
+	});
+
+	it("records calls the wrapper blocks itself, which return rather than throw", async () => {
+		const tools = (agent as any).createEnhancedTools(
+			jwtFor("gm"),
+			"camp-1",
+			undefined,
+			resourceTools,
+			{ allowDelegation: false }
+		);
+
+		// The loop guard trips on the fourth identical call.
+		for (let i = 0; i < 4; i++) {
+			await tools.listFiles.execute({ campaignId: "camp-1" }, {});
+		}
+		await drain();
+
+		const blocked = rows().filter((row) => row.status === "failed");
+		expect(blocked.length).toBeGreaterThan(0);
+		expect(blocked[0].error).toBeNull();
+		expect(blocked[0].summary?.message).toContain("too many times");
+	});
+
+	it("stays silent when the log is switched off", async () => {
+		const disabledAgent = new ResourceStub();
+		(disabledAgent as any).env = {
+			DB: {},
+			LORESMITH_AGENT_ACTIVITY_LOG: "false",
+		};
+
+		const tools = (disabledAgent as any).createEnhancedTools(
+			jwtFor("gm"),
+			"camp-1",
+			undefined,
+			resourceTools,
+			{ allowDelegation: false }
+		);
+		await tools.listFiles.execute({ campaignId: "camp-1" }, {});
+		await drain();
+
+		expect(saveMany).not.toHaveBeenCalled();
+	});
+
+	it("writes nothing for an unauthenticated turn", async () => {
+		const tools = (agent as any).createEnhancedTools(
+			null,
+			"camp-1",
+			undefined,
+			resourceTools,
+			{ allowDelegation: false }
+		);
+		await tools.listFiles.execute({ campaignId: "camp-1" }, {});
+		await drain();
+
+		expect(saveMany).not.toHaveBeenCalled();
+	});
+
+	it("hangs a delegate's tool calls under the delegating call", async () => {
+		generateTextMock.mockImplementation(async ({ tools }: any) => {
+			await tools.searchRules.execute({ query: "grappling" }, {});
+			return { text: "Grappling works like this." };
+		});
+
+		const tools = (agent as any).createEnhancedTools(
+			jwtFor("gm"),
+			"camp-1",
+			undefined,
+			resourceTools,
+			{ campaignRole: "gm" }
+		);
+
+		await tools.askAnotherAgent.execute(
+			{
+				agentType: "rules-reference",
+				request: "How does grappling work?",
+				reason: "rules question",
+			},
+			{ toolCallId: "call-1" }
+		);
+		await drain();
+
+		const delegation = rowFor("askAnotherAgent");
+		const delegateWork = rowFor("searchRules");
+
+		expect(delegation?.actionType).toBe("delegation");
+		expect(delegation?.agentType).toBe("resources");
+
+		// The delegate's work is attributed to the delegate, and linked to the
+		// call that caused it — the join #281 renders as per-agent badges.
+		expect(delegateWork?.agentType).toBe("rules-reference");
+		expect(delegateWork?.parentId).toBe(delegation?.id);
+		expect(delegateWork?.rootId).toBe(delegation?.rootId);
+		expect(delegateWork?.campaignId).toBe("camp-1");
+		expect(delegateWork?.username).toBe("gm");
+	});
+});

--- a/tests/dao/agent-activity-dao.test.ts
+++ b/tests/dao/agent-activity-dao.test.ts
@@ -1,0 +1,244 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	AGENT_ACTIVITY_RETENTION_DAYS,
+	AgentActivityDAO,
+	type PendingAgentActivityWrite,
+} from "@/dao/agent-activity-dao";
+import { AGENT_ACTIVITY_STATUS } from "@/types/agent-activity";
+
+function createHarness(options: { tableExists?: boolean } = {}) {
+	const tableExists = options.tableExists ?? true;
+	const bind = vi.fn().mockReturnThis();
+	const all = vi.fn(
+		async (): Promise<{ results: unknown[] }> => ({
+			results: [],
+		})
+	);
+	const run = vi.fn().mockResolvedValue({ meta: { changes: 3 } });
+	const stmt = { bind, all, run, first: vi.fn().mockResolvedValue(null) };
+	const prepare = vi.fn().mockReturnValue(stmt);
+	const batch = vi.fn().mockResolvedValue([]);
+
+	// hasTable() is the first query every method makes; answer it, then let the
+	// per-test queueing below drive the real query.
+	all.mockImplementation(async () => {
+		const sql = prepare.mock.calls.at(-1)?.[0] as string;
+		if (sql?.includes("sqlite_master")) {
+			return { results: tableExists ? [{ name: "agent_activity" }] : [] };
+		}
+		return { results: queued.shift() ?? [] };
+	});
+
+	const queued: unknown[][] = [];
+	const db = { prepare, batch } as unknown as D1Database;
+
+	return {
+		dao: new AgentActivityDAO(db),
+		prepare,
+		bind,
+		run,
+		batch,
+		queue: (rows: unknown[]) => queued.push(rows),
+		/** SQL of the last statement that was not the table-existence probe. */
+		lastSql: () =>
+			[...prepare.mock.calls]
+				.map((call) => call[0] as string)
+				.filter((sql) => !sql.includes("sqlite_master"))
+				.at(-1) ?? "",
+	};
+}
+
+const ROW: PendingAgentActivityWrite = {
+	id: "act-1",
+	username: "gm",
+	agentType: "campaign",
+	campaignId: "camp-1",
+	sessionId: "do-1",
+	actionType: "tool_call",
+	toolName: "listCampaigns",
+	status: AGENT_ACTIVITY_STATUS.SUCCEEDED,
+	parentId: null,
+	rootId: "act-1",
+	startedAt: "2026-08-08T00:00:00.000Z",
+	endedAt: "2026-08-08T00:00:01.000Z",
+	durationMs: 1000,
+	summary: { input: { campaignId: "camp-1" } },
+	error: null,
+};
+
+describe("AgentActivityDAO", () => {
+	let harness: ReturnType<typeof createHarness>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		harness = createHarness();
+	});
+
+	describe("when the migration has not been applied yet", () => {
+		// Merging to main deploys the Worker but not D1 migrations, and this table
+		// is written from inside every agent's tool path.
+		beforeEach(() => {
+			harness = createHarness({ tableExists: false });
+		});
+
+		it("drops writes instead of throwing", async () => {
+			await expect(harness.dao.saveMany([ROW])).resolves.toBeUndefined();
+			expect(harness.batch).not.toHaveBeenCalled();
+		});
+
+		it("reads as empty", async () => {
+			await expect(harness.dao.query({ username: "gm" })).resolves.toEqual([]);
+			await expect(harness.dao.getTree("act-1", "gm")).resolves.toEqual([]);
+			await expect(harness.dao.pruneOldRows()).resolves.toBe(0);
+			await expect(harness.dao.failStaleRunningRows()).resolves.toBe(0);
+		});
+
+		it("reports zeroed counts", async () => {
+			await expect(
+				harness.dao.getSummaryCounts({ username: "gm" })
+			).resolves.toEqual({
+				total: 0,
+				running: 0,
+				succeeded: 0,
+				failed: 0,
+				byAgentType: {},
+			});
+		});
+	});
+
+	it("writes a whole batch in one round trip", async () => {
+		await harness.dao.saveMany([ROW, { ...ROW, id: "act-2" }]);
+
+		expect(harness.batch).toHaveBeenCalledTimes(1);
+		expect(harness.batch.mock.calls[0][0]).toHaveLength(2);
+		expect(harness.lastSql()).toContain("ON CONFLICT(id) DO UPDATE");
+	});
+
+	it("does not overwrite identity or start time on a second write", async () => {
+		await harness.dao.saveMany([ROW]);
+		const sql = harness.lastSql();
+
+		expect(sql).toContain("status = excluded.status");
+		expect(sql).toContain("ended_at = excluded.ended_at");
+		expect(sql).not.toContain("started_at = excluded.started_at");
+		expect(sql).not.toContain("username = excluded.username");
+	});
+
+	it("keeps an existing summary when a later write has none", async () => {
+		await harness.dao.saveMany([ROW]);
+		expect(harness.lastSql()).toContain(
+			"summary = COALESCE(excluded.summary, agent_activity.summary)"
+		);
+	});
+
+	it("skips the round trip entirely for an empty batch", async () => {
+		await harness.dao.saveMany([]);
+		expect(harness.batch).not.toHaveBeenCalled();
+		expect(harness.prepare).not.toHaveBeenCalled();
+	});
+
+	it("always scopes reads by username", async () => {
+		await harness.dao.query({ username: "gm", campaignId: "camp-1" });
+
+		expect(harness.lastSql()).toContain("WHERE username = ?");
+		expect(harness.bind).toHaveBeenCalledWith(
+			"gm",
+			"camp-1",
+			expect.any(Number),
+			expect.any(Number)
+		);
+	});
+
+	it("caps the page size a caller can ask for", async () => {
+		await harness.dao.query({ username: "gm", limit: 100_000 });
+		const bound = harness.bind.mock.calls.at(-1) as unknown[];
+		expect(bound[1]).toBe(200);
+	});
+
+	it("floors a nonsensical offset at zero", async () => {
+		await harness.dao.query({ username: "gm", offset: -5 });
+		const bound = harness.bind.mock.calls.at(-1) as unknown[];
+		expect(bound[2]).toBe(0);
+	});
+
+	it("maps stored rows back into records, parsing the summary", async () => {
+		harness.queue([
+			{
+				id: "act-1",
+				username: "gm",
+				agent_type: "campaign",
+				campaign_id: "camp-1",
+				session_id: "do-1",
+				action_type: "tool_call",
+				tool_name: "listCampaigns",
+				status: "succeeded",
+				parent_id: null,
+				root_id: "act-1",
+				started_at: "2026-08-08T00:00:00.000Z",
+				ended_at: "2026-08-08T00:00:01.000Z",
+				duration_ms: 1000,
+				summary: '{"message":"ok"}',
+				error: null,
+			},
+		]);
+
+		const [record] = await harness.dao.query({ username: "gm" });
+
+		expect(record.agentType).toBe("campaign");
+		expect(record.campaignId).toBe("camp-1");
+		expect(record.summary).toEqual({ message: "ok" });
+	});
+
+	it("reads a tree oldest-first, scoped to its owner", async () => {
+		await harness.dao.getTree("root-1", "gm");
+
+		expect(harness.lastSql()).toContain("WHERE root_id = ? AND username = ?");
+		expect(harness.lastSql()).toContain("ORDER BY started_at ASC");
+		expect(harness.bind).toHaveBeenCalledWith("root-1", "gm");
+	});
+
+	it("aggregates counts by status and by agent type", async () => {
+		harness.queue([
+			{ status: "succeeded", count: 4 },
+			{ status: "failed", count: 1 },
+			{ status: "running", count: 2 },
+		]);
+		harness.queue([
+			{ agent_type: "campaign", count: 5 },
+			{ agent_type: "rules-reference", count: 2 },
+		]);
+
+		const counts = await harness.dao.getSummaryCounts({ username: "gm" });
+
+		expect(counts).toEqual({
+			total: 7,
+			running: 2,
+			succeeded: 4,
+			failed: 1,
+			byAgentType: { campaign: 5, "rules-reference": 2 },
+		});
+	});
+
+	it("prunes by age using the documented retention window", async () => {
+		const deleted = await harness.dao.pruneOldRows();
+
+		expect(deleted).toBe(3);
+		expect(harness.lastSql()).toContain("DELETE FROM agent_activity");
+		expect(harness.bind).toHaveBeenCalledWith(
+			`-${AGENT_ACTIVITY_RETENTION_DAYS} days`
+		);
+	});
+
+	it("closes out rows stranded running by a dead Worker", async () => {
+		await harness.dao.failStaleRunningRows(30);
+
+		expect(harness.lastSql()).toContain("UPDATE agent_activity");
+		expect(harness.bind).toHaveBeenCalledWith(
+			"failed",
+			expect.any(String),
+			"running",
+			"-30 minutes"
+		);
+	});
+});

--- a/tests/lib/agent-activity-summary.test.ts
+++ b/tests/lib/agent-activity-summary.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+	collectTouchedIds,
+	MAX_SUMMARY_BYTES,
+	parseSummary,
+	serializeSummary,
+	summarizeToolInput,
+	summarizeToolResult,
+} from "@/lib/agent-activity-summary";
+
+describe("summarizeToolInput", () => {
+	it("redacts the JWT the tool wrapper injects, and keeps the key", () => {
+		const summary = summarizeToolInput({
+			jwt: "eyJhbGciOiJIUzI1NiJ9.real.token",
+			campaignId: "camp-1",
+		});
+
+		expect(summary.jwt).toBe("[redacted]");
+		expect(summary.campaignId).toBe("camp-1");
+	});
+
+	it("redacts secret-shaped keys it has never seen before", () => {
+		const summary = summarizeToolInput({
+			stripeApiKey: "sk_live_123",
+			refreshToken: "rt_123",
+			userPassword: "hunter2",
+			name: "Gandalf",
+		});
+
+		expect(summary.stripeApiKey).toBe("[redacted]");
+		expect(summary.refreshToken).toBe("[redacted]");
+		expect(summary.userPassword).toBe("[redacted]");
+		expect(summary.name).toBe("Gandalf");
+	});
+
+	it("truncates long values instead of storing them whole", () => {
+		const summary = summarizeToolInput({ query: "x".repeat(500) });
+		expect(summary.query.length).toBeLessThan(200);
+		expect(summary.query.endsWith("…")).toBe(true);
+	});
+
+	it("describes arrays and objects by shape, not content", () => {
+		const summary = summarizeToolInput({ ids: ["a", "b", "c"] });
+		expect(summary.ids).toBe("[3 items]");
+	});
+
+	it("returns an empty map for non-object input", () => {
+		expect(summarizeToolInput(null)).toEqual({});
+		expect(summarizeToolInput("text")).toEqual({});
+		expect(summarizeToolInput([1, 2])).toEqual({});
+	});
+});
+
+describe("collectTouchedIds", () => {
+	it("finds ids nested inside a tool result envelope", () => {
+		const touched = collectTouchedIds({
+			result: {
+				data: {
+					entities: [{ id: "ent-1" }, { id: "ent-2" }],
+					fileKey: "uploads/book.pdf",
+				},
+			},
+		});
+
+		expect(touched?.entityIds).toEqual(["ent-1", "ent-2"]);
+		expect(touched?.fileKeys).toEqual(["uploads/book.pdf"]);
+	});
+
+	it("caps how many ids one bulk action can contribute", () => {
+		const touched = collectTouchedIds({
+			entities: Array.from({ length: 50 }, (_, i) => ({ id: `ent-${i}` })),
+		});
+		expect(touched?.entityIds?.length).toBe(10);
+	});
+
+	it("returns undefined when nothing identifiable is present", () => {
+		expect(collectTouchedIds({ message: "done" })).toBeUndefined();
+		expect(collectTouchedIds(null)).toBeUndefined();
+	});
+
+	it("terminates on a self-referential result", () => {
+		const cyclic: Record<string, unknown> = { id: "ent-1" };
+		cyclic.self = cyclic;
+		expect(collectTouchedIds(cyclic)?.entityIds).toEqual(["ent-1"]);
+	});
+});
+
+describe("summarizeToolResult", () => {
+	it("keeps the start-time input summary and adds what the result revealed", () => {
+		const merged = summarizeToolResult(
+			{ result: { success: true, message: "Created", data: { id: "ent-9" } } },
+			{ input: { name: "Gandalf" } }
+		);
+
+		expect(merged.input).toEqual({ name: "Gandalf" });
+		expect(merged.message).toBe("Created");
+		expect(merged.touched?.entityIds).toEqual(["ent-9"]);
+	});
+});
+
+describe("serializeSummary", () => {
+	it("sheds the input map rather than exceeding the cap", () => {
+		const json = serializeSummary({
+			input: Object.fromEntries(
+				Array.from({ length: 12 }, (_, i) => [`key${i}`, "y".repeat(120)])
+			),
+			message: "kept",
+		});
+
+		expect(json).not.toBeNull();
+		expect((json as string).length).toBeLessThanOrEqual(MAX_SUMMARY_BYTES);
+		// Whatever survives must still be parseable — the read path JSON.parses it.
+		expect(parseSummary(json)?.message).toBe("kept");
+	});
+
+	it("round-trips a normal summary", () => {
+		const summary = { input: { a: "1" }, message: "ok" };
+		expect(parseSummary(serializeSummary(summary))).toEqual(summary);
+	});
+
+	it("treats malformed stored JSON as absent", () => {
+		expect(parseSummary("{not json")).toBeNull();
+		expect(parseSummary(null)).toBeNull();
+	});
+});

--- a/tests/routes/agent-activity.test.ts
+++ b/tests/routes/agent-activity.test.ts
@@ -1,0 +1,308 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { D1Database } from "@cloudflare/workers-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// These modules pull in the cloudflare: protocol, which Vitest cannot load.
+vi.mock("agents", () => ({
+	routeAgentRequest: () =>
+		Promise.resolve(new Response("Not found", { status: 404 })),
+}));
+vi.mock("@/durable-objects", () => ({
+	Chat: class {},
+	NotificationHub: class {},
+}));
+vi.mock("@/durable-objects/chat", () => ({ Chat: class {} }));
+vi.mock("@/durable-objects/upload-session", () => ({
+	UploadSessionDO: class {},
+}));
+
+const { AgentActivityDAO } = await import("@/dao/agent-activity-dao");
+
+let agentActivityDAO: InstanceType<typeof AgentActivityDAO>;
+
+vi.mock("@/dao/dao-factory", () => ({
+	getDAOFactory: vi.fn(() => ({ agentActivityDAO })),
+}));
+
+const {
+	handleGetAgentActivitySummary,
+	handleGetAgentActivityTree,
+	handleListAgentActivity,
+} = await import("@/routes/agent-activity");
+
+function d1Adapter(db: DatabaseSync): D1Database {
+	return {
+		prepare(sql: string) {
+			return {
+				bind(...params: unknown[]) {
+					return {
+						all: async () => ({
+							results: db.prepare(sql).all(...(params as [])),
+						}),
+						first: async () => db.prepare(sql).get(...(params as [])) ?? null,
+						run: async () => {
+							const result = db.prepare(sql).run(...(params as []));
+							return { meta: { changes: Number(result.changes ?? 0) } };
+						},
+					};
+				},
+			};
+		},
+		// The DAO writes through db.batch(); the adapter's statements are already
+		// bound, so running them in order is a faithful stand-in.
+		async batch(statements: any[]) {
+			return Promise.all(statements.map((statement) => statement.run()));
+		},
+	} as unknown as D1Database;
+}
+
+// The real migration, so the route tests fail if the schema and the queries
+// ever disagree.
+const ACTIVITY_MIGRATION = readFileSync(
+	join(__dirname, "../../migrations/0036_agent_activity.sql"),
+	"utf8"
+);
+
+let db: DatabaseSync;
+let d1: D1Database;
+
+function createContext(
+	options: {
+		username?: string;
+		params?: Record<string, string>;
+		query?: Record<string, string>;
+	} = {}
+) {
+	return {
+		env: { DB: d1 },
+		userAuth: options.username
+			? { username: options.username, type: "user-auth" }
+			: undefined,
+		req: {
+			param: (name: string) => options.params?.[name],
+			query: (name: string) => options.query?.[name],
+		},
+		json: (body: unknown, status = 200) =>
+			new Response(JSON.stringify(body), {
+				status,
+				headers: { "Content-Type": "application/json" },
+			}),
+		get: () => undefined,
+	};
+}
+
+let rowCounter = 0;
+
+async function seed(overrides: Partial<Record<string, unknown>> = {}) {
+	rowCounter += 1;
+	const id = (overrides.id as string) ?? `act-${rowCounter}`;
+	await agentActivityDAO.saveMany([
+		{
+			id,
+			username: "gm",
+			agentType: "campaign",
+			campaignId: "camp-1",
+			sessionId: "do-1",
+			actionType: "tool_call",
+			toolName: "listCampaigns",
+			status: "succeeded",
+			parentId: null,
+			rootId: id,
+			startedAt: `2026-08-0${rowCounter}T00:00:00.000Z`,
+			endedAt: `2026-08-0${rowCounter}T00:00:01.000Z`,
+			durationMs: 1000,
+			summary: null,
+			error: null,
+			...(overrides as any),
+		},
+	]);
+	return id;
+}
+
+beforeEach(async () => {
+	rowCounter = 0;
+	db = new DatabaseSync(":memory:");
+	db.exec(ACTIVITY_MIGRATION);
+	d1 = d1Adapter(db);
+	agentActivityDAO = new AgentActivityDAO(d1);
+});
+
+describe("GET /api/agent-activity", () => {
+	it("401s without authentication", async () => {
+		const response = await handleListAgentActivity(createContext() as any);
+		expect(response.status).toBe(401);
+		expect(await response.json()).not.toHaveProperty("activities");
+	});
+
+	it("returns only the caller's rows", async () => {
+		await seed({ username: "gm" });
+		await seed({ username: "other-user" });
+
+		const response = await handleListAgentActivity(
+			createContext({ username: "gm" }) as any
+		);
+		const body: any = await response.json();
+
+		expect(body.activities).toHaveLength(1);
+		expect(body.activities[0].username).toBe("gm");
+	});
+
+	it("ignores a username supplied in the query string", async () => {
+		// The row's username is the only authorization check on this table, so
+		// accepting it as input would put every other user a parameter away.
+		await seed({ username: "victim" });
+
+		const response = await handleListAgentActivity(
+			createContext({ username: "gm", query: { username: "victim" } }) as any
+		);
+		const body: any = await response.json();
+
+		expect(body.activities).toEqual([]);
+	});
+
+	it("filters by campaign, agent type, and status", async () => {
+		await seed({ campaignId: "camp-1", agentType: "campaign" });
+		await seed({ campaignId: "camp-2", agentType: "campaign" });
+		await seed({ campaignId: "camp-1", agentType: "rules-reference" });
+		await seed({ campaignId: "camp-1", status: "failed" });
+
+		const byCampaign: any = await (
+			await handleListAgentActivity(
+				createContext({
+					username: "gm",
+					query: { campaignId: "camp-1" },
+				}) as any
+			)
+		).json();
+		expect(byCampaign.activities).toHaveLength(3);
+
+		const byAgent: any = await (
+			await handleListAgentActivity(
+				createContext({
+					username: "gm",
+					query: { agentType: "rules-reference" },
+				}) as any
+			)
+		).json();
+		expect(byAgent.activities).toHaveLength(1);
+
+		const byStatus: any = await (
+			await handleListAgentActivity(
+				createContext({ username: "gm", query: { status: "failed" } }) as any
+			)
+		).json();
+		expect(byStatus.activities).toHaveLength(1);
+	});
+
+	it("returns newest first", async () => {
+		const first = await seed();
+		const second = await seed();
+
+		const body: any = await (
+			await handleListAgentActivity(createContext({ username: "gm" }) as any)
+		).json();
+
+		expect(body.activities.map((a: any) => a.id)).toEqual([second, first]);
+	});
+
+	it("pages", async () => {
+		await seed();
+		await seed();
+		await seed();
+
+		const body: any = await (
+			await handleListAgentActivity(
+				createContext({
+					username: "gm",
+					query: { limit: "2", offset: "2" },
+				}) as any
+			)
+		).json();
+
+		expect(body.activities).toHaveLength(1);
+	});
+});
+
+describe("GET /api/agent-activity/summary", () => {
+	it("counts the window, not the page", async () => {
+		await seed({ status: "succeeded" });
+		await seed({ status: "failed" });
+		await seed({ status: "running", agentType: "rules-reference" });
+
+		const counts: any = await (
+			await handleGetAgentActivitySummary(
+				createContext({ username: "gm" }) as any
+			)
+		).json();
+
+		expect(counts.total).toBe(3);
+		expect(counts.succeeded).toBe(1);
+		expect(counts.failed).toBe(1);
+		expect(counts.running).toBe(1);
+		expect(counts.byAgentType).toEqual({ campaign: 2, "rules-reference": 1 });
+	});
+
+	it("applies the same filters as the list", async () => {
+		await seed({ campaignId: "camp-1" });
+		await seed({ campaignId: "camp-2" });
+
+		const counts: any = await (
+			await handleGetAgentActivitySummary(
+				createContext({
+					username: "gm",
+					query: { campaignId: "camp-1" },
+				}) as any
+			)
+		).json();
+
+		expect(counts.total).toBe(1);
+	});
+});
+
+describe("GET /api/agent-activity/tree/:rootId", () => {
+	it("returns a delegation tree oldest-first", async () => {
+		const root = await seed({
+			id: "root-1",
+			toolName: "askAnotherAgent",
+			actionType: "delegation",
+		});
+		await seed({
+			id: "child-1",
+			parentId: root,
+			rootId: root,
+			agentType: "rules-reference",
+			toolName: "searchRules",
+		});
+
+		const body: any = await (
+			await handleGetAgentActivityTree(
+				createContext({ username: "gm", params: { rootId: "root-1" } }) as any
+			)
+		).json();
+
+		expect(body.activities.map((a: any) => a.id)).toEqual([
+			"root-1",
+			"child-1",
+		]);
+		expect(body.activities[1].agentType).toBe("rules-reference");
+	});
+
+	it("404s for another user's tree, without confirming it exists", async () => {
+		await seed({ id: "root-1", username: "other-user" });
+
+		const response = await handleGetAgentActivityTree(
+			createContext({ username: "gm", params: { rootId: "root-1" } }) as any
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("400s without a rootId", async () => {
+		const response = await handleGetAgentActivityTree(
+			createContext({ username: "gm" }) as any
+		);
+		expect(response.status).toBe(400);
+	});
+});

--- a/tests/services/agent-activity-recorder.test.ts
+++ b/tests/services/agent-activity-recorder.test.ts
@@ -1,0 +1,308 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PendingAgentActivityWrite } from "@/dao/agent-activity-dao";
+import {
+	AGENT_ACTIVITY_ENV,
+	AgentActivityRecorder,
+	isAgentActivityLoggingEnabled,
+	isSuccessfulToolResult,
+	recordAgentActivity,
+} from "@/services/agent-activity/agent-activity-recorder";
+import { AGENT_ACTIVITY_STATUS } from "@/types/agent-activity";
+
+const saveMany = vi.fn<(rows: PendingAgentActivityWrite[]) => Promise<void>>();
+
+vi.mock("@/dao/agent-activity-dao", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/dao/agent-activity-dao")>();
+	return {
+		...actual,
+		AgentActivityDAO: class {
+			saveMany(rows: PendingAgentActivityWrite[]) {
+				return saveMany(rows);
+			}
+		},
+	};
+});
+
+const DB = {} as D1Database;
+const ENV = { DB } as unknown as Record<string, unknown>;
+
+const CONTEXT = {
+	username: "gm",
+	agentType: "campaign",
+	campaignId: "camp-1",
+	sessionId: "do-1",
+};
+
+/** Every row handed to the DAO across all flushes, in write order. */
+function writtenRows(): PendingAgentActivityWrite[] {
+	return saveMany.mock.calls.flatMap((call) => call[0]);
+}
+
+/** Latest state written for a given id. */
+function latest(id: string): PendingAgentActivityWrite | undefined {
+	return writtenRows()
+		.filter((row) => row.id === id)
+		.at(-1);
+}
+
+describe("isAgentActivityLoggingEnabled", () => {
+	it("defaults to on so agents are logged without configuration", () => {
+		expect(isAgentActivityLoggingEnabled({})).toBe(true);
+		expect(isAgentActivityLoggingEnabled(undefined)).toBe(true);
+	});
+
+	it("is a kill switch: any falsy value turns it off without a deploy", () => {
+		for (const value of ["0", "false", "no", "off", "OFF"]) {
+			expect(
+				isAgentActivityLoggingEnabled({ [AGENT_ACTIVITY_ENV]: value })
+			).toBe(false);
+		}
+		expect(isAgentActivityLoggingEnabled({ [AGENT_ACTIVITY_ENV]: false })).toBe(
+			false
+		);
+	});
+});
+
+describe("AgentActivityRecorder.create", () => {
+	it("returns null without a D1 binding", () => {
+		expect(AgentActivityRecorder.create({}, CONTEXT)).toBeNull();
+	});
+
+	it("returns null when the kill switch is thrown", () => {
+		expect(
+			AgentActivityRecorder.create(
+				{ ...ENV, [AGENT_ACTIVITY_ENV]: "false" },
+				CONTEXT
+			)
+		).toBeNull();
+	});
+
+	it("returns null on an unauthenticated turn", () => {
+		// A row is authorized by its username; one without an owner could never be
+		// read back, so writing it would only cost storage.
+		expect(
+			AgentActivityRecorder.create(ENV, { ...CONTEXT, username: null })
+		).toBeNull();
+	});
+
+	it("returns null without a session to attribute the work to", () => {
+		expect(
+			AgentActivityRecorder.create(ENV, { ...CONTEXT, sessionId: "" })
+		).toBeNull();
+	});
+});
+
+describe("AgentActivityRecorder", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		saveMany.mockResolvedValue(undefined);
+	});
+
+	it("records a completed action with duration and redacted input", async () => {
+		const recorder = AgentActivityRecorder.create(ENV, CONTEXT);
+		if (!recorder) throw new Error("expected a recorder");
+
+		const id = recorder.begin({
+			actionType: "tool_call",
+			toolName: "listCampaigns",
+			input: { jwt: "secret-token", campaignId: "camp-1" },
+		});
+		recorder.finish(id, {
+			status: AGENT_ACTIVITY_STATUS.SUCCEEDED,
+			result: { result: { success: true, message: "ok" } },
+		});
+		await recorder.settle();
+
+		const row = latest(id);
+		expect(row?.status).toBe("succeeded");
+		expect(row?.toolName).toBe("listCampaigns");
+		expect(row?.agentType).toBe("campaign");
+		expect(row?.username).toBe("gm");
+		expect(row?.summary?.input?.jwt).toBe("[redacted]");
+		expect(row?.durationMs).toBeGreaterThanOrEqual(0);
+		expect(row?.endedAt).not.toBeNull();
+	});
+
+	it("makes a root action its own tree root", async () => {
+		const recorder = AgentActivityRecorder.create(ENV, CONTEXT);
+		const id = recorder?.begin({ actionType: "tool_call", toolName: "a" });
+		await recorder?.settle();
+
+		expect(latest(id as string)?.rootId).toBe(id);
+		expect(latest(id as string)?.parentId).toBeNull();
+	});
+
+	it("coalesces a start and finish that land between flushes into one write", async () => {
+		const recorder = AgentActivityRecorder.create(ENV, CONTEXT);
+		if (!recorder) throw new Error("expected a recorder");
+
+		// No await between the two: this is the common case for a fast tool, and
+		// the point of the buffer is that it costs one round trip, not two.
+		const id = recorder.begin({ actionType: "tool_call", toolName: "a" });
+		recorder.finish(id, { status: AGENT_ACTIVITY_STATUS.SUCCEEDED });
+		await recorder.settle();
+
+		expect(writtenRows().filter((row) => row.id === id)).toHaveLength(1);
+		expect(latest(id)?.status).toBe("succeeded");
+	});
+
+	it("batches concurrent tool calls together rather than one write each", async () => {
+		const recorder = AgentActivityRecorder.create(ENV, CONTEXT);
+		if (!recorder) throw new Error("expected a recorder");
+
+		const ids = ["a", "b", "c"].map((toolName) =>
+			recorder.begin({ actionType: "tool_call", toolName })
+		);
+		for (const id of ids) {
+			recorder.finish(id, { status: AGENT_ACTIVITY_STATUS.SUCCEEDED });
+		}
+		await recorder.settle();
+
+		expect(saveMany).toHaveBeenCalledTimes(1);
+		expect(saveMany.mock.calls[0][0]).toHaveLength(3);
+	});
+
+	it("keeps a long-running action visible as running before it resolves", async () => {
+		const recorder = AgentActivityRecorder.create(ENV, CONTEXT);
+		if (!recorder) throw new Error("expected a recorder");
+
+		const id = recorder.begin({ actionType: "tool_call", toolName: "slow" });
+		await recorder.settle();
+		expect(latest(id)?.status).toBe("running");
+
+		recorder.finish(id, { status: AGENT_ACTIVITY_STATUS.SUCCEEDED });
+		await recorder.settle();
+		expect(latest(id)?.status).toBe("succeeded");
+	});
+
+	it("truncates a long failure message", async () => {
+		const recorder = AgentActivityRecorder.create(ENV, CONTEXT);
+		if (!recorder) throw new Error("expected a recorder");
+
+		const id = recorder.begin({ actionType: "tool_call", toolName: "boom" });
+		recorder.finish(id, {
+			status: AGENT_ACTIVITY_STATUS.FAILED,
+			error: new Error("x".repeat(5000)),
+		});
+		await recorder.settle();
+
+		expect(latest(id)?.error?.length).toBeLessThanOrEqual(500);
+	});
+
+	it("ignores an unknown id rather than throwing inside a tool call", async () => {
+		const recorder = AgentActivityRecorder.create(ENV, CONTEXT);
+		expect(() =>
+			recorder?.finish("nope", { status: AGENT_ACTIVITY_STATUS.SUCCEEDED })
+		).not.toThrow();
+	});
+
+	it("swallows a D1 failure — a lost log line must not fail the turn", async () => {
+		saveMany.mockRejectedValue(new Error("D1 down"));
+		const recorder = AgentActivityRecorder.create(ENV, CONTEXT);
+		if (!recorder) throw new Error("expected a recorder");
+
+		recorder.begin({ actionType: "tool_call", toolName: "a" });
+		await expect(recorder.settle()).resolves.toBeUndefined();
+	});
+
+	it("hangs a delegate's work under the delegating call", async () => {
+		const parent = AgentActivityRecorder.create(ENV, CONTEXT);
+		if (!parent) throw new Error("expected a recorder");
+
+		const delegationId = parent.begin({
+			actionType: "delegation",
+			toolName: "askAnotherAgent",
+		});
+		const child = AgentActivityRecorder.create(
+			ENV,
+			parent.childContext(delegationId, "rules-reference")
+		);
+		const childId = child?.begin({
+			actionType: "tool_call",
+			toolName: "searchRules",
+		});
+
+		await parent.settle();
+		await child?.settle();
+
+		const childRow = latest(childId as string);
+		expect(childRow?.parentId).toBe(delegationId);
+		expect(childRow?.rootId).toBe(latest(delegationId)?.rootId);
+		// Attributed to the delegate, which is what per-agent badges need.
+		expect(childRow?.agentType).toBe("rules-reference");
+		expect(childRow?.campaignId).toBe("camp-1");
+	});
+});
+
+describe("isSuccessfulToolResult", () => {
+	it("treats an explicit failure envelope as a failure", () => {
+		expect(isSuccessfulToolResult({ result: { success: false } })).toBe(false);
+		expect(isSuccessfulToolResult({ success: false })).toBe(false);
+	});
+
+	it("treats anything else as a success", () => {
+		expect(isSuccessfulToolResult({ result: { success: true } })).toBe(true);
+		expect(isSuccessfulToolResult("plain string")).toBe(true);
+		expect(isSuccessfulToolResult(undefined)).toBe(true);
+	});
+});
+
+describe("recordAgentActivity", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		saveMany.mockResolvedValue(undefined);
+	});
+
+	it("runs the tool untouched when there is no recorder", async () => {
+		const result = await recordAgentActivity(
+			null,
+			{ toolName: "a", input: {} },
+			async (activityId) => {
+				expect(activityId).toBeNull();
+				return "value";
+			}
+		);
+		expect(result).toBe("value");
+		expect(saveMany).not.toHaveBeenCalled();
+	});
+
+	it("records a failure envelope as failed, not succeeded", async () => {
+		const recorder = AgentActivityRecorder.create(ENV, CONTEXT);
+		await recordAgentActivity(
+			recorder,
+			{ toolName: "a", input: {} },
+			async () => ({ result: { success: false, message: "blocked" } })
+		);
+		await recorder?.settle();
+
+		expect(writtenRows().at(-1)?.status).toBe("failed");
+	});
+
+	it("records a thrown error as failed and rethrows it", async () => {
+		const recorder = AgentActivityRecorder.create(ENV, CONTEXT);
+		await expect(
+			recordAgentActivity(recorder, { toolName: "a", input: {} }, async () => {
+				throw new Error("kaboom");
+			})
+		).rejects.toThrow("kaboom");
+		await recorder?.settle();
+
+		const row = writtenRows().at(-1);
+		expect(row?.status).toBe("failed");
+		expect(row?.error).toBe("kaboom");
+	});
+
+	it("classifies askAnotherAgent as a delegation", async () => {
+		const recorder = AgentActivityRecorder.create(ENV, CONTEXT);
+		await recordAgentActivity(
+			recorder,
+			{ toolName: "askAnotherAgent", input: {} },
+			async () => ({ result: { success: true } })
+		);
+		await recorder?.settle();
+
+		expect(writtenRows().at(-1)?.actionType).toBe("delegation");
+	});
+});

--- a/tests/tools/agent-handoff-tools.test.ts
+++ b/tests/tools/agent-handoff-tools.test.ts
@@ -63,6 +63,10 @@ describe("createAskAnotherAgentTool", () => {
 		expect(run).toHaveBeenCalledWith({
 			agentType: "rules-reference",
 			request: "What trainings does The Foundling start with?",
+			// Null because nothing injected an activity row id here; when the
+			// BaseAgent tool wrapper is in play this carries the delegating call's
+			// id so the delegate's work links to it (issue #739).
+			parentActivityId: null,
 		});
 		expect(result.result.success).toBe(true);
 		expect(result.result.data.answer).toContain("Waterbending");


### PR DESCRIPTION
Closes #739.

## What

Adds the `agent_activity` primitive: an append-only record of agent actions with
lifecycle state, per-agent attribution, timing, and parent/child linkage.

Rows are written from `BaseAgent.createEnhancedTools` — the one wrapper every
agent's every tool call already passes through (JWT injection, campaign-id
override, loop guard all live there). So **every agent is logged with no
per-agent instrumentation**, and an agent added tomorrow is logged the day it is
added.

## Why

Per the issue: #273, #276, #277, #279 and #281 have not moved because each
independently requires an agent activity substrate that does not exist. Tool
results flow back through `streamText` into the response stream and are then
gone — nothing durably records that a tool ran, which agent ran it, what it
touched, or whether it succeeded.

This is the thinnest version that supports #273 and #281, which are pure reads,
so the schema is validated before anything depends on its write path. `cancelled`
and `awaiting_approval` exist as statuses but nothing writes them yet — that is
what makes #277 and #276 a status transition rather than a schema change.

## The three design questions the issue raised

**Write cost.** Nothing on the hot path is awaited. `begin`/`finish` mutate an
in-memory map; flushes chain onto a single promise, so enqueues during an
in-flight flush coalesce into the next one and each flush drains everything
dirty in one `db.batch()`. A tool that starts and finishes between two flushes —
the common case — is written **once**, with its final state, because the DAO
upserts on `id`. Losing a row is acceptable; losing a turn is not, so every
failure path logs and continues.

**Retention.** 14 days, swept on the fast cron. Shorter than the 90-day cost
ledger because this gains a row per *tool call* rather than per turn, and its
readers care about the last few days. The same sweep closes out rows stranded
`running` by a Worker that died mid-call — marked `failed`, since nobody asked
for them to stop.

**Granularity.** Per tool call, as the issue suggested. `action_type` is coarser
than `tool_name` (`tool_call` / `delegation`) so a future generation or indexing
step lands without a migration.

## Two things worth reviewing closely

**The summary never holds raw tool input.** The wrapper injects the caller's JWT
into arguments before `execute`, so a verbatim copy would persist a live
credential in a table built to be displayed. `src/lib/agent-activity-summary.ts`
redacts by key — an explicit list plus a substring pass for the `*Token`,
`*Secret`, `*Password`, `*ApiKey` families, so a tool added later is covered
without being added to a list — and keeps redacted keys as `[redacted]` rather
than dropping them, so an authenticated action does not read as anonymous.
`tests/agents/base-agent-activity.test.ts` asserts the tool really did receive
the JWT and the log really did not.

**Reads are scoped by the row's denormalized `username`, and only that.** A
`username` in the query string is ignored; the caller's own is taken from the
JWT and pinned. There is a test for exactly that, and the tree endpoint 404s
rather than confirming another user's id exists.

## Delegation trees

`askAnotherAgent` is itself a tool, so it gets a row typed `delegation`. The
delegate's tools are built through the same wrapper with a child context, so the
delegate's work is recorded under *its* `agent_type` with the delegating call as
`parent_id`. Every row carries `root_id` (its own id when it is a root), so one
indexed equality fetches a whole multi-agent turn without a recursive query.

## Degradation

Merging to `main` deploys the Worker but not D1 migrations, and this writes from
inside every agent's tool path — throwing during that window would not lose a
log line, it would break every agent in prod. `AgentActivityDAO.isSchemaReady()`
degrades every method to a no-op or an empty result. Logging is also skipped
with no `DB` binding, on an unauthenticated turn, or when
`LORESMITH_AGENT_ACTIVITY_LOG` is set falsy (kill switch, no deploy needed).

## Note on the complexity gate

The tool wrapper body is long-standing grandfathered complexity (CCN 48,
`src/agents/base-agent.ts::(anonymous)` in `complexity-baseline.json`). Wrapping
it via a named inner function made the ratchet read it as brand-new debt, so the
recording is applied as a decorator (`withActivityRecording`) and the body stays
one anonymous function. **No baseline entry was edited** — `npm run complexity`
passes as-is.

## What each blocked issue becomes now

| Issue | What is left |
|---|---|
| #273 Agent dashboard | A view over `GET /api/agent-activity` + its summary endpoint |
| #281 Multi-agent visualization | A join on `agent_type` / `root_id`, rendered as badges |
| #277 Interrupt controls | Write `cancelled` + a cancellation check in the agent loop |
| #276 Autonomy levels | Write `awaiting_approval` as a gate on write-capable tools |
| #279 Guided flows | Parent/child linkage + a flow definition |

## Verification

Everything below was run locally on this branch:

- `npm run check` — exit 0
- `npx vitest run` — 238 files, **2432 passed**, 0 failed
- `npx vitest run --coverage` — exit 0 (branches 75.42%, above the 70% gate)
- `node scripts/check/check-complexity.mjs` — passed, baseline untouched
- `node scripts/d1/check-migrations.mjs` — passed (0036 + bootstrap in sync)
- `node scripts/check/check-bundle-size.mjs` — within budget
- `npm run build` — succeeded
- `npm run knip` — no new findings
- `npm run wiki:sync:dry-run` — see below

67 of those tests are new, across five files: the summarizer (redaction,
truncation, bounded id-walk), the DAO (schema-missing degradation, upsert shape,
username scoping, retention), the recorder (coalescing, batching, kill switch,
child context), the BaseAgent integration (JWT never persisted, blocked calls
recorded as failures, delegation tree), and the routes (username pinning,
filters, paging, 404s) — the last of which run against the real migration SQL in
in-memory SQLite, so the schema and the queries cannot drift apart silently.

One existing assertion changed: `tests/tools/agent-handoff-tools.test.ts` pinned
the delegation runner's argument shape, which now carries `parentActivityId`.

### Not run

- Playwright e2e (CI runs it).
- Nothing was exercised against a real deployed Worker or remote D1 — no
  migration has been applied anywhere yet.

## Wiki

`docs/AGENT_ACTIVITY.md` is new and **is** registered in `FILE_MAPPINGS` and the
sidebar. `npm run wiki:sync:dry-run` confirms the merge will add:

```
?? Technical/Agent-Activity-Log.md
 M _Sidebar.md
 M Technical/Agent-Design.md
```

(the other entries in that dry-run output are pre-existing wiki drift, not from
this branch). The wiki is one merge behind until this lands; **`Agent-Activity-Log`
is the page pending.**

## How to see this change

```bash
gh pr checkout <PR#>
npm install            # only if dependencies changed
```

There is no user-visible UI in this PR — it is the substrate the dashboard in
#273 will render. Two ways to see it working:

**1. The tests, which are the evidence:**

```bash
npx vitest run tests/agents/base-agent-activity.test.ts \
               tests/services/agent-activity-recorder.test.ts \
               tests/dao/agent-activity-dao.test.ts \
               tests/routes/agent-activity.test.ts \
               tests/lib/agent-activity-summary.test.ts
```

**What you should see:** 67 passing. The ones that show the feature rather than
its parts are `"records a tool call with no per-agent instrumentation"`,
`"never persists the JWT the wrapper injects into arguments"`, and
`"hangs a delegate's tool calls under the delegating call"`.

**2. Against a running local stack**, if you want real rows. Two terminals per
`docs/DEV_SETUP.md`:

```bash
npm run migrate:local:full     # applies 0036
npm run dev:cloudflare         # terminal 1
npm run start                  # terminal 2
```

Send any chat message that makes an agent use a tool (e.g. "list my campaigns"),
then:

```bash
curl -s http://localhost:8787/api/agent-activity \
  -H "Authorization: Bearer $JWT" | jq
```

**What you should see:** before this change, that endpoint did not exist and no
trace of the tool call survived the response stream. After it, one row per tool
call — `agentType`, `campaignId`, `status`, `durationMs`, and a `summary` whose
`input.jwt` reads `[redacted]`. If the agent handed off, `GET
/api/agent-activity/tree/<rootId>` returns the delegating call followed by the
delegate's own work, attributed to the delegate.

*I did not run step 2 — no local D1 data or JWT in this environment. Step 1 I ran
in full.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
